### PR TITLE
Use app settings for work hours, slot duration and work days; wire through slot/date/calendar logic

### DIFF
--- a/src/repositories/app-settings.repository.ts
+++ b/src/repositories/app-settings.repository.ts
@@ -1,16 +1,41 @@
 import { db } from '../db/knex';
 
 const DEFAULT_TIMEZONE = 'Europe/Moscow';
+const DEFAULT_WORK_START_HOUR = 9;
+const DEFAULT_WORK_END_HOUR = 20;
+const DEFAULT_WORK_DAYS = '1,2,3,4,5,6';
+const DEFAULT_SLOT_DURATION_MIN = 90;
 
 type AppSettingsRow = {
   timezone: string;
+  work_start_hour: number;
+  work_end_hour: number;
+  work_days: string;
+  slot_duration_min: number;
 };
 
-export async function getDefaultTimezone() {
+export async function getAppSettings() {
   const row = await db('app_settings')
-    .select('timezone')
+    .select(
+      'timezone',
+      'work_start_hour',
+      'work_end_hour',
+      'work_days',
+      'slot_duration_min',
+    )
     .orderBy('id', 'asc')
     .first<AppSettingsRow>();
 
-  return row?.timezone || DEFAULT_TIMEZONE;
+  return {
+    timezone: row?.timezone || DEFAULT_TIMEZONE,
+    workStartHour: row?.work_start_hour ?? DEFAULT_WORK_START_HOUR,
+    workEndHour: row?.work_end_hour ?? DEFAULT_WORK_END_HOUR,
+    workDays: row?.work_days || DEFAULT_WORK_DAYS,
+    slotDurationMin: row?.slot_duration_min ?? DEFAULT_SLOT_DURATION_MIN,
+  };
+}
+
+export async function getDefaultTimezone() {
+  const settings = await getAppSettings();
+  return settings.timezone;
 }

--- a/src/routes/telegramWebhook.ts
+++ b/src/routes/telegramWebhook.ts
@@ -36,17 +36,23 @@ import { findServiceById } from '../repositories/service.repository';
 import { findSpecialistById } from '../repositories/specialist.repository';
 import { createBookingAppointment } from '../services/appointment.service';
 import { sendBookingStubNotification } from '../services/notification.service';
-import { getDefaultTimezone } from '../repositories/app-settings.repository';
+import { getAppSettings } from '../repositories/app-settings.repository';
 
 export const telegramWebhookRouter = Router();
 
-function buildCalendarLink(date: string, time: string, title: string, timezone: string) {
+function buildCalendarLink(
+  date: string,
+  time: string,
+  title: string,
+  timezone: string,
+  durationMin: number,
+) {
   const compactDate = date.replace(/-/g, '');
   const compactTime = time.replace(':', '');
   const [hours, minutes] = time.split(':').map(Number);
 
   const endDateTime = new Date(Date.UTC(2000, 0, 1, hours, minutes));
-  endDateTime.setUTCHours(endDateTime.getUTCHours() + 1);
+  endDateTime.setUTCMinutes(endDateTime.getUTCMinutes() + durationMin);
 
   const end = `${compactDate}T${String(endDateTime.getUTCHours()).padStart(2, '0')}${String(
     endDateTime.getUTCMinutes(),
@@ -347,12 +353,13 @@ telegramWebhookRouter.post(
           await answerCallbackQuery(callback.id, t(lang, 'booking.created'));
           await editMessageText(chatId, messageId, t(lang, 'booking.created'));
 
-          const timezone = await getDefaultTimezone();
+          const appSettings = await getAppSettings();
           const calendarUrl = buildCalendarLink(
             payload.selectedDate!,
             payload.selectedTime!,
             serviceName,
-            timezone,
+            appSettings.timezone,
+            appSettings.slotDurationMin,
           );
           const paymentUrl = `https://example.com/pay/${appointmentResult.appointment.id}`;
 

--- a/src/services/booking.service.ts
+++ b/src/services/booking.service.ts
@@ -39,7 +39,7 @@ export async function selectService(userId: number, serviceId: number) {
       skipSpecialist: true as const,
       service,
       specialist: defaultSpecialist,
-      dates: getNextAvailableDates(),
+      dates: await getNextAvailableDates(),
     };
   }
 
@@ -67,6 +67,6 @@ export async function selectSpecialist(userId: number, specialistId: number) {
   return {
     ok: true as const,
     specialist,
-    dates: getNextAvailableDates(),
+    dates: await getNextAvailableDates(),
   };
 }

--- a/src/services/date.service.ts
+++ b/src/services/date.service.ts
@@ -1,15 +1,31 @@
-export function getNextAvailableDates(count = 7): string[] {
+import { getAppSettings } from '../repositories/app-settings.repository';
+
+function parseWorkDays(workDays: string) {
+  const allowed = new Set<number>();
+
+  for (const chunk of workDays.split(',')) {
+    const day = Number(chunk.trim());
+    if (Number.isInteger(day) && day >= 0 && day <= 6) {
+      allowed.add(day);
+    }
+  }
+
+  return allowed;
+}
+
+export async function getNextAvailableDates(count = 7): Promise<string[]> {
   const results: string[] = [];
   const now = new Date();
+  const settings = await getAppSettings();
+  const allowedWorkDays = parseWorkDays(settings.workDays);
 
   for (let i = 0; results.length < count && i < 21; i += 1) {
     const date = new Date(now);
     date.setDate(now.getDate() + i);
 
     const day = date.getDay(); // 0=Sun, 1=Mon, ... 6=Sat
-    const isWorkingDay = day >= 1 && day <= 6;
 
-    if (!isWorkingDay) continue;
+    if (!allowedWorkDays.has(day)) continue;
 
     const formatted = formatDate(date);
     results.push(formatted);

--- a/src/services/slot.service.ts
+++ b/src/services/slot.service.ts
@@ -1,15 +1,21 @@
 import { findBusyAppointmentTimesByDate } from '../repositories/appointment.repository';
+import { getAppSettings } from '../repositories/app-settings.repository';
 import { findServiceById } from '../repositories/service.repository';
 
-function buildDaySlots(durationMin: number) {
-  const startMinutes = 9 * 60;
-  const endMinutes = 20 * 60;
+function buildDaySlots(
+  durationMin: number,
+  slotDurationMin: number,
+  workStartHour: number,
+  workEndHour: number,
+) {
+  const startMinutes = workStartHour * 60;
+  const endMinutes = workEndHour * 60;
   const slots: string[] = [];
 
   for (
     let minute = startMinutes;
     minute + durationMin <= endMinutes;
-    minute += durationMin
+    minute += slotDurationMin
   ) {
     const hours = String(Math.floor(minute / 60)).padStart(2, '0');
     const mins = String(minute % 60).padStart(2, '0');
@@ -25,9 +31,15 @@ export async function getAvailableSlots(params: {
   serviceId: number;
 }) {
   const service = await findServiceById(params.serviceId);
+  const settings = await getAppSettings();
   const durationMin = service?.duration_min ?? 90;
 
-  const allSlots = buildDaySlots(durationMin);
+  const allSlots = buildDaySlots(
+    durationMin,
+    settings.slotDurationMin,
+    settings.workStartHour,
+    settings.workEndHour,
+  );
   const busySlots = await findBusyAppointmentTimesByDate(
     params.date,
     params.specialistId,


### PR DESCRIPTION
### Motivation

- Introduce centralized application settings for timezone, work hours, slot duration and work days so scheduling and calendar links are configurable.
- Replace hard-coded workday/working hours/slot interval logic with values coming from the database to support different business setups.

### Description

- Added `getAppSettings()` in `app-settings.repository.ts` that returns timezone, `workStartHour`, `workEndHour`, `workDays` and `slotDurationMin` with defaults and kept `getDefaultTimezone()` as a thin wrapper.
- Updated `telegramWebhook` to use `getAppSettings()` and pass `slotDurationMin` into `buildCalendarLink()` so calendar end time matches appointment duration.
- Made `getNextAvailableDates()` asynchronous and driven by `workDays` from `getAppSettings()`, with a `parseWorkDays()` helper to accept a comma-separated day list.
- Updated `slot.service` to build day slots from `workStartHour`/`workEndHour` and use `slotDurationMin` as the step while `durationMin` controls how long an appointment blocks time, and awaited async `getNextAvailableDates()` in booking flows.

### Testing

- Ran the test suite with `npm test` and the TypeScript build with `npm run build`, and both completed successfully.
- Verified that `getAvailableSlots` and `getNextAvailableDates` return values using the database-backed defaults when no custom settings exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3a734c5e48333aa6c72a40f37d41e)