### PR TITLE
Fix PostgreSQL connection resolution in server config

### DIFF
--- a/server/knexfile.ts
+++ b/server/knexfile.ts
@@ -3,10 +3,25 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const resolveConnectionString = (envName: 'development' | 'production'): string => {
+  const primary = envName === 'production' ? process.env.DATABASE_URL : process.env.DATABASE_PUBLIC_URL;
+  const fallback = envName === 'production' ? process.env.DATABASE_PUBLIC_URL : process.env.DATABASE_URL;
+  const connection = primary ?? fallback;
+
+  if (!connection) {
+    throw new Error(
+      `Не задана строка подключения к Postgres для окружения "${envName}". ` +
+        'Укажите DATABASE_PUBLIC_URL или DATABASE_URL в server/.env.',
+    );
+  }
+
+  return connection;
+};
+
 const config: Record<string, Knex.Config> = {
   development: {
     client: 'pg',
-    connection: process.env.DATABASE_PUBLIC_URL,
+    connection: resolveConnectionString('development'),
     migrations: {
       directory: './src/db/migrations',
       extension: 'ts',
@@ -15,10 +30,11 @@ const config: Record<string, Knex.Config> = {
       min: 0,
       max: 7,
     },
+    acquireConnectionTimeout: 10_000,
   },
   production: {
     client: 'pg',
-    connection: process.env.DATABASE_URL,
+    connection: resolveConnectionString('production'),
     migrations: {
       directory: './dist/db/migrations',
       extension: 'js',
@@ -27,6 +43,7 @@ const config: Record<string, Knex.Config> = {
       min: 0,
       max: 7,
     },
+    acquireConnectionTimeout: 10_000,
   },
 };
 

--- a/server/src/db/config.ts
+++ b/server/src/db/config.ts
@@ -1,20 +1,37 @@
 import type { Knex } from 'knex';
 
+const resolveConnectionString = (envName: 'development' | 'production'): string => {
+  const primary = envName === 'production' ? process.env.DATABASE_URL : process.env.DATABASE_PUBLIC_URL;
+  const fallback = envName === 'production' ? process.env.DATABASE_PUBLIC_URL : process.env.DATABASE_URL;
+  const connection = primary ?? fallback;
+
+  if (!connection) {
+    throw new Error(
+      `Не задана строка подключения к Postgres для окружения "${envName}". ` +
+        'Укажите DATABASE_PUBLIC_URL или DATABASE_URL в server/.env.',
+    );
+  }
+
+  return connection;
+};
+
 export const knexConfig: Record<string, Knex.Config> = {
   development: {
     client: 'pg',
-    connection: process.env.DATABASE_PUBLIC_URL,
+    connection: resolveConnectionString('development'),
     pool: {
       min: 0,
       max: 7,
     },
+    acquireConnectionTimeout: 10_000,
   },
   production: {
     client: 'pg',
-    connection: process.env.DATABASE_URL,
+    connection: resolveConnectionString('production'),
     pool: {
       min: 0,
       max: 7,
     },
+    acquireConnectionTimeout: 10_000,
   },
 };


### PR DESCRIPTION
### Motivation

- The server could fail with `Unable to acquire a connection` when only one of the DB env vars was present or env setup drifted, making local startup fragile.
- Provide a clear startup error and faster failure when the DB is misconfigured or unreachable to reduce confusing runtime errors.

### Description

- Added a `resolveConnectionString` helper and fallback between `DATABASE_PUBLIC_URL` and `DATABASE_URL` for both `development` and `production` in `server/src/db/config.ts` and mirrored it in `server/knexfile.ts`.
- Throw a clear error at startup if neither env variable is set, explaining which variables to configure.
- Added `acquireConnectionTimeout: 10_000` to both configs so Knex fails fast when it cannot acquire a connection from the pool.
- Updated runtime and migration configs to use the same connection resolution logic to keep behavior consistent across dev and migration runs.

### Testing

- Ran `npm run -w @scheduletm/server typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6193f29388333a0ecac411d9dfbe5)