### PR TITLE
Bootstrap server and web MVP: auth, settings, integrations, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,16 @@
 # Server
 PORT=3000
-APP_URL=https://example.com
-WEBHOOK_SECRET=change_me_to_a_long_random_value
+APP_URL=http://localhost:5173
+SESSION_COOKIE_NAME=scheduletm_refresh
+ACCESS_TOKEN_TTL_SECONDS=900
+REFRESH_TOKEN_TTL_DAYS=30
 
-# Telegram
+# Telegram (legacy bot)
 BOT_TOKEN=123456:telegram-bot-token
 
 # Database
 DATABASE_PUBLIC_URL=postgres://user:pass@localhost:5432/scheduletm
 DATABASE_URL=postgres://user:pass@localhost:5432/scheduletm
-
 
 # Notifications worker
 NOTIFICATION_POLL_MS=60000

--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -1,39 +1,38 @@
 # PRODUCTION_READINESS_CHECKLIST
 
-Чеклист для нового контура `server + web`.
+Чеклист для `server + web`.
 
 ## 1. Platform & runtime
 
 - [ ] Зафиксировать Node.js LTS версию для всех workspace.
-- [ ] Настроить единые команды CI: install, typecheck, test, build.
-- [ ] Добавить lockfile политику и reproducible installs.
+- [ ] Настроить CI команды: install, typecheck, test, build.
+- [ ] Добавить lockfile-политику и reproducible installs.
 
 ## 2. Security
 
-- [ ] Добавить безопасную работу с секретами (`.env`, secret manager).
-- [ ] Подключить проверку Firebase ID token на server.
-- [ ] Ограничить CORS для production-доменов.
-- [ ] Добавить базовые security middleware (helmet, rate limit).
+- [x] Валидация payload через `zod`.
+- [x] `helmet` для базовых security headers.
+- [x] Salted PBKDF2 hashing для паролей.
+- [x] Brute-force lockout на login endpoint.
+- [x] Refresh session через `HttpOnly` cookie.
+- [ ] Добавить CSRF protection для refresh cookie flow.
+- [ ] Перенести секреты в secret manager (production).
 
-## 3. Observability
+## 3. API architecture
 
-- [ ] Добавить health/readiness endpoints на server.
-- [ ] Подключить структурированные логи и request-id.
-- [ ] Определить SLI/SLO (latency/error rate/auth failures).
+- [x] Разделить server-код по слоям (`routes/services/middlewares/config/repositories`).
+- [ ] Перенести in-memory store в persistent storage.
+- [ ] Добавить миграции и backup policy.
 
 ## 4. Integrations
 
-- [ ] Описать контракт интеграции с Google Calendar API.
-- [ ] Описать политику обновления Firebase SDK / service account ключей.
-- [ ] Добавить retry/backoff стратегию для внешних API.
+- [x] Добавить минимальный контракт `/api/integrations/google/connect`.
+- [ ] Реализовать полноценный OAuth 2.0 Google flow.
+- [ ] Добавить retry/backoff для внешних API.
 
 ## 5. Web delivery
 
-- [ ] Добавить production build pipeline для web.
+- [x] Включить роутинг для `/login`, `/register`, `/settings`.
+- [x] Использовать MUI как базовую UI систему.
 - [ ] Подключить error tracking.
-- [ ] Настроить кэширование и заголовки безопасности.
-
-## 6. Migration strategy
-
-- [ ] Задокументировать границы ответственности `bot` vs `server/web` на период миграции.
-- [ ] Зафиксировать критерии полного перехода на `server/web`.
+- [ ] Настроить caching/security headers на edge.

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -3,17 +3,27 @@
 ## Назначение модулей
 
 - `bot/` — существующее backend-приложение Telegram-бота.
-- `server/` — заготовка под API для web-приложения:
-  - `server/package.json` — зависимости и скрипты сервера.
-  - `server/tsconfig.json` — TypeScript-конфигурация сборки в `dist`.
-  - `server/src/` — директория под исходники API.
-- `web/` — заготовка под SPA:
-  - `web/package.json` — зависимости React/MobX/MUI/Firebase/Axios.
-  - `web/tsconfig.json` — TypeScript-конфигурация фронтенда.
-  - `web/vite.config.ts` — Vite + React plugin.
-  - `web/src/` — директория под исходники UI.
+- `server/` — API для web-приложения:
+  - `server/src/index.ts` — bootstrap.
+  - `server/src/app.ts` — инициализация Express middleware/роутов.
+  - `server/src/config/*` — env + схемы валидации.
+  - `server/src/routes/*` — auth/settings/integrations/health endpoints.
+  - `server/src/services/*` — бизнес-логика auth/settings.
+  - `server/src/middlewares/*` — auth + login lock middleware.
+  - `server/src/repositories/inMemoryStore.ts` — in-memory состояние (MVP).
+- `web/` — SPA:
+  - `web/src/app/*` — root app + router.
+  - `web/src/pages/*` — страницы.
+  - `web/src/containers/*` — контейнеры с запросами и состоянием.
+  - `web/src/components/*` — UI-компоненты.
+  - `web/src/shared/*` — API client, типы, auth context.
 
-## Root-level orchestration
+## API карта (MVP)
 
-- `package.json` в корне определяет npm workspaces (`bot`, `server`, `web`).
-- Команды `typecheck/build/test` запускаются по всем пакетам через `npm run -ws ...`.
+- `GET /health`
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `POST /api/auth/refresh`
+- `GET /api/settings`
+- `PUT /api/settings`
+- `POST /api/integrations/google/connect`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ScheduleTM Monorepo
 
-Репозиторий переведен на монорепо-структуру и теперь разделен на изолированные приложения:
+Репозиторий разделен на изолированные приложения:
 
-- `bot` — текущий Telegram-бот (legacy и рабочий контур).
-- `server` — новый Node.js API слой для web-клиента и интеграций.
-- `web` — новый frontend (React + MobX + MUI CSS + Axios).
+- `bot` — Telegram-бот (legacy).
+- `server` — Node.js API слой для web-клиента и интеграций.
+- `web` — React SPA для пользователя.
 
-## Текущая структура
+## Структура
 
 ```text
 scheduletm/
@@ -15,38 +15,55 @@ scheduletm/
 └─ web/
 ```
 
-## Базовый стек
+## MVP сейчас
 
 ### Web
 
-- React
-- MobX
-- MUI CSS (`muicss`)
-- Axios
-- Firebase (SSO)
-- Google Calendar API client (`gapi-script`)
+- Страницы: `/login`, `/register`, `/settings` через `react-router-dom`.
+- UI на `@mui/material` (без кастомного CSS на старте).
+- Разделение на `components`, `containers`, `pages`, `app`, `shared`.
+- Кнопка `Подключить Google` на странице настроек.
 
 ### Server
 
-- Node.js + Express
-- Google APIs (Calendar)
-- Firebase Admin (проверка SSO токенов)
-- Axios
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `POST /api/auth/refresh`
+- `GET /api/settings`
+- `PUT /api/settings`
+- `POST /api/integrations/google/connect`
 
-## Workspace команды
+Сервер разнесен по слоям:
 
-Из корня:
+- `config` — env + схемы валидации.
+- `routes` — HTTP-маршруты.
+- `middlewares` — auth/rate-limit middleware.
+- `services` — бизнес-логика auth/settings.
+- `repositories` — in-memory store (MVP).
+- `utils` — утилиты (crypto/cookies).
+
+## Безопасность (MVP)
+
+- `helmet`.
+- CORS ограничен `APP_URL`.
+- Валидация входа через `zod`.
+- Salted PBKDF2 hash для паролей.
+- Защита логина от brute-force (lockout).
+- Refresh-сессия через `HttpOnly` cookie.
+
+> Пока используется in-memory storage. Для production нужно перенести users/sessions/settings в БД.
+
+## Команды
 
 ```bash
 npm install
 npm run typecheck
 npm run build
-npm run test
 ```
 
-## Важно
+Локально:
 
-На данном этапе сделан только bootstrap и конфигурация модулей `web` и `server`.
-Бизнес-логика и прикладной код в новые модули пока не добавлялись.
-
-Старый контур `bot` остается доступным и не удаляется до завершения миграции.
+```bash
+npm run -w @scheduletm/server dev
+npm run -w @scheduletm/web dev
+```

--- a/TODO.md
+++ b/TODO.md
@@ -5,24 +5,25 @@
 - [x] Добавить `server/` как отдельный workspace.
 - [x] Добавить `web/` как отдельный workspace.
 - [x] Добавить root `package.json` с npm workspaces.
-- [x] Подключить базовые зависимости для React/MobX/MUI/Axios/Firebase/Google API.
-- [x] Подключить базовые зависимости для Node API (Express/Google APIs/Firebase Admin).
 
-## Этап 2 — Минимальный каркас API
+## Этап 2 — API MVP (выполнено)
 
-- [ ] Добавить `server/src/index.ts` с health endpoint и базовым bootstrap Express.
-- [ ] Добавить env-конфиг для server (`.env.example` + валидация).
-- [ ] Определить API-модули: auth, calendar, scheduling.
+- [x] Реализовать auth endpoints (register/login/refresh).
+- [x] Реализовать settings API (get/save).
+- [x] Реализовать google connect API endpoint.
+- [x] Разнести сервер по слоям (`routes/services/middlewares/config`).
 
-## Этап 3 — Минимальный каркас Web
+## Этап 3 — Web MVP (выполнено)
 
-- [ ] Добавить entrypoint для React приложения.
-- [ ] Добавить базовые слои: `app`, `shared`, `entities`, `features`, `pages`.
-- [ ] Добавить инициализацию MobX store и Axios client.
-- [ ] Добавить SSO flow через Firebase.
-- [ ] Добавить интеграционный слой для Google Calendar.
+- [x] Разбить UI на `components/containers/pages`.
+- [x] Добавить роутинг (`react-router-dom`).
+- [x] Перейти на MUI (`@mui/material`) и убрать кастомный CSS на старте.
+- [x] Добавить страницы login/register/settings.
 
-## Этап 4 — Миграция
+## Этап 4 — Следующий шаг
 
-- [ ] Зафиксировать план постепенного переноса функциональности из `bot` в `server/web`.
-- [ ] Определить дедлайн, после которого `bot` будет переведен в maintenance-only режим.
+- [ ] Перенести in-memory storage в БД.
+- [ ] Добавить полноценный Google OAuth 2.0 flow.
+- [ ] Добавить logout endpoint и отзыв refresh-сессий на backend.
+- [ ] Добавить CSRF protection для refresh cookie flow.
+- [ ] Добавить интеграционные и e2e тесты.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,30 @@
+import cors from 'cors';
+import express from 'express';
+import helmet from 'helmet';
+import morgan from 'morgan';
+import { env } from './config/env.js';
+import { authRoutes } from './routes/authRoutes.js';
+import { healthRoutes } from './routes/healthRoutes.js';
+import { integrationRoutes } from './routes/integrationRoutes.js';
+import { settingsRoutes } from './routes/settingsRoutes.js';
+
+export const createApp = () => {
+  const app = express();
+
+  app.disable('x-powered-by');
+  app.use(helmet());
+  app.use(morgan('dev'));
+  app.use(cors({ origin: env.APP_URL, credentials: true }));
+  app.use(express.json({ limit: '32kb' }));
+
+  app.use(healthRoutes);
+  app.use('/api/auth', authRoutes);
+  app.use('/api/settings', settingsRoutes);
+  app.use('/api/integrations', integrationRoutes);
+
+  app.use((_req, res) => {
+    res.status(404).json({ message: 'Not found' });
+  });
+
+  return app;
+};

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  PORT: z.coerce.number().int().positive().default(3000),
+  APP_URL: z.string().url().default('http://localhost:5173'),
+  SESSION_COOKIE_NAME: z.string().default('scheduletm_refresh'),
+  ACCESS_TOKEN_TTL_SECONDS: z.coerce.number().int().positive().default(900),
+  REFRESH_TOKEN_TTL_DAYS: z.coerce.number().int().positive().default(30)
+});
+
+export const env = envSchema.parse(process.env);

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const passwordSchema = z
+  .string()
+  .min(10)
+  .max(128)
+  .regex(/[A-Z]/, 'must contain uppercase letter')
+  .regex(/[a-z]/, 'must contain lowercase letter')
+  .regex(/[0-9]/, 'must contain number');
+
+export const registrationSchema = z.object({
+  email: z.string().email().max(254),
+  password: passwordSchema
+});
+
+export const loginSchema = registrationSchema;
+
+export const settingsSchema = z.object({
+  timezone: z.string().min(1).max(64),
+  dailyDigestEnabled: z.boolean(),
+  defaultMeetingDuration: z.coerce.number().int().min(15).max(180),
+  weekStartsOnMonday: z.boolean(),
+  locale: z.string().min(2).max(16)
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,9 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const [{ createApp }, { env }] = await Promise.all([import('./app.js'), import('./config/env.js')]);
+
+createApp().listen(env.PORT, () => {
+  console.log(`server listening on http://localhost:${env.PORT}`);
+});

--- a/server/src/middlewares/authMiddleware.ts
+++ b/server/src/middlewares/authMiddleware.ts
@@ -1,0 +1,22 @@
+import type { NextFunction, Request, Response } from 'express';
+import { resolveUserByAccessToken } from '../services/authService.js';
+import type { User } from '../types/domain.js';
+
+type AuthedRequest = Request & { user: User };
+
+export const requireAccessToken = (req: Request, res: Response, next: NextFunction) => {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const user = resolveUserByAccessToken(auth.slice('Bearer '.length));
+  if (!user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  (req as AuthedRequest).user = user;
+  return next();
+};
+
+export type { AuthedRequest };

--- a/server/src/middlewares/loginRateLimit.ts
+++ b/server/src/middlewares/loginRateLimit.ts
@@ -1,0 +1,10 @@
+import type { NextFunction, Request, Response } from 'express';
+import { isLockedIp } from '../services/authService.js';
+
+export const blockIfTooManyAttempts = (req: Request, res: Response, next: NextFunction) => {
+  if (isLockedIp(req.ip ?? 'unknown')) {
+    return res.status(429).json({ message: 'Too many login attempts. Try again later.' });
+  }
+
+  return next();
+};

--- a/server/src/repositories/inMemoryStore.ts
+++ b/server/src/repositories/inMemoryStore.ts
@@ -1,0 +1,16 @@
+import type { AppSettings, Session, User } from '../types/domain.js';
+
+export const usersByEmail = new Map<string, User>();
+export const settingsByUserId = new Map<string, AppSettings>();
+export const refreshSessions = new Map<string, Session>();
+export const accessSessions = new Map<string, Session>();
+export const loginAttempts = new Map<string, { count: number; lockedUntil: number }>();
+
+export const defaultSettings: AppSettings = {
+  timezone: 'UTC',
+  dailyDigestEnabled: true,
+  defaultMeetingDuration: 30,
+  weekStartsOnMonday: true,
+  locale: 'ru-RU',
+  googleConnected: false
+};

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { env } from '../config/env.js';
+import { loginSchema, registrationSchema } from '../config/schemas.js';
+import { blockIfTooManyAttempts } from '../middlewares/loginRateLimit.js';
+import {
+  authenticateUser,
+  clearAttempts,
+  issueSession,
+  refreshAccess,
+  registerFailedAttempt,
+  registerUser
+} from '../services/authService.js';
+import { parseCookies } from '../utils/cookies.js';
+
+export const authRoutes = Router();
+
+authRoutes.post('/register', (req, res) => {
+  const parsed = registrationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: 'Invalid registration payload' });
+  }
+
+  const user = registerUser(parsed.data.email, parsed.data.password);
+  if (!user) {
+    return res.status(409).json({ message: 'Email already exists' });
+  }
+
+  const accessToken = issueSession(user.id, res);
+  return res.status(201).json({ accessToken, user: { id: user.id, email: user.email } });
+});
+
+authRoutes.post('/login', blockIfTooManyAttempts, (req, res) => {
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: 'Invalid login payload' });
+  }
+
+  const user = authenticateUser(parsed.data.email, parsed.data.password);
+  if (!user) {
+    registerFailedAttempt(req.ip ?? 'unknown');
+    return res.status(401).json({ message: 'Invalid email or password' });
+  }
+
+  clearAttempts(req.ip ?? 'unknown');
+  const accessToken = issueSession(user.id, res);
+  return res.json({ accessToken, user: { id: user.id, email: user.email } });
+});
+
+authRoutes.post('/refresh', (req, res) => {
+  const refreshToken = parseCookies(req).get(env.SESSION_COOKIE_NAME);
+  if (!refreshToken) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const userId = refreshAccess(refreshToken);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const accessToken = issueSession(userId, res);
+  return res.json({ accessToken });
+});

--- a/server/src/routes/healthRoutes.ts
+++ b/server/src/routes/healthRoutes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+
+export const healthRoutes = Router();
+
+healthRoutes.get('/health', (_req, res) => {
+  res.json({ ok: true, at: new Date().toISOString() });
+});

--- a/server/src/routes/integrationRoutes.ts
+++ b/server/src/routes/integrationRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
+import { markGoogleConnected } from '../services/settingsService.js';
+
+export const integrationRoutes = Router();
+
+integrationRoutes.post('/google/connect', requireAccessToken, (req, res) => {
+  const user = (req as AuthedRequest).user;
+  return res.json(markGoogleConnected(user.id));
+});

--- a/server/src/routes/settingsRoutes.ts
+++ b/server/src/routes/settingsRoutes.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
+import { getSettings, updateSettings } from '../services/settingsService.js';
+
+export const settingsRoutes = Router();
+
+settingsRoutes.get('/', requireAccessToken, (req, res) => {
+  const user = (req as AuthedRequest).user;
+  return res.json(getSettings(user.id));
+});
+
+settingsRoutes.put('/', requireAccessToken, (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const updated = updateSettings(user.id, req.body);
+  if (!updated) {
+    return res.status(400).json({ message: 'Invalid settings payload' });
+  }
+
+  return res.json(updated);
+});

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -1,0 +1,102 @@
+import crypto from 'node:crypto';
+import type { Response } from 'express';
+import { env } from '../config/env.js';
+import {
+  accessSessions,
+  defaultSettings,
+  loginAttempts,
+  refreshSessions,
+  settingsByUserId,
+  usersByEmail
+} from '../repositories/inMemoryStore.js';
+import type { User } from '../types/domain.js';
+import { createToken, hashPassword, sanitizeEmail, verifyPassword } from '../utils/crypto.js';
+
+const now = () => Date.now();
+const cookieExpiresMs = env.REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+const accessExpiresMs = env.ACCESS_TOKEN_TTL_SECONDS * 1000;
+
+export const isLockedIp = (ip: string) => {
+  const attempt = loginAttempts.get(ip);
+  return Boolean(attempt && attempt.lockedUntil > now());
+};
+
+export const registerFailedAttempt = (ip: string) => {
+  const current = loginAttempts.get(ip) ?? { count: 0, lockedUntil: 0 };
+  const nextCount = current.count + 1;
+  const lockForMs = nextCount >= 5 ? 15 * 60 * 1000 : 0;
+
+  loginAttempts.set(ip, {
+    count: lockForMs > 0 ? 0 : nextCount,
+    lockedUntil: lockForMs > 0 ? now() + lockForMs : 0
+  });
+};
+
+export const clearAttempts = (ip: string) => loginAttempts.delete(ip);
+
+export const issueSession = (userId: string, res: Response) => {
+  const accessToken = createToken();
+  const refreshToken = createToken();
+
+  accessSessions.set(accessToken, { userId, expiresAt: now() + accessExpiresMs });
+  refreshSessions.set(refreshToken, { userId, expiresAt: now() + cookieExpiresMs });
+
+  res.cookie(env.SESSION_COOKIE_NAME, refreshToken, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: cookieExpiresMs,
+    path: '/api/auth'
+  });
+
+  return accessToken;
+};
+
+export const registerUser = (emailRaw: string, password: string): User | null => {
+  const email = sanitizeEmail(emailRaw);
+  if (usersByEmail.has(email)) {
+    return null;
+  }
+
+  const salt = crypto.randomBytes(16).toString('hex');
+  const user: User = {
+    id: crypto.randomUUID(),
+    email,
+    passwordSalt: salt,
+    passwordHash: hashPassword(password, salt),
+    createdAt: new Date().toISOString()
+  };
+
+  usersByEmail.set(email, user);
+  settingsByUserId.set(user.id, { ...defaultSettings });
+  return user;
+};
+
+export const authenticateUser = (emailRaw: string, password: string): User | null => {
+  const email = sanitizeEmail(emailRaw);
+  const user = usersByEmail.get(email);
+  if (!user) {
+    return null;
+  }
+
+  return verifyPassword(password, user.passwordSalt, user.passwordHash) ? user : null;
+};
+
+export const refreshAccess = (refreshToken: string) => {
+  const current = refreshSessions.get(refreshToken);
+  if (!current || current.expiresAt < now()) {
+    return null;
+  }
+
+  refreshSessions.delete(refreshToken);
+  return current.userId;
+};
+
+export const resolveUserByAccessToken = (token: string): User | null => {
+  const session = accessSessions.get(token);
+  if (!session || session.expiresAt < now()) {
+    return null;
+  }
+
+  return [...usersByEmail.values()].find((item) => item.id === session.userId) ?? null;
+};

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -1,0 +1,29 @@
+import type { AppSettings } from '../types/domain.js';
+import { settingsSchema } from '../config/schemas.js';
+import { defaultSettings, settingsByUserId } from '../repositories/inMemoryStore.js';
+
+export const getSettings = (userId: string): AppSettings => {
+  return settingsByUserId.get(userId) ?? { ...defaultSettings };
+};
+
+export const updateSettings = (userId: string, payload: unknown): AppSettings | null => {
+  const parsed = settingsSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+
+  const next = { ...getSettings(userId), ...parsed.data };
+  settingsByUserId.set(userId, next);
+  return next;
+};
+
+export const markGoogleConnected = (userId: string) => {
+  const next = { ...getSettings(userId), googleConnected: true };
+  settingsByUserId.set(userId, next);
+  return {
+    status: 'connected',
+    provider: 'google',
+    connectedAt: new Date().toISOString(),
+    oauthUrl: 'https://accounts.google.com/o/oauth2/v2/auth'
+  };
+};

--- a/server/src/types/domain.ts
+++ b/server/src/types/domain.ts
@@ -1,0 +1,21 @@
+export type User = {
+  id: string;
+  email: string;
+  passwordHash: string;
+  passwordSalt: string;
+  createdAt: string;
+};
+
+export type AppSettings = {
+  timezone: string;
+  dailyDigestEnabled: boolean;
+  defaultMeetingDuration: number;
+  weekStartsOnMonday: boolean;
+  locale: string;
+  googleConnected: boolean;
+};
+
+export type Session = {
+  userId: string;
+  expiresAt: number;
+};

--- a/server/src/utils/cookies.ts
+++ b/server/src/utils/cookies.ts
@@ -1,0 +1,15 @@
+import type { Request } from 'express';
+
+export const parseCookies = (req: Request) => {
+  const header = req.headers.cookie;
+  if (!header) {
+    return new Map<string, string>();
+  }
+
+  const pairs = header.split(';').map((item) => item.trim().split('='));
+  const parsed = new Map<string, string>();
+  for (const [key, ...rest] of pairs) {
+    parsed.set(key, decodeURIComponent(rest.join('=')));
+  }
+  return parsed;
+};

--- a/server/src/utils/crypto.ts
+++ b/server/src/utils/crypto.ts
@@ -1,0 +1,11 @@
+import crypto from 'node:crypto';
+
+export const sanitizeEmail = (email: string) => email.trim().toLowerCase();
+
+export const hashPassword = (password: string, salt: string) =>
+  crypto.pbkdf2Sync(password, salt, 310000, 32, 'sha256').toString('hex');
+
+export const createToken = () => crypto.randomBytes(32).toString('hex');
+
+export const verifyPassword = (password: string, salt: string, hash: string) =>
+  crypto.timingSafeEqual(Buffer.from(hashPassword(password, salt), 'hex'), Buffer.from(hash, 'hex'));

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ScheduleTM Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -15,9 +15,12 @@
     "gapi-script": "^1.2.0",
     "mobx": "^6.13.7",
     "mobx-react-lite": "^4.1.1",
-    "muicss": "^0.10.3",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^7.3.4",
+    "react-router-dom": "^7.9.4"
   },
   "devDependencies": {
     "@types/react": "^19.2.2",

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -1,0 +1,13 @@
+import { CssBaseline } from '@mui/material';
+import { RouterProvider } from 'react-router-dom';
+import { AuthProvider } from '../shared/auth/AuthContext';
+import { router } from './router';
+
+export function App() {
+  return (
+    <AuthProvider>
+      <CssBaseline />
+      <RouterProvider router={router} />
+    </AuthProvider>
+  );
+}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -1,0 +1,11 @@
+import { Navigate, createBrowserRouter } from 'react-router-dom';
+import { LoginPage } from '../pages/LoginPage';
+import { RegisterPage } from '../pages/RegisterPage';
+import { SettingsPage } from '../pages/SettingsPage';
+
+export const router = createBrowserRouter([
+  { path: '/', element: <Navigate to="/login" replace /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/register', element: <RegisterPage /> },
+  { path: '/settings', element: <SettingsPage /> }
+]);

--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -1,0 +1,44 @@
+import { Box, Button, Stack, TextField, Typography } from '@mui/material';
+
+type AuthCardProps = {
+  title: string;
+  email: string;
+  password: string;
+  submitText: string;
+  switchText: string;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSubmit: () => void;
+  onSwitch: () => void;
+};
+
+export function AuthCard(props: AuthCardProps) {
+  return (
+    <Box sx={{ maxWidth: 460, mx: 'auto', mt: 8 }}>
+      <Stack spacing={2} sx={{ p: 3, borderRadius: 2, boxShadow: 2, bgcolor: 'background.paper' }}>
+        <Typography variant="h5">{props.title}</Typography>
+        <TextField
+          label="Email"
+          type="email"
+          value={props.email}
+          onChange={(event) => props.onEmailChange(event.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Пароль"
+          type="password"
+          inputProps={{ minLength: 10 }}
+          value={props.password}
+          onChange={(event) => props.onPasswordChange(event.target.value)}
+          fullWidth
+        />
+        <Button variant="contained" onClick={props.onSubmit}>
+          {props.submitText}
+        </Button>
+        <Button variant="text" onClick={props.onSwitch}>
+          {props.switchText}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -1,0 +1,92 @@
+import {
+  Box,
+  Button,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography
+} from '@mui/material';
+import type { AppSettings } from '../shared/types/api';
+
+type SettingsCardProps = {
+  settings: AppSettings;
+  onSettingsChange: (next: AppSettings) => void;
+  onSave: () => void;
+  onConnectGoogle: () => void;
+  onLogout: () => void;
+};
+
+export function SettingsCard({
+  settings,
+  onSettingsChange,
+  onSave,
+  onConnectGoogle,
+  onLogout
+}: SettingsCardProps) {
+  return (
+    <Box sx={{ maxWidth: 560, mx: 'auto', mt: 6 }}>
+      <Stack spacing={2} sx={{ p: 3, borderRadius: 2, boxShadow: 2, bgcolor: 'background.paper' }}>
+        <Typography variant="h5">Настройки</Typography>
+
+        <TextField
+          label="Timezone"
+          value={settings.timezone}
+          onChange={(event) => onSettingsChange({ ...settings, timezone: event.target.value })}
+        />
+
+        <TextField
+          label="Locale"
+          value={settings.locale}
+          onChange={(event) => onSettingsChange({ ...settings, locale: event.target.value })}
+        />
+
+        <TextField
+          label="Default meeting duration (min)"
+          type="number"
+          inputProps={{ min: 15, max: 180 }}
+          value={settings.defaultMeetingDuration}
+          onChange={(event) =>
+            onSettingsChange({ ...settings, defaultMeetingDuration: Number(event.target.value) })
+          }
+        />
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={settings.dailyDigestEnabled}
+              onChange={(event) =>
+                onSettingsChange({ ...settings, dailyDigestEnabled: event.target.checked })
+              }
+            />
+          }
+          label="Daily digest enabled"
+        />
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={settings.weekStartsOnMonday}
+              onChange={(event) =>
+                onSettingsChange({ ...settings, weekStartsOnMonday: event.target.checked })
+              }
+            />
+          }
+          label="Week starts on Monday"
+        />
+
+        <Button variant="contained" onClick={onSave}>
+          Сохранить настройки
+        </Button>
+
+        <Button variant="outlined" onClick={onConnectGoogle} disabled={settings.googleConnected}>
+          {settings.googleConnected ? 'Google подключен' : 'Подключить Google'}
+        </Button>
+
+        <Button color="error" variant="text" onClick={onLogout}>
+          Выйти
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/web/src/containers/AuthContainer.tsx
+++ b/web/src/containers/AuthContainer.tsx
@@ -1,0 +1,59 @@
+import { Alert, Box, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthCard } from '../components/AuthCard';
+import { apiClient } from '../shared/api/client';
+import { useAuth } from '../shared/auth/AuthContext';
+import type { AuthResponse } from '../shared/types/api';
+
+type AuthMode = 'login' | 'register';
+
+type AuthContainerProps = {
+  mode: AuthMode;
+};
+
+export function AuthContainer({ mode }: AuthContainerProps) {
+  const navigate = useNavigate();
+  const { setAccessToken } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const isLogin = mode === 'login';
+
+  const submit = async () => {
+    try {
+      const endpoint = isLogin ? '/api/auth/login' : '/api/auth/register';
+      const response = await apiClient.post<AuthResponse>(endpoint, { email, password });
+      setAccessToken(response.data.accessToken);
+      setError('');
+      navigate('/settings');
+    } catch {
+      setError(isLogin ? 'Не удалось войти. Проверьте email/пароль.' : 'Не удалось зарегистрироваться.');
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ mt: 4, textAlign: 'center' }}>
+        ScheduleTM
+      </Typography>
+      {error && (
+        <Box sx={{ maxWidth: 460, mx: 'auto', mt: 2 }}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      )}
+      <AuthCard
+        title={isLogin ? 'Вход' : 'Регистрация'}
+        email={email}
+        password={password}
+        submitText={isLogin ? 'Войти' : 'Зарегистрироваться'}
+        switchText={isLogin ? 'Нет аккаунта? Зарегистрироваться' : 'Уже есть аккаунт? Войти'}
+        onEmailChange={setEmail}
+        onPasswordChange={setPassword}
+        onSubmit={submit}
+        onSwitch={() => navigate(isLogin ? '/register' : '/login')}
+      />
+    </Box>
+  );
+}

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -1,0 +1,87 @@
+import { Alert, Box } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SettingsCard } from '../components/SettingsCard';
+import { apiClient, authHeaders } from '../shared/api/client';
+import { useAuth } from '../shared/auth/AuthContext';
+import type { AppSettings } from '../shared/types/api';
+
+const defaultSettings: AppSettings = {
+  timezone: 'UTC',
+  dailyDigestEnabled: true,
+  defaultMeetingDuration: 30,
+  weekStartsOnMonday: true,
+  locale: 'ru-RU',
+  googleConnected: false
+};
+
+export function SettingsContainer() {
+  const navigate = useNavigate();
+  const { accessToken, clearAuth } = useAuth();
+  const [settings, setSettings] = useState<AppSettings>(defaultSettings);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!accessToken) {
+      navigate('/login');
+      return;
+    }
+
+    const load = async () => {
+      try {
+        const response = await apiClient.get<AppSettings>('/api/settings', {
+          headers: authHeaders(accessToken)
+        });
+        setSettings(response.data);
+      } catch {
+        setError('Не удалось загрузить настройки.');
+      }
+    };
+
+    void load();
+  }, [accessToken, navigate]);
+
+  const saveSettings = async () => {
+    try {
+      const response = await apiClient.put<AppSettings>('/api/settings', settings, {
+        headers: authHeaders(accessToken)
+      });
+      setSettings(response.data);
+      setError('');
+    } catch {
+      setError('Не удалось сохранить настройки.');
+    }
+  };
+
+  const connectGoogle = async () => {
+    try {
+      await apiClient.post('/api/integrations/google/connect', {}, { headers: authHeaders(accessToken) });
+      setSettings((prev) => ({ ...prev, googleConnected: true }));
+      setError('');
+    } catch {
+      setError('Не удалось подключить Google.');
+    }
+  };
+
+  const logout = () => {
+    clearAuth();
+    navigate('/login');
+  };
+
+  return (
+    <Box>
+      {error && (
+        <Box sx={{ maxWidth: 560, mx: 'auto', mt: 2 }}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      )}
+      <SettingsCard
+        settings={settings}
+        onSettingsChange={setSettings}
+        onSave={saveSettings}
+        onConnectGoogle={connectGoogle}
+        onLogout={logout}
+      />
+    </Box>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './app/App';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,0 +1,5 @@
+import { AuthContainer } from '../containers/AuthContainer';
+
+export function LoginPage() {
+  return <AuthContainer mode="login" />;
+}

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -1,0 +1,5 @@
+import { AuthContainer } from '../containers/AuthContainer';
+
+export function RegisterPage() {
+  return <AuthContainer mode="register" />;
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,5 @@
+import { SettingsContainer } from '../containers/SettingsContainer';
+
+export function SettingsPage() {
+  return <SettingsContainer />;
+}

--- a/web/src/shared/api/client.ts
+++ b/web/src/shared/api/client.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3000',
+  withCredentials: true
+});
+
+export const authHeaders = (accessToken: string) => ({
+  Authorization: `Bearer ${accessToken}`
+});

--- a/web/src/shared/auth/AuthContext.tsx
+++ b/web/src/shared/auth/AuthContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useMemo, useState, type PropsWithChildren } from 'react';
+
+type AuthContextValue = {
+  accessToken: string;
+  setAccessToken: (token: string) => void;
+  clearAuth: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const TOKEN_KEY = 'scheduletm_access_token';
+
+export function AuthProvider({ children }: PropsWithChildren) {
+  const [accessToken, setAccessTokenState] = useState<string>(() => localStorage.getItem(TOKEN_KEY) ?? '');
+
+  const setAccessToken = (token: string) => {
+    setAccessTokenState(token);
+    localStorage.setItem(TOKEN_KEY, token);
+  };
+
+  const clearAuth = () => {
+    setAccessTokenState('');
+    localStorage.removeItem(TOKEN_KEY);
+  };
+
+  const value = useMemo(() => ({ accessToken, setAccessToken, clearAuth }), [accessToken]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used inside AuthProvider');
+  }
+
+  return context;
+};

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -1,0 +1,16 @@
+export type AuthResponse = {
+  accessToken: string;
+  user: {
+    id: string;
+    email: string;
+  };
+};
+
+export type AppSettings = {
+  timezone: string;
+  dailyDigestEnabled: boolean;
+  defaultMeetingDuration: number;
+  weekStartsOnMonday: boolean;
+  locale: string;
+  googleConnected: boolean;
+};


### PR DESCRIPTION
### Motivation

- Provide a minimal server + web MVP to start migrating functionality from the legacy `bot` to a modern API and SPA, including basic auth, settings and Google integration contract.
- Introduce secure defaults and basic protections (input validation, security headers, password hashing, login lockout, refresh via cookie) to make the bootstrap safer for local and early staging use.
- Document the new project structure, API surface and next migration steps for the team.

### Description

- Added an Express-based server (`server/src`) with `createApp`, health and API routes for auth, settings and integrations, plus `auth` middlewares and rate-limit middleware for login attempts.
- Implemented auth and settings services backed by an in-memory store (`server/src/repositories/inMemoryStore.ts`) with PBKDF2 password hashing, token/session creation, refresh cookie handling and simple access token resolution in `server/src/services/*` and `server/src/utils/crypto.ts`.
- Added runtime/env validation and payload schemas using `zod` (`server/src/config/env.ts`, `server/src/config/schemas.ts`) and basic security middleware `helmet`, `morgan`, `cors` and JSON body parsing in `server/src/app.ts`.
- Bootstrapped a React SPA (`web/`) with routing and pages (`/login`, `/register`, `/settings`), UI components using MUI, an `AuthContext`, API client with `axios`, and updated `web/package.json` dependencies and `index.html` entrypoint.
- Updated repository documentation and project maps (`README.md`, `PROJECT_MAP.md`, `TODO.md`, `PRODUCTION_READINESS_CHECKLIST.md`) and adjusted `.env.example` to reflect new env keys and defaults.

### Testing

- Ran TypeScript typecheck via `npm run typecheck` across packages and it completed successfully.
- No automated unit or integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f403d9688333ba113ddc186cf195)