### PR TITLE
Rename user tables to telegram_users / telegram_user_sessions and add migrations

### DIFF
--- a/bot/src/db/seeds/booking.ts
+++ b/bot/src/db/seeds/booking.ts
@@ -12,7 +12,7 @@ export async function seed(knex: Knex): Promise<void> {
 
   const accountId = account.id;
 
-  await knex('user_sessions').del();
+  await knex('telegram_user_sessions').del();
   await knex('appointments').del();
   await knex('services').del();
   await knex('specialists').del();

--- a/bot/src/repositories/tests/user-session.repository.test.ts
+++ b/bot/src/repositories/tests/user-session.repository.test.ts
@@ -33,7 +33,7 @@ function createDbMock(initialSession: SessionRow | null) {
   };
 
   const db: any = ((table: string) => {
-    expect(table).toBe('user_sessions');
+    expect(table).toBe('telegram_user_sessions');
     return qb;
   }) as any;
 

--- a/bot/src/repositories/user-session.repository.ts
+++ b/bot/src/repositories/user-session.repository.ts
@@ -2,11 +2,11 @@ import { db } from '../db/knex';
 import { BookingPayload, UserSessionState } from '../types/session';
 
 export async function findSessionByUserId(accountId: number, userId: number) {
-  return db('user_sessions').where({ account_id: accountId, user_id: userId }).first();
+  return db('telegram_user_sessions').where({ account_id: accountId, user_id: userId }).first();
 }
 
 export async function createSession(accountId: number, userId: number) {
-  const [session] = await db('user_sessions')
+  const [session] = await db('telegram_user_sessions')
     .insert({
       account_id: accountId,
       user_id: userId,
@@ -39,7 +39,7 @@ export async function updateSessionState(
     updateData.payload_json = JSON.stringify(payload);
   }
 
-  const [session] = await db('user_sessions')
+  const [session] = await db('telegram_user_sessions')
     .where({ account_id: accountId, user_id: userId })
     .update(updateData, ['*']);
 
@@ -64,7 +64,7 @@ export async function mergeSessionPayload(
     ...patch,
   };
 
-  const [updated] = await db('user_sessions')
+  const [updated] = await db('telegram_user_sessions')
     .where({ account_id: accountId, user_id: userId })
     .update(
       {

--- a/bot/src/repositories/user.repository.ts
+++ b/bot/src/repositories/user.repository.ts
@@ -12,11 +12,11 @@ export type CreateUserInput = {
 };
 
 export async function findUserByTelegramId(accountId: number, telegramId: number) {
-  return db("users").where({ account_id: accountId, telegram_id: telegramId }).first();
+  return db("telegram_users").where({ account_id: accountId, telegram_id: telegramId }).first();
 }
 
 export async function createUser(input: CreateUserInput) {
-  const [user] = await db("users")
+  const [user] = await db("telegram_users")
     .insert({
       account_id: input.accountId,
       telegram_id: input.telegramId,
@@ -50,7 +50,7 @@ export async function updateUserByTelegramId(
     updateData.language_code = patch.languageCode;
   }
 
-  const [user] = await db("users")
+  const [user] = await db("telegram_users")
     .where({ account_id: accountId, telegram_id: telegramId })
     .update(updateData, ["*"]);
 

--- a/server/src/db/migrations/20260421130000_rename_telegram_tables.ts
+++ b/server/src/db/migrations/20260421130000_rename_telegram_tables.ts
@@ -1,0 +1,36 @@
+import type { Knex } from 'knex';
+
+const TELEGRAM_USERS_TABLE = 'telegram_users';
+const TELEGRAM_USER_SESSION_TABLE = 'telegram_user_sessions';
+
+async function renameUsersTable(knex: Knex, from: string, to: string): Promise<void> {
+  const hasFrom = await knex.schema.hasTable(from);
+  const hasTo = await knex.schema.hasTable(to);
+
+  if (hasFrom && !hasTo) {
+    await knex.schema.renameTable(from, to);
+  }
+}
+
+async function renameUserSessionTable(knex: Knex, from: string, to: string): Promise<void> {
+  const hasFrom = await knex.schema.hasTable(from);
+  const hasTo = await knex.schema.hasTable(to);
+
+  if (hasFrom && !hasTo) {
+    await knex.schema.renameTable(from, to);
+  }
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await renameUsersTable(knex, 'users', TELEGRAM_USERS_TABLE);
+
+  if (!(await knex.schema.hasTable(TELEGRAM_USER_SESSION_TABLE))) {
+    await renameUserSessionTable(knex, 'user_sessions', TELEGRAM_USER_SESSION_TABLE);
+    await renameUserSessionTable(knex, 'users_session', TELEGRAM_USER_SESSION_TABLE);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await renameUsersTable(knex, TELEGRAM_USERS_TABLE, 'users');
+  await renameUserSessionTable(knex, TELEGRAM_USER_SESSION_TABLE, 'user_sessions');
+}

--- a/server/src/db/migrations/20260421133000_rename_telegram_user_session_to_plural.ts
+++ b/server/src/db/migrations/20260421133000_rename_telegram_user_session_to_plural.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex';
+
+const SINGULAR_TABLE = 'telegram_user_session';
+const PLURAL_TABLE = 'telegram_user_sessions';
+
+async function renameTableIfNeeded(knex: Knex, from: string, to: string): Promise<void> {
+  const hasFrom = await knex.schema.hasTable(from);
+  const hasTo = await knex.schema.hasTable(to);
+
+  if (hasFrom && !hasTo) {
+    await knex.schema.renameTable(from, to);
+  }
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await renameTableIfNeeded(knex, SINGULAR_TABLE, PLURAL_TABLE);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await renameTableIfNeeded(knex, PLURAL_TABLE, SINGULAR_TABLE);
+}

--- a/server/src/repositories/userIdentityLinkRepository.ts
+++ b/server/src/repositories/userIdentityLinkRepository.ts
@@ -10,7 +10,7 @@ export async function findTelegramUserByEmail(
   accountId: number,
   email: string,
 ): Promise<TelegramUserRow | null> {
-  const row = await db('users')
+  const row = await db('telegram_users')
     .where({ account_id: accountId, email })
     .first<TelegramUserRow>();
 


### PR DESCRIPTION
### Motivation

- Standardize database table names for Telegram-related entities by switching from generic `users`/`user_sessions` to explicit `telegram_users`/`telegram_user_sessions` to avoid ambiguity and support separate user identity domains.

### Description

- Updated repository code to use `telegram_users` and `telegram_user_sessions` instead of `users` and `user_sessions` across user and session repositories and seed logic.
- Adjusted unit test DB mock in `user-session.repository.test.ts` to expect `telegram_user_sessions` table access.
- Added two DB migrations: `20260421130000_rename_telegram_tables.ts` to rename existing `users`/`user_sessions` (and `users_session`) to telegram-specific tables with existence checks, and `20260421133000_rename_telegram_user_session_to_plural.ts` to convert a singular `telegram_user_session` table to the plural `telegram_user_sessions` if present.
- Preserved existing behavior when tables already have the target names by checking `knex.schema.hasTable` before renaming.

### Testing

- Updated unit tests for repository code and ran the automated test suite, and all tests passed.
- Performed migrations locally (renames guarded by existence checks) to verify they run without errors in both directions (up and down).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e749d603588333984e387ec6808f9f)