### PR TITLE
Persist web auth sessions in DB, add logout endpoint and client-side auto-logout on 401

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -15,6 +15,7 @@
 - [x] Salted PBKDF2 hashing для паролей.
 - [x] Brute-force lockout на login endpoint.
 - [x] Refresh session через `HttpOnly` cookie.
+- [x] Logout endpoint удаляет текущие web auth-сессии из БД и очищает refresh cookie.
 - [ ] Добавить CSRF protection для refresh cookie flow.
 - [ ] Перенести секреты в secret manager (production).
 
@@ -22,6 +23,7 @@
 
 - [x] Разделить server-код по слоям (`routes/services/middlewares/config/repositories`).
 - [ ] Перенести in-memory store в persistent storage.
+- [x] Вынести web auth-сессии в persistent storage (`web_user_sessions`, access + refresh, revoke + expires_at).
 - [ ] Добавить миграции и backup policy.
 - [x] Развести identity-таблицы для Telegram и Web (`users` + `web_users` + `user_identity_links`).
 - [x] Добавить связку специалиста и web identity (`specialists.web_user_id`) для персональных интеграций.
@@ -42,6 +44,7 @@
 - [x] Добавить в header профильный dropdown авторизованного пользователя (settings/logout) с адаптацией под мобильные экраны.
 - [ ] Подключить error tracking.
 - [ ] Настроить caching/security headers на edge.
+- [x] При `401 Unauthorized` на API автоматически очищать auth-state во фронте и отправлять пользователя на `/login`.
 
 ## 6. Appointments readiness
 

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -20,6 +20,7 @@
 - `web_users.google_api_key` — Google OAuth `access_token`, сохраняемый после web-коннекта Google.
 - `user_identity_links` — 1:1 bridge между `users` и `web_users` внутри `account_id`.
 - `specialists.web_user_id` — 1:1 bridge между `specialists` и `web_users` внутри `account_id`.
+- `web_user_sessions` — web auth-сессии (`access`/`refresh`) с `expires_at`/`revoked_at`, источник истины для проверки токенов и refresh-rotation.
 - Миграция: `server/src/db/migrations/20260420133000_add_web_users_and_identity_links.ts`.
 - Реализация: `server/src/services/authService.ts` + `bot/src/services/user.service.ts` используют эту схему для auth и auto-link по email.
 - `web/` — SPA:
@@ -31,6 +32,7 @@
   - `web/src/shared/ui/*` — базовые MUI-wrapper компоненты (`AppButton`, `AppTabs`, `AppForm`, `AppTextField`, `AppPage`, `AppIcons`).
   - `web/src/shared/theme/*` — константы дизайна + фабрика темы + light/dark + palette variants.
   - `web/src/shared/*` — API client, типы, auth context и переиспользуемая инфраструктура.
+  - `web/src/shared/api/client.ts` — глобальный `401` handler: при `Unauthorized` очищает auth-state и переводит пользователя на `/login`.
   - `web/src/shared/i18n/*` — словари переводов (`ru/en`) и i18n-контекст приложения.
   - До логина показываются только auth-страницы (`/login`, `/register`) без header/left menu; после регистрации маршрут ведёт на `/login`.
 
@@ -40,6 +42,7 @@
 - `POST /api/auth/register`
 - `POST /api/auth/login`
 - `POST /api/auth/refresh`
+- `POST /api/auth/logout`
 - `GET /api/settings`
 - `PUT /api/settings`
 - `POST /api/integrations/google/oauth/start`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ scheduletm/
 - `POST /api/auth/register`
 - `POST /api/auth/login`
 - `POST /api/auth/refresh`
+- `POST /api/auth/logout`
 - `GET /api/settings`
 - `PUT /api/settings`
 - `POST /api/integrations/google/oauth/start`
@@ -154,8 +155,11 @@ scheduletm/
 - Salted PBKDF2 hash для паролей.
 - Защита логина от brute-force (lockout).
 - Refresh-сессия через `HttpOnly` cookie.
+- Access/refresh web-сессии сохраняются в БД (`web_user_sessions`), а не в in-memory.
+- Logout в web вызывает backend `POST /api/auth/logout`, который удаляет текущие access/refresh токены из БД и очищает refresh cookie.
+- Если API возвращает `401 Unauthorized`, web-клиент автоматически очищает auth-сессию и делает redirect на `/login`.
 
-> Пока используется in-memory storage. Для production нужно перенести users/sessions/settings в БД.
+> `settings` пока остаются in-memory. Web auth-сессии уже хранятся в БД, следующий шаг — перенести туда же settings.
 
 ## Команды
 

--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,7 @@
 ### 4.1 Data layer
 
 - [ ] Перенести in-memory storage в БД (минимум users/sessions/settings).
+- [x] Перенести web auth-сессии в БД (`web_user_sessions`, access + refresh токены).
 - [ ] Добавить миграции и seed для локальной разработки.
 - [x] Развести identity-модели: `users` (Telegram), `web_users` (web-auth), `user_identity_links` (1:1 связь в рамках account).
 - [x] Сохранять Google OAuth ключ web-пользователя в `web_users.google_api_key` после успешного callback.
@@ -53,7 +54,7 @@
 
 ### 4.4 Security & auth hardening
 
-- [ ] Добавить logout endpoint и отзыв refresh-сессий на backend.
+- [x] Добавить logout endpoint и удаление текущей web-сессии из БД на backend.
 - [ ] Добавить CSRF protection для refresh cookie flow.
 - [x] Добавить полноценный Google OAuth 2.0 flow (web button -> backend start -> google callback).
 
@@ -63,6 +64,7 @@
 - [x] Для неавторизованных пользователей показывать только `/login` и `/register` без меню/настроек; после регистрации делать redirect на `/login`.
 - [x] Добавить в header профиль авторизованного пользователя (avatar/инициалы + dropdown с settings/logout) и mobile-friendly компоновку шапки.
 - [ ] Добавить интеграционные тесты (server) и e2e smoke (web).
+- [x] На `401 Unauthorized` в web-клиенте автоматически делать logout и redirect на `/login`.
 
 ### 4.6 UI foundation (выполнено)
 

--- a/server/src/db/migrations/20260421100000_add_web_user_sessions.ts
+++ b/server/src/db/migrations/20260421100000_add_web_user_sessions.ts
@@ -1,0 +1,39 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'web_user_sessions';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE_NAME);
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table
+      .integer('account_id')
+      .notNullable()
+      .references('id')
+      .inTable('accounts')
+      .onDelete('CASCADE');
+    table
+      .integer('web_user_id')
+      .notNullable()
+      .references('id')
+      .inTable('web_users')
+      .onDelete('CASCADE');
+    table.string('token').notNullable().unique();
+    table.string('session_type').notNullable();
+    table.timestamp('expires_at', { useTz: true }).notNullable();
+    table.timestamp('revoked_at', { useTz: true });
+    table.timestamps(true, true);
+
+    table.index(['account_id'], 'web_user_sessions_account_id_index');
+    table.index(['account_id', 'web_user_id'], 'web_user_sessions_account_user_index');
+    table.index(['session_type'], 'web_user_sessions_type_index');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists(TABLE_NAME);
+}

--- a/server/src/repositories/inMemoryStore.ts
+++ b/server/src/repositories/inMemoryStore.ts
@@ -1,9 +1,7 @@
-import type { AppSettings, Session, User } from '../types/domain.js';
+import type { AppSettings, User } from '../types/domain.js';
 
 export const usersByEmail = new Map<string, User>();
 export const settingsByUserId = new Map<string, AppSettings>();
-export const refreshSessions = new Map<string, Session>();
-export const accessSessions = new Map<string, Session>();
 export const loginAttempts = new Map<string, { count: number; lockedUntil: number }>();
 export const oauthStateByToken = new Map<string, { userId: string; createdAt: number }>();
 

--- a/server/src/repositories/webUserSessionRepository.ts
+++ b/server/src/repositories/webUserSessionRepository.ts
@@ -1,0 +1,67 @@
+import { db } from '../db/knex.js';
+
+export type WebSessionType = 'access' | 'refresh';
+
+type WebUserSessionRecord = {
+  id: number;
+  account_id: number;
+  web_user_id: number;
+  token: string;
+  session_type: WebSessionType;
+  expires_at: Date;
+  revoked_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type CreateWebUserSessionInput = {
+  accountId: number;
+  webUserId: number;
+  token: string;
+  sessionType: WebSessionType;
+  expiresAt: Date;
+};
+
+export async function createWebUserSession(input: CreateWebUserSessionInput): Promise<void> {
+  await db('web_user_sessions').insert({
+    account_id: input.accountId,
+    web_user_id: input.webUserId,
+    token: input.token,
+    session_type: input.sessionType,
+    expires_at: input.expiresAt,
+  });
+}
+
+export async function findActiveWebUserSessionByToken(
+  accountId: number,
+  token: string,
+  sessionType: WebSessionType,
+): Promise<WebUserSessionRecord | null> {
+  const row = await db('web_user_sessions')
+    .where({
+      account_id: accountId,
+      token,
+      session_type: sessionType,
+    })
+    .whereNull('revoked_at')
+    .where('expires_at', '>', db.fn.now())
+    .first<WebUserSessionRecord>();
+
+  return row ?? null;
+}
+
+export async function revokeWebUserSessionByToken(accountId: number, token: string): Promise<void> {
+  await db('web_user_sessions')
+    .where({ account_id: accountId, token })
+    .whereNull('revoked_at')
+    .update({
+      revoked_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    });
+}
+
+export async function deleteWebUserSessionByToken(accountId: number, token: string): Promise<void> {
+  await db('web_user_sessions')
+    .where({ account_id: accountId, token })
+    .del();
+}

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -6,6 +6,7 @@ import {
   authenticateUser,
   clearAttempts,
   issueSession,
+  logoutSession,
   refreshAccess,
   registerFailedAttempt,
   registerUser
@@ -32,7 +33,7 @@ authRoutes.post('/register', async (req, res) => {
       });
     }
 
-    const accessToken = issueSession(user.id, res);
+    const accessToken = await issueSession(user.id, res);
     return res.status(201).json({
       message: 'Регистрация прошла успешно',
       accessToken,
@@ -64,7 +65,7 @@ authRoutes.post('/login', blockIfTooManyAttempts, async (req, res) => {
     }
 
     clearAttempts(req.ip ?? 'unknown');
-    const accessToken = issueSession(user.id, res);
+    const accessToken = await issueSession(user.id, res);
     return res.json({
       message: 'Вход выполнен успешно',
       accessToken,
@@ -76,7 +77,7 @@ authRoutes.post('/login', blockIfTooManyAttempts, async (req, res) => {
   }
 });
 
-authRoutes.post('/refresh', (req, res) => {
+authRoutes.post('/refresh', async (req, res) => {
   const refreshToken = parseCookies(req).get(env.SESSION_COOKIE_NAME);
 
   if (!refreshToken) {
@@ -85,16 +86,36 @@ authRoutes.post('/refresh', (req, res) => {
     });
   }
 
-  const userId = refreshAccess(refreshToken);
+  const userId = await refreshAccess(refreshToken);
   if (!userId) {
     return res.status(401).json({
       message: 'Не удалось обновить сессию. Войдите снова'
     });
   }
 
-  const accessToken = issueSession(userId, res);
+  const accessToken = await issueSession(userId, res);
   return res.json({
     message: 'Сессия обновлена',
     accessToken
   });
+});
+
+authRoutes.post('/logout', async (req, res) => {
+  const refreshToken = parseCookies(req).get(env.SESSION_COOKIE_NAME);
+  const auth = req.headers.authorization;
+  const accessToken = auth?.startsWith('Bearer ') ? auth.slice('Bearer '.length) : undefined;
+
+  try {
+    await logoutSession(refreshToken, accessToken);
+    res.clearCookie(env.SESSION_COOKIE_NAME, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/api/auth'
+    });
+    return res.status(204).send();
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: 'Не удалось завершить сессию' });
+  }
 });

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -1,15 +1,17 @@
 import crypto from 'node:crypto';
 import type { Response } from 'express';
 import { env } from '../config/env.js';
-import {
-  accessSessions,
-  loginAttempts,
-  refreshSessions
-} from '../repositories/inMemoryStore.js';
+import { loginAttempts } from '../repositories/inMemoryStore.js';
 import { getDefaultAccountId } from '../repositories/accountRepository.js';
 import { createDefaultSpecialistForWebUserIfMissing } from '../repositories/specialistRepository.js';
 import { createIdentityLinkIfMissing, findTelegramUserByEmail } from '../repositories/userIdentityLinkRepository.js';
 import { createWebUser, findWebUserByEmail, findWebUserById, touchWebUserLastLogin } from '../repositories/webUserRepository.js';
+import {
+  createWebUserSession,
+  deleteWebUserSessionByToken,
+  findActiveWebUserSessionByToken,
+  revokeWebUserSessionByToken
+} from '../repositories/webUserSessionRepository.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 import { createToken, hashPassword, sanitizeEmail, verifyPassword } from '../utils/crypto.js';
@@ -36,12 +38,32 @@ export const registerFailedAttempt = (ip: string) => {
 
 export const clearAttempts = (ip: string) => loginAttempts.delete(ip);
 
-export const issueSession = (userId: string, res: Response) => {
+export const issueSession = async (userId: string, res: Response) => {
+  const accountId = await getDefaultAccountId();
+  const numericUserId = Number(userId);
+  if (!Number.isInteger(numericUserId)) {
+    throw new Error('Invalid web user id for session issue');
+  }
+
   const accessToken = createToken();
   const refreshToken = createToken();
+  const accessExpiresAt = new Date(now() + accessExpiresMs);
+  const refreshExpiresAt = new Date(now() + cookieExpiresMs);
 
-  accessSessions.set(accessToken, { userId, expiresAt: now() + accessExpiresMs });
-  refreshSessions.set(refreshToken, { userId, expiresAt: now() + cookieExpiresMs });
+  await createWebUserSession({
+    accountId,
+    webUserId: numericUserId,
+    token: accessToken,
+    sessionType: 'access',
+    expiresAt: accessExpiresAt
+  });
+  await createWebUserSession({
+    accountId,
+    webUserId: numericUserId,
+    token: refreshToken,
+    sessionType: 'refresh',
+    expiresAt: refreshExpiresAt
+  });
 
   res.cookie(env.SESSION_COOKIE_NAME, refreshToken, {
     httpOnly: true,
@@ -130,32 +152,40 @@ export const authenticateUser = async (emailRaw: string, password: string): Prom
   return mapWebUserToDomain(user.id, user.email, user.role, user.password_salt, user.password_hash, user.created_at);
 };
 
-export const refreshAccess = (refreshToken: string) => {
-  const current = refreshSessions.get(refreshToken);
-  if (!current || current.expiresAt < now()) {
+export const refreshAccess = async (refreshToken: string) => {
+  const accountId = await getDefaultAccountId();
+  const current = await findActiveWebUserSessionByToken(accountId, refreshToken, 'refresh');
+  if (!current) {
     return null;
   }
 
-  refreshSessions.delete(refreshToken);
-  return current.userId;
+  await revokeWebUserSessionByToken(accountId, refreshToken);
+  return String(current.web_user_id);
 };
 
 export const resolveUserByAccessToken = async (token: string): Promise<User | null> => {
-  const session = accessSessions.get(token);
-  if (!session || session.expiresAt < now()) {
-    return null;
-  }
-
   const accountId = await getDefaultAccountId();
-  const userId = Number(session.userId);
-  if (!Number.isInteger(userId)) {
+  const session = await findActiveWebUserSessionByToken(accountId, token, 'access');
+  if (!session) {
     return null;
   }
 
-  const user = await findWebUserById(accountId, userId);
+  const user = await findWebUserById(accountId, session.web_user_id);
   if (!user) {
     return null;
   }
 
   return mapWebUserToDomain(user.id, user.email, user.role, user.password_salt, user.password_hash, user.created_at);
+};
+
+export const logoutSession = async (refreshToken?: string, accessToken?: string) => {
+  const accountId = await getDefaultAccountId();
+
+  if (refreshToken) {
+    await deleteWebUserSessionByToken(accountId, refreshToken);
+  }
+
+  if (accessToken) {
+    await deleteWebUserSessionByToken(accountId, accessToken);
+  }
 };

--- a/server/src/types/domain.ts
+++ b/server/src/types/domain.ts
@@ -19,8 +19,3 @@ export type AppSettings = {
   uiThemeMode: 'light' | 'dark';
   uiPaletteVariantId: string;
 };
-
-export type Session = {
-  userId: string;
-  expiresAt: number;
-};

--- a/web/src/components/layout/UserMenu.tsx
+++ b/web/src/components/layout/UserMenu.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { useMemo, useState, type MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { apiClient, authHeaders } from '../../shared/api/client';
 import { useAuth } from '../../shared/auth/AuthContext';
 import { useI18n } from '../../shared/i18n/I18nContext';
 import { AppIcons } from '../../shared/ui/AppIcons';
@@ -45,7 +46,7 @@ function toInitials(displayName: string) {
 }
 
 export function UserMenu() {
-  const { user, clearAuth } = useAuth();
+  const { user, accessToken, clearAuth } = useAuth();
   const { t } = useI18n();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -70,8 +71,15 @@ export function UserMenu() {
     navigate('/settings');
   };
 
-  const logout = () => {
+  const logout = async () => {
     closeMenu();
+    try {
+      await apiClient.post('/api/auth/logout', {}, {
+        headers: accessToken ? authHeaders(accessToken) : undefined
+      });
+    } catch {
+      // Если logout API недоступен, локально все равно завершаем сессию.
+    }
     clearAuth();
     navigate('/login');
   };

--- a/web/src/shared/api/client.ts
+++ b/web/src/shared/api/client.ts
@@ -17,6 +17,12 @@ export const apiClient = axios.create({
   withCredentials: true
 });
 
+let unauthorizedHandler: (() => void) | null = null;
+
+export function setUnauthorizedHandler(handler: (() => void) | null) {
+  unauthorizedHandler = handler;
+}
+
 apiClient.interceptors.request.use((config) => {
   const url = config.url ?? '';
   const normalizedBaseUrl = config.baseURL?.replace(/\/+$/, '') ?? '';
@@ -41,6 +47,12 @@ apiClient.interceptors.response.use((response) => {
   }
 
   return response;
+}, (error) => {
+  if (error?.response?.status === 401) {
+    unauthorizedHandler?.();
+  }
+
+  return Promise.reject(error);
 });
 
 export const authHeaders = (accessToken: string) => ({

--- a/web/src/shared/auth/AuthContext.tsx
+++ b/web/src/shared/auth/AuthContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useMemo, useState, type PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import { setUnauthorizedHandler } from '../api/client';
 import type { WebUserRole } from '../types/roles';
 
 type AuthUser = {
@@ -50,6 +51,19 @@ export function AuthProvider({ children }: PropsWithChildren) {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
   };
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      clearAuth();
+      if (window.location.pathname !== '/login') {
+        window.location.assign('/login');
+      }
+    });
+
+    return () => {
+      setUnauthorizedHandler(null);
+    };
+  }, []);
 
   const value = useMemo(() => ({
     accessToken,


### PR DESCRIPTION
### Motivation

- Replace in-memory session storage with a persistent source of truth for web auth sessions to support refresh-rotation and revoke semantics. 
- Provide a backend `logout` operation that removes the current web session and clears the refresh cookie. 
- Ensure the frontend reacts to server-side session invalidation by clearing local auth-state and redirecting users to `/login` on `401 Unauthorized`.

### Description

- Add DB migration `server/src/db/migrations/20260421100000_add_web_user_sessions.ts` to create `web_user_sessions` with `access`/`refresh` session types, `expires_at`, and `revoked_at` columns. 
- Implement `server/src/repositories/webUserSessionRepository.ts` with `createWebUserSession`, `findActiveWebUserSessionByToken`, `revokeWebUserSessionByToken`, and `deleteWebUserSessionByToken`. 
- Replace in-memory session maps with DB-backed logic in `server/src/services/authService.ts`, making `issueSession`, `refreshAccess`, and `resolveUserByAccessToken` operate on `web_user_sessions`, and add `logoutSession` to delete tokens. 
- Add `POST /api/auth/logout` route in `server/src/routes/authRoutes.ts` that revokes/deletes current refresh and access tokens and clears the refresh cookie. 
- Remove the `Session` type and the `accessSessions`/`refreshSessions` maps from `server/src/repositories/inMemoryStore.ts`. 
- Update web client API and auth flow: export `setUnauthorizedHandler` and invoke it on `401` in `web/src/shared/api/client.ts`; set handler in `web/src/shared/auth/AuthContext.tsx` to clear local auth and redirect to `/login`; call backend `POST /api/auth/logout` from `web/src/components/layout/UserMenu.tsx` when logging out. 
- Update documentation files (`README.md`, `PROJECT_MAP.md`, `PRODUCTION_READINESS_CHECKLIST.md`, `TODO.md`) to reflect that web sessions are persisted in `web_user_sessions`, that `POST /api/auth/logout` exists, and that the frontend auto-logs out on `401`.

### Testing

- Ran type checking using `npm run typecheck` which completed successfully. 
- Performed a local build with `npm run build` which succeeded. 
- No unit/integration tests were modified in this change set and no automated server tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e738d875048333a6edb4672213178a)