### PR TITLE
Add calendar & payment actions post-booking: link builders, ICS endpoint, keyboard and tests

### DIFF
--- a/src/bot/keyboards.ts
+++ b/src/bot/keyboards.ts
@@ -120,6 +120,24 @@ export function getBookingConfirmationKeyboard() {
   };
 }
 
+
+export function getBookingFinalInlineKeyboard(
+  lang: SupportedLanguage,
+  calendarGoogleUrl: string,
+  calendarAppleUrl: string,
+  calendarMicrosoftUrl: string,
+  paymentUrl: string,
+) {
+  return {
+    inline_keyboard: [
+      [{ text: translate(lang, 'booking.openCalendarGoogle'), url: calendarGoogleUrl }],
+      [{ text: translate(lang, 'booking.openCalendarApple'), url: calendarAppleUrl }],
+      [{ text: translate(lang, 'booking.openCalendarMicrosoft'), url: calendarMicrosoftUrl }],
+      [{ text: translate(lang, 'booking.openPayment'), url: paymentUrl }],
+    ],
+  };
+}
+
 export function getMyAppointmentsInlineKeyboard(
   appointments: UserAppointmentKeyboardRow[],
 ) {

--- a/src/bot/tests/keyboards.test.ts
+++ b/src/bot/tests/keyboards.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBookingFinalInlineKeyboard } from '../keyboards';
+
+describe('getBookingFinalInlineKeyboard', () => {
+  it('returns localized calendar choice buttons and payment button with URLs', () => {
+    const keyboard = getBookingFinalInlineKeyboard(
+      'ru',
+      'https://calendar.google.com/calendar/render?x=1',
+      'https://example.com/calendar/apple.ics?x=2',
+      'https://outlook.live.com/calendar/0/deeplink/compose?x=3',
+      'https://example.com/pay/15',
+    );
+
+    expect(keyboard).toEqual({
+      inline_keyboard: [
+        [{ text: '📅 Google Calendar', url: 'https://calendar.google.com/calendar/render?x=1' }],
+        [{ text: '🍎 Apple Calendar (.ics)', url: 'https://example.com/calendar/apple.ics?x=2' }],
+        [{ text: '🪟 Microsoft Calendar', url: 'https://outlook.live.com/calendar/0/deeplink/compose?x=3' }],
+        [{ text: '💳 Перейти к оплате', url: 'https://example.com/pay/15' }],
+      ],
+    });
+  });
+});

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -41,7 +41,9 @@ export const dictionaries: Record<SupportedLanguage, Dictionary> = {
     'booking.paymentLink': 'Ссылка на оплату (заглушка): {{url}}',
     'booking.finalMessage':
       '🎉 {{created}}\n\n🧑‍⚕️ Специалист: {{specialist}}\n📅 Дата: {{date}}\n🕒 Время: {{time}}\n\nВыберите действие в меню ниже.\n\nСпециалист свяжется с вами и пришлёт ссылку на встречу.',
-    'booking.openCalendar': '📅 Открыть календарь',
+    'booking.openCalendarGoogle': '📅 Google Calendar',
+    'booking.openCalendarApple': '🍎 Apple Calendar (.ics)',
+    'booking.openCalendarMicrosoft': '🪟 Microsoft Calendar',
     'booking.openPayment': '💳 Перейти к оплате',
     'booking.notificationStub':
       'Заглушка уведомлений: отправим напоминание о «{{service}}» на {{date}} {{time}} через {{channels}}.',
@@ -110,7 +112,9 @@ export const dictionaries: Record<SupportedLanguage, Dictionary> = {
     'booking.paymentLink': 'Payment link (stub): {{url}}',
     'booking.finalMessage':
       '🎉 {{created}}\n\n🧑‍⚕️ Specialist: {{specialist}}\n📅 Date: {{date}}\n🕒 Time: {{time}}\n\nChoose an action from the menu below.\n\nA specialist will contact you and send a meeting link.',
-    'booking.openCalendar': '📅 Open calendar',
+    'booking.openCalendarGoogle': '📅 Google Calendar',
+    'booking.openCalendarApple': '🍎 Apple Calendar (.ics)',
+    'booking.openCalendarMicrosoft': '🪟 Microsoft Calendar',
     'booking.openPayment': '💳 Open payment',
     'booking.notificationStub':
       'Notification stub: we will send a reminder for "{{service}}" at {{date}} {{time}} via {{channels}}.',

--- a/src/routes/telegramWebhook.ts
+++ b/src/routes/telegramWebhook.ts
@@ -12,6 +12,7 @@ import {
   getAppointmentEditInlineKeyboard,
   getDatesInlineKeyboard,
   getBookingConfirmationKeyboard,
+  getBookingFinalInlineKeyboard,
   getLanguageKeyboard,
   getMainMenuKeyboard,
   getMyAppointmentsInlineKeyboard,
@@ -48,6 +49,12 @@ import { sendBookingStubNotification } from '../services/notification.service';
 import { toDateTimeFromUtc } from '../utils/timezone';
 import { getNextAvailableDates } from '../services/date.service';
 import { getDefaultTimezone } from '../repositories/app-settings.repository';
+import {
+  buildAppleCalendarIcs,
+  buildAppleCalendarLink,
+  buildCalendarLink,
+  buildMicrosoftCalendarLink,
+} from '../utils/calendar-links';
 
 export const telegramWebhookRouter = Router();
 
@@ -97,6 +104,25 @@ async function buildConfirmationText(accountId: number, userId: number, lang: 'r
     specialistName: specialist.name,
   };
 }
+
+
+telegramWebhookRouter.get('/calendar/apple.ics', (req: Request, res: Response) => {
+  const date = typeof req.query.date === 'string' ? req.query.date : '';
+  const time = typeof req.query.time === 'string' ? req.query.time : '';
+  const title = typeof req.query.title === 'string' ? req.query.title : 'ScheduleTM booking';
+  const timezone = typeof req.query.timezone === 'string' ? req.query.timezone : 'UTC';
+  const durationMinRaw = typeof req.query.durationMin === 'string' ? Number(req.query.durationMin) : 60;
+  const durationMin = Number.isFinite(durationMinRaw) ? durationMinRaw : 60;
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !/^\d{2}:\d{2}$/.test(time)) {
+    return res.status(400).send('Invalid date or time');
+  }
+
+  const ics = buildAppleCalendarIcs(date, time, title, timezone, durationMin);
+  res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
+  res.setHeader('Content-Disposition', 'attachment; filename="appointment.ics"');
+  return res.status(200).send(ics);
+});
 
 function buildAppointmentDetailsText(
   lang: 'ru' | 'en',
@@ -424,6 +450,30 @@ telegramWebhookRouter.post(
           await answerCallbackQuery(callback.id, t(lang, 'booking.created'));
           await editMessageText(chatId, messageId, t(lang, 'booking.created'));
 
+          const calendarGoogleUrl = buildCalendarLink(
+            payload.selectedDate!,
+            payload.selectedTime!,
+            serviceName,
+            timezone,
+            appointmentResult.service.duration_min,
+          );
+          const calendarAppleUrl = buildAppleCalendarLink(
+            env.appUrl,
+            payload.selectedDate!,
+            payload.selectedTime!,
+            serviceName,
+            timezone,
+            appointmentResult.service.duration_min,
+          );
+          const calendarMicrosoftUrl = buildMicrosoftCalendarLink(
+            payload.selectedDate!,
+            payload.selectedTime!,
+            serviceName,
+            timezone,
+            appointmentResult.service.duration_min,
+          );
+          const paymentUrl = `https://example.com/pay/${appointmentResult.appointment.id}`;
+
           await sendMessage(
             chatId,
             t(lang, 'booking.finalMessage', {
@@ -432,7 +482,13 @@ telegramWebhookRouter.post(
               time: payload.selectedTime!,
               specialist: confirmData.specialistName,
             }),
-            getMainMenuKeyboard(lang),
+            getBookingFinalInlineKeyboard(
+              lang,
+              calendarGoogleUrl,
+              calendarAppleUrl,
+              calendarMicrosoftUrl,
+              paymentUrl,
+            ),
           );
 
           await sendMessage(chatId, t(lang, 'start.chooseAction'), getMainMenuKeyboard(lang));

--- a/src/utils/calendar-links.ts
+++ b/src/utils/calendar-links.ts
@@ -1,0 +1,115 @@
+function pad(value: number) {
+  return String(value).padStart(2, '0');
+}
+
+function parseDateTime(date: string, time: string) {
+  const [year, month, day] = date.split('-').map(Number);
+  const [hours, minutes] = time.split(':').map(Number);
+
+  return { year, month, day, hours, minutes };
+}
+
+function buildEndDateTime(date: string, time: string, durationMin: number) {
+  const { year, month, day, hours, minutes } = parseDateTime(date, time);
+  const endDateTime = new Date(Date.UTC(year, month - 1, day, hours, minutes));
+  endDateTime.setUTCMinutes(endDateTime.getUTCMinutes() + durationMin);
+
+  return {
+    date: `${endDateTime.getUTCFullYear()}-${pad(endDateTime.getUTCMonth() + 1)}-${pad(endDateTime.getUTCDate())}`,
+    time: `${pad(endDateTime.getUTCHours())}:${pad(endDateTime.getUTCMinutes())}`,
+  };
+}
+
+export function buildCalendarLink(
+  date: string,
+  time: string,
+  title: string,
+  timezone: string,
+  durationMin: number,
+) {
+  const compactDate = date.replace(/-/g, '');
+  const compactTime = time.replace(':', '');
+  const [hours, minutes] = time.split(':').map(Number);
+
+  const endDateTime = new Date(Date.UTC(2000, 0, 1, hours, minutes));
+  endDateTime.setUTCMinutes(endDateTime.getUTCMinutes() + durationMin);
+
+  const end = `${compactDate}T${String(endDateTime.getUTCHours()).padStart(2, '0')}${String(
+    endDateTime.getUTCMinutes(),
+  ).padStart(2, '0')}00`;
+
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: title,
+    dates: `${compactDate}T${compactTime}00/${end}`,
+    ctz: timezone,
+  });
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+export function buildMicrosoftCalendarLink(
+  date: string,
+  time: string,
+  title: string,
+  timezone: string,
+  durationMin: number,
+) {
+  const end = buildEndDateTime(date, time, durationMin);
+
+  const params = new URLSearchParams({
+    path: '/calendar/action/compose',
+    rru: 'addevent',
+    subject: title,
+    startdt: `${date}T${time}:00`,
+    enddt: `${end.date}T${end.time}:00`,
+    ctzt: timezone,
+  });
+
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+}
+
+export function buildAppleCalendarLink(
+  appUrl: string,
+  date: string,
+  time: string,
+  title: string,
+  timezone: string,
+  durationMin: number,
+) {
+  const params = new URLSearchParams({
+    date,
+    time,
+    title,
+    timezone,
+    durationMin: String(durationMin),
+  });
+
+  return `${appUrl}/calendar/apple.ics?${params.toString()}`;
+}
+
+export function buildAppleCalendarIcs(
+  date: string,
+  time: string,
+  title: string,
+  timezone: string,
+  durationMin: number,
+) {
+  const compactStartDate = date.replace(/-/g, '');
+  const compactStartTime = time.replace(':', '');
+  const end = buildEndDateTime(date, time, durationMin);
+  const compactEndDate = end.date.replace(/-/g, '');
+  const compactEndTime = end.time.replace(':', '');
+
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//ScheduleTM//Booking//EN',
+    'BEGIN:VEVENT',
+    `SUMMARY:${title.replace(/\n/g, ' ')}`,
+    `DTSTART;TZID=${timezone}:${compactStartDate}T${compactStartTime}00`,
+    `DTEND;TZID=${timezone}:${compactEndDate}T${compactEndTime}00`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+}

--- a/src/utils/tests/calendar-links.test.ts
+++ b/src/utils/tests/calendar-links.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAppleCalendarIcs,
+  buildAppleCalendarLink,
+  buildCalendarLink,
+  buildMicrosoftCalendarLink,
+} from '../calendar-links';
+
+describe('calendar links utils', () => {
+  it('builds google calendar link', () => {
+    const url = buildCalendarLink('2026-04-19', '09:30', 'Consultation', 'Europe/Moscow', 45);
+    expect(url).toContain('calendar.google.com/calendar/render');
+    expect(url).toContain('action=TEMPLATE');
+    expect(url).toContain('text=Consultation');
+  });
+
+  it('builds apple calendar ics link', () => {
+    const url = buildAppleCalendarLink(
+      'https://app.example.com',
+      '2026-04-19',
+      '09:30',
+      'Consultation',
+      'Europe/Moscow',
+      45,
+    );
+
+    expect(url).toContain('https://app.example.com/calendar/apple.ics?');
+    expect(url).toContain('durationMin=45');
+  });
+
+  it('builds microsoft calendar deeplink', () => {
+    const url = buildMicrosoftCalendarLink('2026-04-19', '09:30', 'Consultation', 'Europe/Moscow', 45);
+    expect(url).toContain('outlook.live.com/calendar/0/deeplink/compose');
+    expect(url).toContain('rru=addevent');
+  });
+
+  it('builds apple ics body', () => {
+    const ics = buildAppleCalendarIcs('2026-04-19', '09:30', 'Consultation', 'Europe/Moscow', 45);
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('SUMMARY:Consultation');
+    expect(ics).toContain('DTSTART;TZID=Europe/Moscow:20260419T093000');
+  });
+});


### PR DESCRIPTION
### Motivation

- Allow users to save confirmed bookings to Google, Apple and Microsoft calendars and provide a payment link from the final booking message. 

### Description

- Add calendar link builders and ICS generator in `src/utils/calendar-links.ts` with `buildCalendarLink`, `buildAppleCalendarLink`, `buildMicrosoftCalendarLink`, and `buildAppleCalendarIcs`. 
- Expose an Apple `.ics` download endpoint at `GET /calendar/apple.ics` in `src/routes/telegramWebhook.ts` and wire calendar/payment URL generation into the booking confirmation flow. 
- Add `getBookingFinalInlineKeyboard` to `src/bot/keyboards.ts` and use it to show localized calendar buttons and a payment button after successful booking. 
- Add localization keys for calendar buttons in `src/i18n/dictionaries.ts` and corresponding unit tests in `src/bot/tests/keyboards.test.ts` and `src/utils/tests/calendar-links.test.ts`. 

### Testing

- Ran unit tests with `vitest` covering calendar link builders and the final keyboard, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ae291df48333a6dbecbc85ffb867)