### PR TITLE
Add brand logos to header and set SVG favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/src/static/images/logo_one_latter.svg" />
     <title>Meetli</title>
   </head>
   <body>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -12,6 +12,8 @@ import type { Locale } from '../../shared/i18n/dictionaries';
 import type { PaletteVariantId } from '../../shared/theme/constants';
 import { PALETTE_VARIANTS } from '../../shared/theme/constants';
 import { AppIcons } from '../../shared/ui/AppIcons';
+import logoText from '../../static/images/logo_text.svg';
+import logoShort from '../../static/images/logo_short.svg';
 
 type HeaderProps = {
   title: string;
@@ -45,7 +47,20 @@ export function Header({
   return (
     <AppBar position="sticky" color="inherit" elevation={0} sx={{ borderBottom: 1, borderColor: 'divider' }}>
       <Toolbar sx={{ gap: 2 }}>
-        <Typography variant="h6">{title}</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Box
+            component="img"
+            src={logoText}
+            alt={title}
+            sx={{ height: 28, display: { xs: 'none', sm: 'block' } }}
+          />
+          <Box
+            component="img"
+            src={logoShort}
+            alt={title}
+            sx={{ height: 30, display: { xs: 'block', sm: 'none' } }}
+          />
+        </Box>
 
         <Box sx={{ flexGrow: 1 }} />
 


### PR DESCRIPTION
### Motivation
- Add the new branding assets in `web/src/static/images` to the app chrome so the header shows the proper logo on desktop and mobile and the site uses the provided SVG favicon.

### Description
- Import `logo_text.svg` and `logo_short.svg` into `web/src/components/layout/Header.tsx` and replace the text `Typography` title with responsive image elements that show `logo_text.svg` on `sm`+ screens and `logo_short.svg` on `xs` screens.
- Add an SVG favicon link to `web/index.html` referencing `/src/static/images/logo_one_latter.svg`.
- Preserve all existing header controls (palette selector, locale selector, theme toggle) and keep layout responsive.

### Testing
- Executed `cd web && npm run build` which failed due to missing `@mui/icons-material` TypeScript dependencies in the current environment, so the full build did not complete and the failure is unrelated to the asset wiring changes.
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60f347f748333bf81cf914c831a95)