### PR TITLE
Add 30-minute slot generation and overlap-aware busy-interval filtering

### DIFF
--- a/src/repositories/appointment.repository.ts
+++ b/src/repositories/appointment.repository.ts
@@ -5,6 +5,11 @@ type AppointmentRow = {
   appointment_at: string | Date;
 };
 
+type BusyAppointmentRow = {
+  appointment_at: string | Date;
+  duration_min: number;
+};
+
 type CreateAppointmentInput = {
   userId: number;
   serviceId: number;
@@ -31,6 +36,33 @@ export async function findBusyAppointmentTimesByDate(
   return rows.map((row) => {
     const dateTime = toMoscowDateTimeFromUtc(row.appointment_at);
     return dateTime.time;
+  });
+}
+
+export async function findBusyAppointmentsByDate(
+  date: string,
+  specialistId: number,
+) {
+  const { startIso: start, endIso: end } = getUtcRangeForMoscowDate(date);
+
+  const rows = (await db('appointments')
+    .where('specialist_id', specialistId)
+    .whereNot('status', 'cancelled')
+    .where('appointment_at', '<', end)
+    .andWhereRaw(
+      "appointment_at + (duration_min * interval '1 minute') > ?",
+      [start],
+    )
+    .select('appointment_at', 'duration_min')) as BusyAppointmentRow[];
+
+  return rows.map((row) => {
+    const dateTime = toMoscowDateTimeFromUtc(row.appointment_at);
+
+    return {
+      date: dateTime.date,
+      time: dateTime.time,
+      durationMin: row.duration_min,
+    };
   });
 }
 

--- a/src/services/slot.service.ts
+++ b/src/services/slot.service.ts
@@ -1,13 +1,11 @@
-import { findBusyAppointmentTimesByDate } from '../repositories/appointment.repository';
+import { findBusyAppointmentsByDate } from '../repositories/appointment.repository';
 import { getAppSettings } from '../repositories/app-settings.repository';
 import { findServiceById } from '../repositories/service.repository';
 
-function buildDaySlots(
-  durationMin: number,
-  slotDurationMin: number,
-  workStartHour: number,
-  workEndHour: number,
-) {
+const SLOT_STEP_MIN = 30;
+const MINUTES_IN_DAY = 24 * 60;
+
+function buildDaySlots(durationMin: number, workStartHour: number, workEndHour: number) {
   const startMinutes = workStartHour * 60;
   const endMinutes = workEndHour * 60;
   const slots: string[] = [];
@@ -15,7 +13,7 @@ function buildDaySlots(
   for (
     let minute = startMinutes;
     minute + durationMin <= endMinutes;
-    minute += slotDurationMin
+    minute += SLOT_STEP_MIN
   ) {
     const hours = String(Math.floor(minute / 60)).padStart(2, '0');
     const mins = String(minute % 60).padStart(2, '0');
@@ -23,6 +21,21 @@ function buildDaySlots(
   }
 
   return slots;
+}
+
+function parseDateToUtcMs(date: string) {
+  const [year, month, day] = date.split('-').map(Number);
+  return Date.UTC(year, month - 1, day);
+}
+
+function getDateOffsetInDays(targetDate: string, selectedDate: string) {
+  const diffMs = parseDateToUtcMs(targetDate) - parseDateToUtcMs(selectedDate);
+  return Math.round(diffMs / (24 * 60 * 60 * 1000));
+}
+
+function parseTimeToMinutes(time: string) {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
 }
 
 export async function getAvailableSlots(params: {
@@ -34,17 +47,28 @@ export async function getAvailableSlots(params: {
   const settings = await getAppSettings();
   const durationMin = service?.duration_min ?? 90;
 
-  const allSlots = buildDaySlots(
-    durationMin,
-    settings.slotDurationMin,
-    settings.workStartHour,
-    settings.workEndHour,
-  );
-  const busySlots = await findBusyAppointmentTimesByDate(
+  const allSlots = buildDaySlots(durationMin, settings.workStartHour, settings.workEndHour);
+  const busyAppointments = await findBusyAppointmentsByDate(
     params.date,
     params.specialistId,
   );
 
-  const busySet = new Set(busySlots);
-  return allSlots.filter((slot) => !busySet.has(slot));
+  const busyIntervals = busyAppointments.map((appointment) => {
+    const dayOffset = getDateOffsetInDays(appointment.date, params.date);
+    const startMinute = dayOffset * MINUTES_IN_DAY + parseTimeToMinutes(appointment.time);
+
+    return {
+      startMinute,
+      endMinute: startMinute + appointment.durationMin,
+    };
+  });
+
+  return allSlots.filter((slot) => {
+    const slotStart = parseTimeToMinutes(slot);
+    const slotEnd = slotStart + durationMin;
+
+    return !busyIntervals.some(
+      (busy) => slotStart < busy.endMinute && slotEnd > busy.startMinute,
+    );
+  });
 }


### PR DESCRIPTION
### Motivation
- Improve flexibility of available time selection by offering candidate slots every 30 minutes instead of using the coarse `slot_duration_min` setting. 
- Ensure generated slots do not overlap existing appointments, including appointments that start before or end after the selected day. 
- Start next available choices from the end of an overlapping appointment so users cannot pick times that would collide with previous/next bookings.

### Description
- Added `findBusyAppointmentsByDate` in `src/repositories/appointment.repository.ts` to load appointments that overlap a selected day and return `date`, `time`, and `durationMin` for each entry. 
- Reworked `getAvailableSlots` in `src/services/slot.service.ts` to generate candidate times with a fixed `SLOT_STEP_MIN = 30` and to compute busy intervals in minutes relative to the selected date. 
- Implemented helper functions `parseDateToUtcMs`, `getDateOffsetInDays`, and `parseTimeToMinutes` and applied interval-overlap logic (`slotStart < busyEnd && slotEnd > busyStart`) to filter out conflicting slots. 
- Kept working hours from app settings and service duration (`duration_min`) to compute slot validity while removing the old increment dependency on `slot_duration_min`.

### Testing
- Built the project successfully with `npm run build` and the TypeScript bundle compiled without errors. 
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ab03cd188333a7b716c5521cd797)