### PR TITLE
fix(server): allow local frontend origin for CORS preflight

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,11 +10,24 @@ import { settingsRoutes } from './routes/settingsRoutes.js';
 
 export const createApp = () => {
   const app = express();
+  const allowedOrigins = Array.from(new Set([env.APP_URL, 'http://localhost:5173']));
 
   app.disable('x-powered-by');
   app.use(helmet());
   app.use(morgan('dev'));
-  app.use(cors({ origin: env.APP_URL, credentials: true }));
+  app.use(
+    cors({
+      credentials: true,
+      origin(origin, callback) {
+        if (!origin || allowedOrigins.includes(origin)) {
+          callback(null, true);
+          return;
+        }
+
+        callback(new Error('Not allowed by CORS'));
+      }
+    })
+  );
   app.use(express.json({ limit: '32kb' }));
 
   app.use(healthRoutes);


### PR DESCRIPTION
### Motivation
- Local frontend preflight requests from `http://localhost:5173` were blocked because the server used a single static `APP_URL` value for CORS, causing `Access-Control-Allow-Origin` to not match the dev origin.
- The change aims to allow credentialed auth flows to work in development while preserving production `APP_URL` as an allowed origin.

### Description
- Replaced the static `origin: env.APP_URL` CORS option with an origin callback that validates against an `allowedOrigins` list.
- Added `allowedOrigins` computed from `env.APP_URL` and `http://localhost:5173` (deduped via `Set`).
- The CORS callback permits requests with no `Origin` and retains `credentials: true` for auth cookie flows.
- Change implemented in `server/src/app.ts`.

### Testing
- Ran `npm run -w server typecheck`, which completed successfully.
- No additional automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61a7457988333a8da21b17f44b5a9)