### PR TITLE
Add web user roles and link specialists to web_user with migration and domain updates

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -24,7 +24,8 @@
 - [ ] Перенести in-memory store в persistent storage.
 - [ ] Добавить миграции и backup policy.
 - [x] Развести identity-таблицы для Telegram и Web (`users` + `web_users` + `user_identity_links`).
-- [x] Добавить связку специалиста и web identity (`specialist_identity_links`) для персональных интеграций.
+- [x] Добавить связку специалиста и web identity (`specialists.web_user_id`) для персональных интеграций.
+- [x] Добавить минимальную ролевую модель web-auth (`owner`/`specialist`) для разграничения доступа.
 
 ## 4. Integrations
 

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -16,9 +16,10 @@
 
 - `users` — Telegram users.
 - `web_users` — web auth users (email/password hash/salt).
+- `web_users.role` — роль web-пользователя (`owner`/`specialist`).
 - `web_users.google_api_key` — Google OAuth `access_token`, сохраняемый после web-коннекта Google.
 - `user_identity_links` — 1:1 bridge между `users` и `web_users` внутри `account_id`.
-- `specialist_identity_links` — 1:1 bridge между `specialists` и `web_users` внутри `account_id`.
+- `specialists.web_user_id` — 1:1 bridge между `specialists` и `web_users` внутри `account_id`.
 - Миграция: `server/src/db/migrations/20260420133000_add_web_users_and_identity_links.ts`.
 - Реализация: `server/src/services/authService.ts` + `bot/src/services/user.service.ts` используют эту схему для auth и auto-link по email.
 - `web/` — SPA:
@@ -85,5 +86,5 @@
 ## Google credentials (текущее разделение)
 
 - `web_users.google_api_key` — ключ, полученный через OAuth в web (под будущие роли и self-service логин специалистов).
-- `specialist_identity_links` — связь владельца credentials с конкретным специалистом.
+- `specialists.web_user_id` — связь владельца credentials с конкретным специалистом.
 - `specialists.google_api_key/google_calendar_id` — fallback в bot booking-flow для обратной совместимости.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ scheduletm/
 - `users` — Telegram-пользователи.
 - `web_users` — web-учетки для email/password auth.
 - `user_identity_links` — связь между Telegram и Web учетками (1:1 в рамках `account_id`).
-- `specialist_identity_links` — связь специалиста с web-учеткой (1:1 в рамках `account_id`) для персонального Google Calendar.
+- `web_users.role` — роль web-пользователя (`owner`/`specialist`).
+- `specialists.web_user_id` — прямая 1:1 привязка специалиста к web-учетке (в рамках `account_id`).
 - `server` auth-сервис регистрирует/логинит через `web_users`, а `bot` user-сервис при наличии email делает auto-link через `user_identity_links`.
 
 Сервер разнесен по слоям:
@@ -103,7 +104,7 @@ scheduletm/
 Текущее состояние модели данных для Google:
 
 - `web_users.google_api_key` — ключ, полученный через web OAuth (источник истины для авторизованного web-пользователя).
-- `specialist_identity_links` определяет, какому специалисту принадлежит `web_user`.
+- `specialists.web_user_id` определяет, какому специалисту принадлежит `web_user`.
 - bot Google Calendar использует сначала ключ/календарь связанного `web_user`, а затем fallback на legacy `specialists.google_api_key` / `specialists.google_calendar_id`.
 
 ## Куда двигаться дальше (web/server)

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,8 @@
 - [ ] Добавить миграции и seed для локальной разработки.
 - [x] Развести identity-модели: `users` (Telegram), `web_users` (web-auth), `user_identity_links` (1:1 связь в рамках account).
 - [x] Сохранять Google OAuth ключ web-пользователя в `web_users.google_api_key` после успешного callback.
-- [x] Добавить связь `specialists <-> web_users` через `specialist_identity_links` для персонального календаря специалиста.
+- [x] Добавить связь `specialists <-> web_users` через `specialists.web_user_id` для персонального календаря специалиста.
+- [x] Добавить ролевую модель web-auth (`owner`/`specialist`) и авто-создание default specialist для owner при регистрации.
 
 ### 4.2 Appointments (MVP)
 

--- a/server/README.md
+++ b/server/README.md
@@ -16,8 +16,9 @@ Node.js/Express API для web-клиента.
 Минимальная рабочая схема:
 
 - `users` — Telegram-профиль (chat context, username, phone, язык и т.д.).
-- `web_users` — web-учетка (email, password hash/salt, login lifecycle).
+- `web_users` — web-учетка (email, password hash/salt, role, login lifecycle).
 - `user_identity_links` — явная 1:1 связь между `users` и `web_users` внутри одного `account_id`.
+- `specialists.web_user_id` — явная 1:1 связь специалиста с web-учеткой внутри одного `account_id`.
 
 Преимущества:
 
@@ -25,10 +26,12 @@ Node.js/Express API для web-клиента.
 - DRY: нет дублирования auth-данных в Telegram-таблице.
 - SOLID: auth/web и telegram-домены развиваются независимо, но связываются через отдельный слой.
 
-В проект добавлена миграция `20260420133000_add_web_users_and_identity_links.ts` с этими таблицами.
+В проект добавлены миграции `20260420133000_add_web_users_and_identity_links.ts` и
+`20260420170000_add_web_user_roles_and_specialist_link.ts` с этими таблицами и связями.
 
-Текущая реализация `server/src/services/authService.ts` уже использует `web_users` для register/login и
-пытается автоматически создать запись в `user_identity_links`, если найден Telegram user с тем же email.
+Текущая реализация `server/src/services/authService.ts` использует `web_users` для register/login,
+создает роль `owner` при регистрации, автоматически добавляет owner как default specialist
+и пытается создать запись в `user_identity_links`, если найден Telegram user с тем же email.
 
 ## Ближайший roadmap
 

--- a/server/src/db/migrations/20260420170000_add_web_user_roles_and_specialist_link.ts
+++ b/server/src/db/migrations/20260420170000_add_web_user_roles_and_specialist_link.ts
@@ -1,0 +1,88 @@
+import type { Knex } from 'knex';
+import { WEB_USER_ROLES, WebUserRole } from '../../types/webUserRole.js';
+
+const WEB_USERS_TABLE = 'web_users';
+const SPECIALISTS_TABLE = 'specialists';
+const ROLE_CHECK = `role IN (${WEB_USER_ROLES.map((role) => `'${role}'`).join(', ')})`;
+
+async function ensureWebUsersRole(knex: Knex) {
+  const hasWebUsers = await knex.schema.hasTable(WEB_USERS_TABLE);
+  if (!hasWebUsers) {
+    return;
+  }
+
+  const hasRole = await knex.schema.hasColumn(WEB_USERS_TABLE, 'role');
+  if (!hasRole) {
+    await knex.schema.alterTable(WEB_USERS_TABLE, (table) => {
+      table.string('role').notNullable().defaultTo(WebUserRole.Owner);
+    });
+  }
+
+  await knex.raw(
+    `ALTER TABLE "${WEB_USERS_TABLE}" DROP CONSTRAINT IF EXISTS "web_users_role_check"`,
+  );
+  await knex.raw(
+    `ALTER TABLE "${WEB_USERS_TABLE}" ADD CONSTRAINT "web_users_role_check" CHECK (${ROLE_CHECK})`,
+  );
+}
+
+async function ensureSpecialistsWebUserId(knex: Knex) {
+  const hasSpecialists = await knex.schema.hasTable(SPECIALISTS_TABLE);
+  if (!hasSpecialists) {
+    return;
+  }
+
+  const hasWebUserId = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'web_user_id');
+  if (!hasWebUserId) {
+    await knex.schema.alterTable(SPECIALISTS_TABLE, (table) => {
+      table
+        .integer('web_user_id')
+        .references('id')
+        .inTable(WEB_USERS_TABLE)
+        .onDelete('SET NULL');
+    });
+  }
+
+  await knex.raw(
+    `CREATE UNIQUE INDEX IF NOT EXISTS "specialists_account_id_web_user_id_unique" ON "${SPECIALISTS_TABLE}" ("account_id", "web_user_id") WHERE "web_user_id" IS NOT NULL`,
+  );
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS "specialists_web_user_id_index" ON "${SPECIALISTS_TABLE}" ("web_user_id")`,
+  );
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await ensureWebUsersRole(knex);
+  await ensureSpecialistsWebUserId(knex);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasSpecialists = await knex.schema.hasTable(SPECIALISTS_TABLE);
+  if (hasSpecialists) {
+    await knex.raw('DROP INDEX IF EXISTS "specialists_web_user_id_index"');
+    await knex.raw('DROP INDEX IF EXISTS "specialists_account_id_web_user_id_unique"');
+
+    const hasWebUserId = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'web_user_id');
+    if (hasWebUserId) {
+      await knex.schema.alterTable(SPECIALISTS_TABLE, (table) => {
+        table.dropColumn('web_user_id');
+      });
+    }
+  }
+
+  const hasWebUsers = await knex.schema.hasTable(WEB_USERS_TABLE);
+  if (!hasWebUsers) {
+    return;
+  }
+
+  await knex.raw(
+    `ALTER TABLE "${WEB_USERS_TABLE}" DROP CONSTRAINT IF EXISTS "web_users_role_check"`,
+  );
+
+  const hasRole = await knex.schema.hasColumn(WEB_USERS_TABLE, 'role');
+  if (hasRole) {
+    await knex.schema.alterTable(WEB_USERS_TABLE, (table) => {
+      table.dropColumn('role');
+    });
+  }
+}

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -1,0 +1,26 @@
+import { db } from '../db/knex.js';
+
+export async function createDefaultSpecialistForWebUserIfMissing(
+  accountId: number,
+  webUserId: number,
+  email: string,
+): Promise<void> {
+  const existing = await db('specialists')
+    .where({ account_id: accountId, web_user_id: webUserId })
+    .first('id');
+
+  if (existing) {
+    return;
+  }
+
+  const fallbackName = email.split('@')[0]?.trim() || `Owner ${webUserId}`;
+
+  await db('specialists').insert({
+    account_id: accountId,
+    code: `owner-${webUserId}`,
+    name: fallbackName,
+    is_active: true,
+    is_default: true,
+    web_user_id: webUserId,
+  });
+}

--- a/server/src/repositories/webUserRepository.ts
+++ b/server/src/repositories/webUserRepository.ts
@@ -1,9 +1,11 @@
 import { db } from '../db/knex.js';
+import { type WebUserRole } from '../types/webUserRole.js';
 
 export type WebUserRecord = {
   id: number;
   account_id: number;
   email: string;
+  role: WebUserRole;
   password_hash: string;
   password_salt: string;
   is_active: boolean;
@@ -18,6 +20,7 @@ export type WebUserRecord = {
 type CreateWebUserInput = {
   accountId: number;
   email: string;
+  role: WebUserRole;
   passwordHash: string;
   passwordSalt: string;
 };
@@ -43,6 +46,7 @@ export async function createWebUser(input: CreateWebUserInput): Promise<WebUserR
     .insert({
       account_id: input.accountId,
       email: input.email,
+      role: input.role,
       password_hash: input.passwordHash,
       password_salt: input.passwordSalt,
       is_active: true,

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -36,7 +36,7 @@ authRoutes.post('/register', async (req, res) => {
     return res.status(201).json({
       message: 'Регистрация прошла успешно',
       accessToken,
-      user: { id: user.id, email: user.email }
+      user: { id: user.id, email: user.email, role: user.role }
     });
   } catch (error) {
     console.error(error);
@@ -68,7 +68,7 @@ authRoutes.post('/login', blockIfTooManyAttempts, async (req, res) => {
     return res.json({
       message: 'Вход выполнен успешно',
       accessToken,
-      user: { id: user.id, email: user.email }
+      user: { id: user.id, email: user.email, role: user.role }
     });
   } catch (error) {
     console.error(error);

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -7,9 +7,11 @@ import {
   refreshSessions
 } from '../repositories/inMemoryStore.js';
 import { getDefaultAccountId } from '../repositories/accountRepository.js';
+import { createDefaultSpecialistForWebUserIfMissing } from '../repositories/specialistRepository.js';
 import { createIdentityLinkIfMissing, findTelegramUserByEmail } from '../repositories/userIdentityLinkRepository.js';
 import { createWebUser, findWebUserByEmail, findWebUserById, touchWebUserLastLogin } from '../repositories/webUserRepository.js';
 import type { User } from '../types/domain.js';
+import { WebUserRole } from '../types/webUserRole.js';
 import { createToken, hashPassword, sanitizeEmail, verifyPassword } from '../utils/crypto.js';
 
 const now = () => Date.now();
@@ -52,10 +54,18 @@ export const issueSession = (userId: string, res: Response) => {
   return accessToken;
 };
 
-const mapWebUserToDomain = (id: number, email: string, passwordSalt: string, passwordHash: string, createdAt: Date): User => {
+const mapWebUserToDomain = (
+  id: number,
+  email: string,
+  role: WebUserRole,
+  passwordSalt: string,
+  passwordHash: string,
+  createdAt: Date,
+): User => {
   return {
     id: String(id),
     email,
+    role,
     passwordSalt,
     passwordHash,
     createdAt: createdAt.toISOString()
@@ -85,15 +95,18 @@ export const registerUser = async (emailRaw: string, password: string): Promise<
   const webUser = await createWebUser({
     accountId,
     email,
+    role: WebUserRole.Owner,
     passwordHash,
     passwordSalt: salt
   });
 
+  await createDefaultSpecialistForWebUserIfMissing(accountId, webUser.id, email);
   await tryLinkTelegramIdentity(accountId, email, webUser.id);
 
   return mapWebUserToDomain(
     webUser.id,
     webUser.email,
+    webUser.role,
     webUser.password_salt,
     webUser.password_hash,
     webUser.created_at
@@ -114,7 +127,7 @@ export const authenticateUser = async (emailRaw: string, password: string): Prom
   }
 
   await touchWebUserLastLogin(accountId, user.id);
-  return mapWebUserToDomain(user.id, user.email, user.password_salt, user.password_hash, user.created_at);
+  return mapWebUserToDomain(user.id, user.email, user.role, user.password_salt, user.password_hash, user.created_at);
 };
 
 export const refreshAccess = (refreshToken: string) => {
@@ -144,5 +157,5 @@ export const resolveUserByAccessToken = async (token: string): Promise<User | nu
     return null;
   }
 
-  return mapWebUserToDomain(user.id, user.email, user.password_salt, user.password_hash, user.created_at);
+  return mapWebUserToDomain(user.id, user.email, user.role, user.password_salt, user.password_hash, user.created_at);
 };

--- a/server/src/types/domain.ts
+++ b/server/src/types/domain.ts
@@ -1,6 +1,9 @@
+import type { WebUserRole } from './webUserRole.js';
+
 export type User = {
   id: string;
   email: string;
+  role: WebUserRole;
   passwordHash: string;
   passwordSalt: string;
   createdAt: string;

--- a/server/src/types/webUserRole.ts
+++ b/server/src/types/webUserRole.ts
@@ -1,0 +1,6 @@
+export enum WebUserRole {
+  Owner = 'owner',
+  Specialist = 'specialist',
+}
+
+export const WEB_USER_ROLES = [WebUserRole.Owner, WebUserRole.Specialist] as const;

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -1,8 +1,11 @@
+import type { WebUserRole } from './roles';
+
 export type AuthResponse = {
   accessToken: string;
   user: {
     id: string;
     email: string;
+    role: WebUserRole;
   };
 };
 

--- a/web/src/shared/types/roles.ts
+++ b/web/src/shared/types/roles.ts
@@ -1,0 +1,4 @@
+export enum WebUserRole {
+  Owner = 'owner',
+  Specialist = 'specialist',
+}


### PR DESCRIPTION
### Motivation

- Introduce a minimal rbac model (`owner`/`specialist`) for web-auth to enable scoped behavior and per-specialist Google integrations.  
- Provide an explicit 1:1 link from `specialists` to `web_users` so owner-created web accounts can own specialist calendar credentials.  
- Surface roles through API and domain types so frontend and services can rely on the role information.

### Description

- Added `WebUserRole` enum and exported `WEB_USER_ROLES` in `server/src/types/webUserRole.ts` and matching frontend `web/src/shared/types/roles.ts`.  
- Created DB migration `20260420170000_add_web_user_roles_and_specialist_link.ts` to add `web_users.role` (with check constraint and default `owner`) and `specialists.web_user_id` with indexes and unique constraint.  
- Implemented `specialistRepository.createDefaultSpecialistForWebUserIfMissing` to auto-create a default specialist for a newly created owner.  
- Extended `webUserRepository` and domain types to include `role`, updated `authService` to assign `owner` on registration, auto-create default specialist, and map/include `role` in `User` domain objects, and updated auth routes to return `user.role` on register/login.  
- Updated frontend API typings (`AuthResponse`) to include `role` and refreshed project docs (`README.md`, `PROJECT_MAP.md`, `PRODUCTION_READINESS_CHECKLIST.md`, `TODO.md`, `server/README.md`) to reflect the new model and migration filenames.

### Testing

- Performed a TypeScript typecheck and project/server build (`tsc` / `yarn build`) and they completed successfully.  
- No automated unit or integration tests were added in this change; existing test suite (if present) was not modified as part of this PR.  
- The new migration was authored with reversible `up`/`down` logic to allow applying and rolling back schema changes in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62e9e2ff0833389829b9936e91ab2)