### PR TITLE
Add Appointments MVP: server endpoints, repository, service and web calendar UI

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -7,8 +7,9 @@
   - `server/src/index.ts` — bootstrap.
   - `server/src/app.ts` — инициализация Express middleware/роутов.
   - `server/src/config/*` — env + схемы валидации.
-  - `server/src/routes/*` — auth/settings/integrations/health endpoints.
-  - `server/src/services/*` — бизнес-логика auth/settings.
+  - `server/src/routes/*` — auth/settings/integrations/appointments/health endpoints.
+  - `server/src/services/*` — бизнес-логика auth/settings/appointments.
+  - `server/src/repositories/appointmentRepository.ts` — доступ к appointments для web-сценариев.
   - `server/src/middlewares/*` — auth + login lock middleware.
   - `server/src/repositories/inMemoryStore.ts` — in-memory состояние (MVP).
 
@@ -36,6 +37,7 @@
   - `web/src/shared/api/client.ts` — глобальный `401` handler: при `Unauthorized` очищает auth-state и переводит пользователя на `/login`.
   - `web/src/shared/i18n/*` — словари переводов (`ru/en`) и i18n-контекст приложения.
   - До логина показываются только auth-страницы (`/login`, `/register`) без header/left menu; после регистрации маршрут ведёт на `/login`.
+  - Добавлена страница `web/src/pages/AppointmentsPage.tsx` и контейнер `web/src/containers/AppointmentsContainer.tsx` для календаря appointments.
 
 ## API карта (MVP)
 
@@ -49,6 +51,11 @@
 - `PUT /api/settings`
 - `POST /api/integrations/google/oauth/start`
 - `GET /api/integrations/google/oauth/callback`
+- `GET /api/appointments`
+- `POST /api/appointments`
+- `PATCH /api/appointments/:id`
+- `POST /api/appointments/:id/cancel`
+- `POST /api/appointments/:id/reschedule`
 
 ## API карта (следующий инкремент — appointments)
 
@@ -61,9 +68,9 @@
 - `POST /api/appointments/:id/mark-paid` — подтвердить оплату.
 - `POST /api/appointments/:id/notify` — ручное уведомление.
 
-### Текущий MVP scope (что делаем прямо сейчас)
+### Текущий MVP scope (статус)
 
-- В первом слайсе реализуем только:
+- Реализовано в первом слайсе:
   - `GET /api/appointments`
   - `POST /api/appointments`
   - `PATCH /api/appointments/:id`
@@ -73,6 +80,7 @@
   - `mark-paid`
   - `notify`
   - расширенные фильтры и аудит-лог.
+  - drag&drop в календаре.
 
 ## Стратегия meeting link
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ scheduletm/
 - После этого — только 2 действия: `cancel` и `reschedule`, остальные операции позже.
 - Критерий готовности: сценарий “создать запись → перенести → отменить” проходит целиком в web и server.
 
+### Appointments MVP: что уже сделано
+
+- Server: добавлены endpoint'ы `GET /api/appointments`, `POST /api/appointments`, `PATCH /api/appointments/:id`, `POST /api/appointments/:id/cancel`, `POST /api/appointments/:id/reschedule`.
+- В server добавлена базовая role-aware фильтрация:
+  - `owner/admin` видят записи всех специалистов внутри своего `account_id`;
+  - `specialist` видит только свои записи.
+- Во все выборки appointments добавлена привязка к `account_id` как базовое правило изоляции данных.
+- Web: добавлена страница `/appointments`:
+  - календарный месяц с переключением месяцев;
+  - список записей выбранного дня;
+  - создание/редактирование записи в popup;
+  - действия `cancel` и `reschedule` через popup.
+- Для `owner/admin` добавлен фильтр по специалистам сверху страницы appointments.
+
+### Appointments MVP: что оставили на следующий инкремент
+
+- Drag & Drop перенос записи по календарю.
+- Детализированный тайм-грид в стиле Teams (с насыщенной визуализацией слотов по часам).
+- Расширенные фильтры календаря и групповые операции.
+
 ## Решение по ссылке на встречу
 
 Рекомендуемая стратегия:
@@ -180,4 +200,3 @@ npm run -w @scheduletm/web dev
 
 Для дополнительной информации смотри PRODUCTION_READINESS_CHECKLIST.md, README.md, TODO.md, PROJECT_MAP.md
 После доработки не зыбудь обновить документации.
-

--- a/TODO.md
+++ b/TODO.md
@@ -24,10 +24,12 @@
 
 ### 4.0 Текущий приоритет (этот шаг)
 
-- [ ] Сделать Appointments MVP Slice end-to-end: `list + create + edit` (server + web).
-- [ ] Ограничить первую версию полями: `scheduledAt`, `status`, `meetingLink`, `notes`.
-- [ ] Добавить только два action endpoint: `cancel`, `reschedule`.
+- [x] Сделать Appointments MVP Slice end-to-end: `list + create + edit` (server + web).
+- [x] Ограничить первую версию полями: `scheduledAt`, `status`, `meetingLink`, `notes`.
+- [x] Добавить только два action endpoint: `cancel`, `reschedule`.
 - [ ] Добавить 3 интеграционных smoke-сценария: create, reschedule, cancel.
+- [ ] Добавить drag&drop перенос записи в календаре (web).
+- [ ] Доработать календарный UI до full time-grid вида (уровень Teams-like).
 
 ### 4.1 Data layer
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import { env } from './config/env.js';
 import { authRoutes } from './routes/authRoutes.js';
 import { healthRoutes } from './routes/healthRoutes.js';
 import { integrationRoutes } from './routes/integrationRoutes.js';
+import { appointmentRoutes } from './routes/appointmentRoutes.js';
 import { settingsRoutes } from './routes/settingsRoutes.js';
 
 export const createApp = () => {
@@ -33,6 +34,7 @@ export const createApp = () => {
   app.use(healthRoutes);
   app.use('/api/auth', authRoutes);
   app.use('/api/settings', settingsRoutes);
+  app.use('/api/appointments', appointmentRoutes);
   app.use('/api/integrations', integrationRoutes);
 
   app.use((_req, res) => {

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -49,3 +49,26 @@ export const specialistUserCreationSchema = z.object({
     .min(2, 'Имя специалиста должно содержать минимум 2 символа')
     .max(120, 'Имя специалиста слишком длинное')
 });
+
+const appointmentStatusSchema = z.enum(['new', 'confirmed', 'cancelled']);
+
+export const appointmentCreateSchema = z.object({
+  specialistId: z.coerce.number().int().positive('Укажите специалиста'),
+  scheduledAt: z.string().datetime('Укажите корректную дату и время'),
+  status: appointmentStatusSchema.optional(),
+  meetingLink: z.string().trim().url('Укажите корректную ссылку').max(2048).optional().or(z.literal('')),
+  notes: z.string().trim().max(2000, 'Комментарий слишком длинный').optional(),
+});
+
+export const appointmentUpdateSchema = z.object({
+  scheduledAt: z.string().datetime('Укажите корректную дату и время').optional(),
+  status: appointmentStatusSchema.optional(),
+  meetingLink: z.string().trim().url('Укажите корректную ссылку').max(2048).optional().or(z.literal('')),
+  notes: z.string().trim().max(2000, 'Комментарий слишком длинный').optional(),
+}).refine((value) => Object.keys(value).length > 0, {
+  message: 'Передайте хотя бы одно поле для обновления',
+});
+
+export const appointmentRescheduleSchema = z.object({
+  scheduledAt: z.string().datetime('Укажите корректную дату и время'),
+});

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -1,0 +1,166 @@
+import { db } from '../db/knex.js';
+
+export type AppointmentStatus = 'new' | 'confirmed' | 'cancelled';
+
+export type AppointmentRecord = {
+  id: number;
+  account_id: number;
+  specialist_id: number;
+  appointment_at: Date;
+  status: AppointmentStatus;
+  comment: string | null;
+  duration_min: number;
+  user_id: number;
+  service_id: number;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type AppointmentListFilters = {
+  accountId: number;
+  from?: Date;
+  to?: Date;
+  specialistId?: number;
+};
+
+type CreateAppointmentInput = {
+  accountId: number;
+  specialistId: number;
+  scheduledAt: Date;
+  status: AppointmentStatus;
+  notes: string | null;
+  userId: number;
+  serviceId: number;
+  durationMin: number;
+};
+
+type UpdateAppointmentInput = {
+  accountId: number;
+  id: number;
+  scheduledAt?: Date;
+  status?: AppointmentStatus;
+  notes?: string | null;
+};
+
+export async function listAppointments(filters: AppointmentListFilters): Promise<AppointmentRecord[]> {
+  const query = db('appointments')
+    .where({ account_id: filters.accountId })
+    .orderBy('appointment_at', 'asc');
+
+  if (filters.specialistId) {
+    query.andWhere('specialist_id', filters.specialistId);
+  }
+
+  if (filters.from) {
+    query.andWhere('appointment_at', '>=', filters.from);
+  }
+
+  if (filters.to) {
+    query.andWhere('appointment_at', '<=', filters.to);
+  }
+
+  return query.select<AppointmentRecord[]>('*');
+}
+
+export async function findAppointmentById(accountId: number, id: number): Promise<AppointmentRecord | null> {
+  const row = await db('appointments')
+    .where({ account_id: accountId, id })
+    .first<AppointmentRecord>();
+
+  return row ?? null;
+}
+
+export async function createAppointment(input: CreateAppointmentInput): Promise<AppointmentRecord> {
+  const [row] = await db('appointments')
+    .insert({
+      account_id: input.accountId,
+      specialist_id: input.specialistId,
+      appointment_at: input.scheduledAt,
+      status: input.status,
+      comment: input.notes,
+      user_id: input.userId,
+      service_id: input.serviceId,
+      duration_min: input.durationMin,
+      is_first_time: false,
+      price: 0,
+      currency: 'RUB',
+      is_paid: false,
+    })
+    .returning<AppointmentRecord[]>('*');
+
+  return row;
+}
+
+export async function updateAppointment(input: UpdateAppointmentInput): Promise<AppointmentRecord | null> {
+  const payload: Record<string, unknown> = {
+    updated_at: db.fn.now(),
+  };
+
+  if (input.scheduledAt) {
+    payload.appointment_at = input.scheduledAt;
+  }
+
+  if (input.status) {
+    payload.status = input.status;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'notes')) {
+    payload.comment = input.notes;
+  }
+
+  const [row] = await db('appointments')
+    .where({ account_id: input.accountId, id: input.id })
+    .update(payload)
+    .returning<AppointmentRecord[]>('*');
+
+  return row ?? null;
+}
+
+export async function ensureFallbackClientForAccount(accountId: number): Promise<number> {
+  const existing = await db('clients')
+    .where({ account_id: accountId })
+    .orderBy('id', 'asc')
+    .first<{ id: number }>('id');
+
+  if (existing) {
+    return existing.id;
+  }
+
+  const [created] = await db('clients')
+    .insert({
+      account_id: accountId,
+      first_name: 'Web',
+      email: `web-client-${accountId}@local.meetli`,
+    })
+    .returning<{ id: number }[]>('id');
+
+  return created.id;
+}
+
+export async function ensureFallbackServiceForAccount(accountId: number): Promise<number> {
+  const existing = await db('services')
+    .where({ account_id: accountId })
+    .orderBy('id', 'asc')
+    .first<{ id: number }>('id');
+
+  if (existing) {
+    return existing.id;
+  }
+
+  const [created] = await db('services')
+    .insert({
+      account_id: accountId,
+      code: `web-service-${accountId}`,
+      name_ru: 'Встреча',
+      name_en: 'Meeting',
+      price: 0,
+      currency: 'RUB',
+      duration_min: 60,
+      sessions_count: 1,
+      is_first_free: false,
+      is_active: true,
+    })
+    .returning<{ id: number }[]>('id');
+
+  return created.id;
+}

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -46,3 +46,34 @@ export async function createSpecialistForWebUser(input: CreateSpecialistInput): 
 
   return row.id;
 }
+
+export type SpecialistRecord = {
+  id: number;
+  account_id: number;
+  code: string;
+  name: string;
+  is_active: boolean;
+  user_id: number | null;
+};
+
+export async function findSpecialistById(accountId: number, specialistId: number): Promise<SpecialistRecord | null> {
+  const row = await db('specialists')
+    .where({ account_id: accountId, id: specialistId })
+    .first<SpecialistRecord>();
+
+  return row ?? null;
+}
+
+export async function listSpecialistsByAccount(accountId: number): Promise<SpecialistRecord[]> {
+  return db('specialists')
+    .where({ account_id: accountId })
+    .orderBy('name', 'asc');
+}
+
+export async function findSpecialistByWebUserId(accountId: number, webUserId: number): Promise<SpecialistRecord | null> {
+  const row = await db('specialists')
+    .where({ account_id: accountId, user_id: webUserId })
+    .first<SpecialistRecord>();
+
+  return row ?? null;
+}

--- a/server/src/routes/appointmentRoutes.ts
+++ b/server/src/routes/appointmentRoutes.ts
@@ -1,0 +1,155 @@
+import { Router } from 'express';
+import {
+  appointmentCreateSchema,
+  appointmentRescheduleSchema,
+  appointmentUpdateSchema,
+} from '../config/schemas.js';
+import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
+import {
+  cancelAppointmentForActor,
+  createAppointmentForActor,
+  getAppointments,
+  rescheduleAppointmentForActor,
+  updateAppointmentForActor,
+} from '../services/appointmentService.js';
+import { formatZodError } from '../utils/validation.js';
+
+export const appointmentRoutes = Router();
+
+appointmentRoutes.use(requireAccessToken);
+
+appointmentRoutes.get('/', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+
+  try {
+    const specialistId = typeof req.query.specialistId === 'string'
+      ? Number(req.query.specialistId)
+      : undefined;
+
+    const data = await getAppointments(actor, {
+      specialistId: Number.isFinite(specialistId) ? specialistId : undefined,
+      from: typeof req.query.from === 'string' ? req.query.from : undefined,
+      to: typeof req.query.to === 'string' ? req.query.to : undefined,
+    });
+
+    return res.json(data);
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: 'Не удалось загрузить записи' });
+  }
+});
+
+appointmentRoutes.post('/', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const parsed = appointmentCreateSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json(formatZodError(parsed.error));
+  }
+
+  try {
+    const created = await createAppointmentForActor(actor, parsed.data);
+    return res.status(201).json(created);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+
+    if (message === 'FORBIDDEN_SPECIALIST') {
+      return res.status(403).json({ message: 'Недостаточно прав для этого специалиста' });
+    }
+
+    if (message === 'SPECIALIST_NOT_FOUND') {
+      return res.status(404).json({ message: 'Специалист не найден' });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: 'Не удалось создать запись' });
+  }
+});
+
+appointmentRoutes.patch('/:id', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const appointmentId = Number(req.params.id);
+
+  if (!Number.isInteger(appointmentId) || appointmentId <= 0) {
+    return res.status(400).json({ message: 'Некорректный id записи' });
+  }
+
+  const parsed = appointmentUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(formatZodError(parsed.error));
+  }
+
+  try {
+    const updated = await updateAppointmentForActor(actor, appointmentId, parsed.data);
+    if (!updated) {
+      return res.status(404).json({ message: 'Запись не найдена' });
+    }
+
+    return res.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+    if (message === 'FORBIDDEN_SPECIALIST') {
+      return res.status(403).json({ message: 'Недостаточно прав для этой записи' });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: 'Не удалось обновить запись' });
+  }
+});
+
+appointmentRoutes.post('/:id/cancel', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const appointmentId = Number(req.params.id);
+
+  if (!Number.isInteger(appointmentId) || appointmentId <= 0) {
+    return res.status(400).json({ message: 'Некорректный id записи' });
+  }
+
+  try {
+    const updated = await cancelAppointmentForActor(actor, appointmentId);
+    if (!updated) {
+      return res.status(404).json({ message: 'Запись не найдена' });
+    }
+
+    return res.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+    if (message === 'FORBIDDEN_SPECIALIST') {
+      return res.status(403).json({ message: 'Недостаточно прав для этой записи' });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: 'Не удалось отменить запись' });
+  }
+});
+
+appointmentRoutes.post('/:id/reschedule', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const appointmentId = Number(req.params.id);
+
+  if (!Number.isInteger(appointmentId) || appointmentId <= 0) {
+    return res.status(400).json({ message: 'Некорректный id записи' });
+  }
+
+  const parsed = appointmentRescheduleSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(formatZodError(parsed.error));
+  }
+
+  try {
+    const updated = await rescheduleAppointmentForActor(actor, appointmentId, parsed.data.scheduledAt);
+    if (!updated) {
+      return res.status(404).json({ message: 'Запись не найдена' });
+    }
+
+    return res.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+    if (message === 'FORBIDDEN_SPECIALIST') {
+      return res.status(403).json({ message: 'Недостаточно прав для этой записи' });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: 'Не удалось перенести запись' });
+  }
+});

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -1,0 +1,232 @@
+import { getDefaultAccountId } from '../repositories/accountRepository.js';
+import {
+  type AppointmentRecord,
+  type AppointmentStatus,
+  createAppointment,
+  ensureFallbackClientForAccount,
+  ensureFallbackServiceForAccount,
+  findAppointmentById,
+  listAppointments,
+  updateAppointment,
+} from '../repositories/appointmentRepository.js';
+import {
+  findSpecialistById,
+  findSpecialistByWebUserId,
+  listSpecialistsByAccount,
+  type SpecialistRecord,
+} from '../repositories/specialistRepository.js';
+import type { User } from '../types/domain.js';
+import { WebUserRole } from '../types/webUserRole.js';
+
+type AppointmentDto = {
+  id: number;
+  specialistId: number;
+  scheduledAt: string;
+  status: AppointmentStatus;
+  meetingLink: string;
+  notes: string;
+};
+
+type AppointmentListResult = {
+  appointments: AppointmentDto[];
+  specialists: Array<{ id: number; name: string }>;
+};
+
+type CreateAppointmentPayload = {
+  specialistId: number;
+  scheduledAt: string;
+  status?: AppointmentStatus;
+  meetingLink?: string;
+  notes?: string;
+};
+
+type UpdateAppointmentPayload = {
+  scheduledAt?: string;
+  status?: AppointmentStatus;
+  meetingLink?: string;
+  notes?: string;
+};
+
+function canManageAllAppointments(role: WebUserRole): boolean {
+  return role === WebUserRole.Owner || role === WebUserRole.Admin;
+}
+
+function parseMeetingLinkFromNotes(notes: string | null): { notes: string; meetingLink: string } {
+  if (!notes) {
+    return { notes: '', meetingLink: '' };
+  }
+
+  const [firstLine, ...restLines] = notes.split('\n');
+  const prefix = 'meetingLink: ';
+
+  if (!firstLine.startsWith(prefix)) {
+    return { notes, meetingLink: '' };
+  }
+
+  return {
+    meetingLink: firstLine.slice(prefix.length).trim(),
+    notes: restLines.join('\n').trim(),
+  };
+}
+
+function composeNotes(meetingLink: string | undefined, notes: string | undefined): string | null {
+  const normalizedMeetingLink = meetingLink?.trim() ?? '';
+  const normalizedNotes = notes?.trim() ?? '';
+
+  if (!normalizedMeetingLink && !normalizedNotes) {
+    return null;
+  }
+
+  if (!normalizedMeetingLink) {
+    return normalizedNotes;
+  }
+
+  return [`meetingLink: ${normalizedMeetingLink}`, normalizedNotes].filter(Boolean).join('\n');
+}
+
+function mapAppointment(row: AppointmentRecord): AppointmentDto {
+  const parsed = parseMeetingLinkFromNotes(row.comment);
+
+  return {
+    id: row.id,
+    specialistId: row.specialist_id,
+    scheduledAt: row.appointment_at.toISOString(),
+    status: row.status,
+    notes: parsed.notes,
+    meetingLink: parsed.meetingLink,
+  };
+}
+
+async function resolveAccountId(actor: User): Promise<number> {
+  if (actor.accountId) {
+    return actor.accountId;
+  }
+
+  return getDefaultAccountId();
+}
+
+async function resolveAllowedSpecialistId(actor: User, accountId: number): Promise<number | null> {
+  if (canManageAllAppointments(actor.role)) {
+    return null;
+  }
+
+  const specialist = await findSpecialistByWebUserId(accountId, Number(actor.id));
+  if (!specialist) {
+    throw new Error('SPECIALIST_PROFILE_NOT_FOUND');
+  }
+
+  return specialist.id;
+}
+
+function mapSpecialistsForUi(rows: SpecialistRecord[]) {
+  return rows.map((item) => ({ id: item.id, name: item.name }));
+}
+
+export async function getAppointments(
+  actor: User,
+  filters: { from?: string; to?: string; specialistId?: number },
+): Promise<AppointmentListResult> {
+  const accountId = await resolveAccountId(actor);
+  const allowedSpecialistId = await resolveAllowedSpecialistId(actor, accountId);
+
+  const specialistId = allowedSpecialistId ?? filters.specialistId;
+
+  const items = await listAppointments({
+    accountId,
+    specialistId,
+    from: filters.from ? new Date(filters.from) : undefined,
+    to: filters.to ? new Date(filters.to) : undefined,
+  });
+
+  const specialists = canManageAllAppointments(actor.role)
+    ? mapSpecialistsForUi(await listSpecialistsByAccount(accountId))
+    : mapSpecialistsForUi(
+        (await listSpecialistsByAccount(accountId)).filter((item) => item.user_id === Number(actor.id)),
+      );
+
+  return {
+    appointments: items.map(mapAppointment),
+    specialists,
+  };
+}
+
+export async function createAppointmentForActor(
+  actor: User,
+  payload: CreateAppointmentPayload,
+): Promise<AppointmentDto> {
+  const accountId = await resolveAccountId(actor);
+
+  if (!canManageAllAppointments(actor.role)) {
+    const selfSpecialist = await findSpecialistByWebUserId(accountId, Number(actor.id));
+    if (!selfSpecialist || selfSpecialist.id !== payload.specialistId) {
+      throw new Error('FORBIDDEN_SPECIALIST');
+    }
+  }
+
+  const specialist = await findSpecialistById(accountId, payload.specialistId);
+  if (!specialist) {
+    throw new Error('SPECIALIST_NOT_FOUND');
+  }
+
+  const [userId, serviceId] = await Promise.all([
+    ensureFallbackClientForAccount(accountId),
+    ensureFallbackServiceForAccount(accountId),
+  ]);
+
+  const created = await createAppointment({
+    accountId,
+    specialistId: payload.specialistId,
+    scheduledAt: new Date(payload.scheduledAt),
+    status: payload.status ?? 'new',
+    notes: composeNotes(payload.meetingLink, payload.notes),
+    userId,
+    serviceId,
+    durationMin: 60,
+  });
+
+  return mapAppointment(created);
+}
+
+export async function updateAppointmentForActor(
+  actor: User,
+  appointmentId: number,
+  payload: UpdateAppointmentPayload,
+): Promise<AppointmentDto | null> {
+  const accountId = await resolveAccountId(actor);
+  const existing = await findAppointmentById(accountId, appointmentId);
+
+  if (!existing) {
+    return null;
+  }
+
+  if (!canManageAllAppointments(actor.role)) {
+    const selfSpecialist = await findSpecialistByWebUserId(accountId, Number(actor.id));
+    if (!selfSpecialist || selfSpecialist.id !== existing.specialist_id) {
+      throw new Error('FORBIDDEN_SPECIALIST');
+    }
+  }
+
+  const updated = await updateAppointment({
+    accountId,
+    id: appointmentId,
+    scheduledAt: payload.scheduledAt ? new Date(payload.scheduledAt) : undefined,
+    status: payload.status,
+    notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink')
+      ? composeNotes(payload.meetingLink, payload.notes)
+      : undefined,
+  });
+
+  return updated ? mapAppointment(updated) : null;
+}
+
+export async function cancelAppointmentForActor(actor: User, appointmentId: number): Promise<AppointmentDto | null> {
+  return updateAppointmentForActor(actor, appointmentId, { status: 'cancelled' });
+}
+
+export async function rescheduleAppointmentForActor(
+  actor: User,
+  appointmentId: number,
+  scheduledAt: string,
+): Promise<AppointmentDto | null> {
+  return updateAppointmentForActor(actor, appointmentId, { scheduledAt });
+}

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -77,6 +77,7 @@ export const issueSession = async (userId: string, res: Response) => {
 
 const mapWebUserToDomain = (
   id: number,
+  accountId: number,
   email: string,
   role: WebUserRole,
   passwordSalt: string,
@@ -85,6 +86,7 @@ const mapWebUserToDomain = (
 ): User => {
   return {
     id: String(id),
+    accountId,
     email,
     role,
     passwordSalt,
@@ -116,6 +118,7 @@ export const registerUser = async (emailRaw: string, password: string): Promise<
 
   return mapWebUserToDomain(
     webUser.id,
+    webUser.account_id,
     webUser.email,
     webUser.role,
     webUser.password_salt,
@@ -168,6 +171,7 @@ export const createSpecialistUser = async (
 
   const user = mapWebUserToDomain(
     webUser.id,
+    webUser.account_id,
     webUser.email,
     webUser.role,
     webUser.password_salt,
@@ -192,7 +196,15 @@ export const authenticateUser = async (emailRaw: string, password: string): Prom
   }
 
   await touchWebUserLastLogin(accountId, user.id);
-  return mapWebUserToDomain(user.id, user.email, user.role, user.password_salt, user.password_hash, user.created_at);
+  return mapWebUserToDomain(
+    user.id,
+    user.account_id,
+    user.email,
+    user.role,
+    user.password_salt,
+    user.password_hash,
+    user.created_at
+  );
 };
 
 export const refreshAccess = async (refreshToken: string) => {
@@ -218,7 +230,15 @@ export const resolveUserByAccessToken = async (token: string): Promise<User | nu
     return null;
   }
 
-  return mapWebUserToDomain(user.id, user.email, user.role, user.password_salt, user.password_hash, user.created_at);
+  return mapWebUserToDomain(
+    user.id,
+    user.account_id,
+    user.email,
+    user.role,
+    user.password_salt,
+    user.password_hash,
+    user.created_at
+  );
 };
 
 export const logoutSession = async (refreshToken?: string, accessToken?: string) => {

--- a/server/src/types/domain.ts
+++ b/server/src/types/domain.ts
@@ -2,6 +2,7 @@ import type { WebUserRole } from './webUserRole.js';
 
 export type User = {
   id: string;
+  accountId: number;
   email: string;
   role: WebUserRole;
   passwordHash: string;

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import { MainLayout } from '../components/layout/MainLayout';
 import { LoginPage } from '../pages/LoginPage';
 import { RegisterPage } from '../pages/RegisterPage';
+import { AppointmentsPage } from '../pages/AppointmentsPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { useAuth } from '../shared/auth/AuthContext';
 
@@ -13,7 +14,7 @@ function ProtectedRoute({ children }: { children: ReactElement }) {
 
 function PublicOnlyRoute({ children }: { children: ReactElement }) {
   const { isAuthenticated } = useAuth();
-  return isAuthenticated ? <Navigate to="/settings" replace /> : children;
+  return isAuthenticated ? <Navigate to="/appointments" replace /> : children;
 }
 
 export const router = createBrowserRouter([
@@ -36,6 +37,14 @@ export const router = createBrowserRouter([
           <PublicOnlyRoute>
             <RegisterPage />
           </PublicOnlyRoute>
+        )
+      },
+      {
+        path: '/appointments',
+        element: (
+          <ProtectedRoute>
+            <AppointmentsPage />
+          </ProtectedRoute>
         )
       },
       {

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -45,7 +45,10 @@ export function MainLayout() {
     void sync();
   }, [accessToken, isAuthenticated, locale, mode, paletteVariantId]);
 
-  const menuItems = [{ to: '/settings', label: t('common.settings'), icon: 'settings' as const }];
+  const menuItems = [
+    { to: '/appointments', label: t('common.appointments'), icon: 'calendar' as const },
+    { to: '/settings', label: t('common.settings'), icon: 'settings' as const }
+  ];
 
   if (!isAuthenticated) {
     return (

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -1,0 +1,370 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { apiClient, authHeaders } from '../shared/api/client';
+import { useAuth } from '../shared/auth/AuthContext';
+import { useI18n } from '../shared/i18n/I18nContext';
+import { AppPage } from '../shared/ui/AppPage';
+import type { AppointmentItem, AppointmentListResponse, AppointmentStatus, SpecialistItem } from '../shared/types/api';
+import { WebUserRole } from '../shared/types/roles';
+
+type EditFormState = {
+  scheduledAt: string;
+  status: AppointmentStatus;
+  meetingLink: string;
+  notes: string;
+};
+
+const STATUS_OPTIONS: AppointmentStatus[] = ['new', 'confirmed', 'cancelled'];
+
+function getMonthMatrix(cursor: Date): Date[] {
+  const firstDay = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth(), 1));
+  const startWeekDay = firstDay.getUTCDay();
+  const gridStart = new Date(firstDay);
+  gridStart.setUTCDate(firstDay.getUTCDate() - startWeekDay);
+
+  return Array.from({ length: 42 }, (_, index) => {
+    const day = new Date(gridStart);
+    day.setUTCDate(gridStart.getUTCDate() + index);
+    return day;
+  });
+}
+
+function toDatetimeLocal(iso: string): string {
+  const date = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+}
+
+function fromDatetimeLocal(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function sameDay(left: Date, right: Date): boolean {
+  return left.getUTCFullYear() === right.getUTCFullYear()
+    && left.getUTCMonth() === right.getUTCMonth()
+    && left.getUTCDate() === right.getUTCDate();
+}
+
+function statusLabel(status: AppointmentStatus): string {
+  if (status === 'confirmed') return 'confirmed';
+  if (status === 'cancelled') return 'cancelled';
+  return 'new';
+}
+
+export function AppointmentsContainer() {
+  const { t } = useI18n();
+  const { accessToken, user } = useAuth();
+  const [appointments, setAppointments] = useState<AppointmentItem[]>([]);
+  const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
+  const [selectedSpecialistId, setSelectedSpecialistId] = useState<number | 'all'>('all');
+  const [monthCursor, setMonthCursor] = useState(() => new Date());
+  const [selectedDay, setSelectedDay] = useState(() => new Date());
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<AppointmentItem | null>(null);
+  const [form, setForm] = useState<EditFormState>({
+    scheduledAt: toDatetimeLocal(new Date().toISOString()),
+    status: 'new',
+    meetingLink: '',
+    notes: '',
+  });
+
+  const monthDays = useMemo(() => getMonthMatrix(monthCursor), [monthCursor]);
+
+  const appointmentsForSelectedDay = useMemo(() => {
+    return appointments
+      .filter((item) => sameDay(new Date(item.scheduledAt), selectedDay))
+      .sort((a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime());
+  }, [appointments, selectedDay]);
+
+  const canManageAll = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin;
+
+  const loadAppointments = async (nextSpecialistId: number | 'all' = selectedSpecialistId) => {
+    if (!accessToken) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await apiClient.get<AppointmentListResponse>('/api/appointments', {
+        headers: authHeaders(accessToken),
+        params: nextSpecialistId === 'all' ? undefined : { specialistId: nextSpecialistId },
+      });
+
+      setAppointments(response.data.appointments);
+      setSpecialists(response.data.specialists);
+      setError('');
+    } catch {
+      setError('Unable to load appointments');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadAppointments();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken]);
+
+  const openCreate = () => {
+    const specialistId = selectedSpecialistId === 'all'
+      ? specialists[0]?.id
+      : selectedSpecialistId;
+
+    if (!specialistId) {
+      setError('Create at least one specialist first');
+      return;
+    }
+
+    setForm({
+      scheduledAt: toDatetimeLocal(new Date(selectedDay).toISOString()),
+      status: 'new',
+      meetingLink: '',
+      notes: '',
+    });
+    setEditingItem(null);
+    setIsCreateOpen(true);
+  };
+
+  const submitForm = async () => {
+    if (!accessToken) {
+      return;
+    }
+
+    const specialistId = selectedSpecialistId === 'all'
+      ? specialists[0]?.id
+      : selectedSpecialistId;
+
+    if (!specialistId) {
+      setError('Specialist is required');
+      return;
+    }
+
+    try {
+      if (editingItem) {
+        await apiClient.patch(`/api/appointments/${editingItem.id}`, {
+          scheduledAt: fromDatetimeLocal(form.scheduledAt),
+          status: form.status,
+          meetingLink: form.meetingLink,
+          notes: form.notes,
+        }, {
+          headers: authHeaders(accessToken),
+        });
+      } else {
+        await apiClient.post('/api/appointments', {
+          specialistId,
+          scheduledAt: fromDatetimeLocal(form.scheduledAt),
+          status: form.status,
+          meetingLink: form.meetingLink,
+          notes: form.notes,
+        }, {
+          headers: authHeaders(accessToken),
+        });
+      }
+
+      setIsCreateOpen(false);
+      await loadAppointments(selectedSpecialistId);
+    } catch {
+      setError('Unable to save appointment');
+    }
+  };
+
+  const openEdit = (item: AppointmentItem) => {
+    setEditingItem(item);
+    setForm({
+      scheduledAt: toDatetimeLocal(item.scheduledAt),
+      status: item.status,
+      meetingLink: item.meetingLink,
+      notes: item.notes,
+    });
+    setIsCreateOpen(true);
+  };
+
+  const cancelAppointment = async () => {
+    if (!editingItem || !accessToken) {
+      return;
+    }
+
+    try {
+      await apiClient.post(`/api/appointments/${editingItem.id}/cancel`, {}, {
+        headers: authHeaders(accessToken),
+      });
+
+      setIsCreateOpen(false);
+      await loadAppointments(selectedSpecialistId);
+    } catch {
+      setError('Unable to cancel appointment');
+    }
+  };
+
+  const onSpecialistChange = async (value: number | 'all') => {
+    setSelectedSpecialistId(value);
+    await loadAppointments(value);
+  };
+
+  return (
+    <AppPage
+      title={t('appointments.pageTitle')}
+      subtitle={t('appointments.pageSubtitle')}
+    >
+      {error && (
+        <Box sx={{ mb: 2, maxWidth: 720 }}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      )}
+
+      <Stack spacing={2}>
+        {canManageAll && (
+          <FormControl sx={{ maxWidth: 360 }} size="small">
+            <InputLabel id="specialist-filter">{t('appointments.specialistFilter')}</InputLabel>
+            <Select
+              labelId="specialist-filter"
+              label={t('appointments.specialistFilter')}
+              value={selectedSpecialistId}
+              onChange={(event) => {
+                const raw = event.target.value;
+                void onSpecialistChange(raw === 'all' ? 'all' : Number(raw));
+              }}
+            >
+              <MenuItem value="all">{t('appointments.allSpecialists')}</MenuItem>
+              {specialists.map((specialist) => (
+                <MenuItem key={specialist.id} value={specialist.id}>{specialist.name}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1.4fr 1fr' }, gap: 2 }}>
+          <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 2, p: 2 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+              <Typography variant="h6">{monthCursor.toLocaleString(undefined, { month: 'long', year: 'numeric' })}</Typography>
+              <Stack direction="row" spacing={1}>
+                <Button size="small" onClick={() => setMonthCursor(new Date(Date.UTC(monthCursor.getUTCFullYear(), monthCursor.getUTCMonth() - 1, 1)))}>{'<'}</Button>
+                <Button size="small" onClick={() => setMonthCursor(new Date(Date.UTC(monthCursor.getUTCFullYear(), monthCursor.getUTCMonth() + 1, 1)))}>{'>'}</Button>
+              </Stack>
+            </Box>
+
+            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, minmax(0, 1fr))', gap: 1 }}>
+              {monthDays.map((day) => {
+                const isCurrentMonth = day.getUTCMonth() === monthCursor.getUTCMonth();
+                const isSelected = sameDay(day, selectedDay);
+                const count = appointments.filter((item) => sameDay(new Date(item.scheduledAt), day)).length;
+
+                return (
+                  <Button
+                    key={day.toISOString()}
+                    variant={isSelected ? 'contained' : 'text'}
+                    color={isCurrentMonth ? 'primary' : 'inherit'}
+                    onClick={() => setSelectedDay(day)}
+                    sx={{ minHeight: 70, flexDirection: 'column', alignItems: 'flex-start', textTransform: 'none' }}
+                  >
+                    <Typography variant="body2">{day.getUTCDate()}</Typography>
+                    {count > 0 && <Typography variant="caption">{count} appt</Typography>}
+                  </Button>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 2, p: 2 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+              <Typography variant="h6">{selectedDay.toLocaleDateString()}</Typography>
+              <Button onClick={openCreate} variant="outlined" size="small">
+                {t('appointments.create')}
+              </Button>
+            </Box>
+
+            {isLoading ? <Typography variant="body2">Loading...</Typography> : null}
+
+            <Stack spacing={1.5}>
+              {appointmentsForSelectedDay.map((item) => (
+                <Box
+                  key={item.id}
+                  sx={{
+                    border: 1,
+                    borderColor: 'divider',
+                    borderRadius: 1.5,
+                    p: 1.5,
+                    cursor: 'pointer',
+                  }}
+                  onClick={() => openEdit(item)}
+                >
+                  <Typography variant="subtitle2">{new Date(item.scheduledAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</Typography>
+                  <Typography variant="body2">{statusLabel(item.status)}</Typography>
+                  {item.notes && <Typography variant="caption" color="text.secondary">{item.notes}</Typography>}
+                </Box>
+              ))}
+              {appointmentsForSelectedDay.length === 0 && (
+                <Typography variant="body2" color="text.secondary">{t('appointments.emptyDay')}</Typography>
+              )}
+            </Stack>
+          </Box>
+        </Box>
+      </Stack>
+
+      <Dialog open={isCreateOpen} onClose={() => setIsCreateOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>{editingItem ? t('appointments.editTitle') : t('appointments.createTitle')}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label={t('appointments.fields.scheduledAt')}
+              type="datetime-local"
+              value={form.scheduledAt}
+              onChange={(event) => setForm((prev) => ({ ...prev, scheduledAt: event.target.value }))}
+              slotProps={{ inputLabel: { shrink: true } }}
+            />
+            <FormControl>
+              <InputLabel id="status-label">{t('appointments.fields.status')}</InputLabel>
+              <Select
+                labelId="status-label"
+                label={t('appointments.fields.status')}
+                value={form.status}
+                onChange={(event) => setForm((prev) => ({ ...prev, status: event.target.value as AppointmentStatus }))}
+              >
+                {STATUS_OPTIONS.map((status) => (
+                  <MenuItem key={status} value={status}>{statusLabel(status)}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label={t('appointments.fields.meetingLink')}
+              value={form.meetingLink}
+              onChange={(event) => setForm((prev) => ({ ...prev, meetingLink: event.target.value }))}
+            />
+            <TextField
+              label={t('appointments.fields.notes')}
+              value={form.notes}
+              onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+              multiline
+              minRows={3}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          {editingItem && (
+            <Button color="error" onClick={cancelAppointment}>{t('appointments.cancelAction')}</Button>
+          )}
+          <Button onClick={() => setIsCreateOpen(false)}>{t('appointments.close')}</Button>
+          <Button variant="contained" onClick={submitForm}>{t('appointments.save')}</Button>
+        </DialogActions>
+      </Dialog>
+    </AppPage>
+  );
+}

--- a/web/src/pages/AppointmentsPage.tsx
+++ b/web/src/pages/AppointmentsPage.tsx
@@ -1,0 +1,5 @@
+import { AppointmentsContainer } from '../containers/AppointmentsContainer';
+
+export function AppointmentsPage() {
+  return <AppointmentsContainer />;
+}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -10,6 +10,7 @@ export const dictionaries = {
       login: 'Login',
       register: 'Register',
       language: 'Language',
+      appointments: 'Appointments',
       profileMenuAria: 'Open profile menu',
       appearancePaletteAria: 'Select color palette',
       themeToggleAria: 'Toggle theme mode',
@@ -55,6 +56,25 @@ export const dictionaries = {
         save: 'Unable to save settings.',
         connectGoogle: 'Unable to connect Google.'
       }
+    },
+    appointments: {
+      pageTitle: 'Appointments',
+      pageSubtitle: 'Calendar view with schedule by day and time.',
+      specialistFilter: 'Specialist',
+      allSpecialists: 'All specialists',
+      create: 'Create',
+      createTitle: 'Create appointment',
+      editTitle: 'Edit appointment',
+      save: 'Save',
+      close: 'Close',
+      emptyDay: 'No appointments on this day.',
+      cancelAction: 'Cancel appointment',
+      fields: {
+        scheduledAt: 'Date and time',
+        status: 'Status',
+        meetingLink: 'Meeting link',
+        notes: 'Notes'
+      }
     }
   },
   ru: {
@@ -68,6 +88,7 @@ export const dictionaries = {
       login: 'Вход',
       register: 'Регистрация',
       language: 'Язык',
+      appointments: 'Записи',
       profileMenuAria: 'Открыть меню профиля',
       appearancePaletteAria: 'Выбрать цветовую палитру',
       themeToggleAria: 'Переключить тему',
@@ -113,6 +134,25 @@ export const dictionaries = {
         save: 'Не удалось сохранить настройки.',
         connectGoogle: 'Не удалось подключить Google.'
       }
+    },
+    appointments: {
+      pageTitle: 'Записи',
+      pageSubtitle: 'Календарный вид с расписанием по дням и времени.',
+      specialistFilter: 'Специалист',
+      allSpecialists: 'Все специалисты',
+      create: 'Создать',
+      createTitle: 'Создать запись',
+      editTitle: 'Редактировать запись',
+      save: 'Сохранить',
+      close: 'Закрыть',
+      emptyDay: 'На этот день записей нет.',
+      cancelAction: 'Отменить запись',
+      fields: {
+        scheduledAt: 'Дата и время',
+        status: 'Статус',
+        meetingLink: 'Ссылка на встречу',
+        notes: 'Комментарий'
+      }
     }
   }
 } as const;
@@ -129,6 +169,7 @@ export type TranslationKey =
   | 'common.login'
   | 'common.register'
   | 'common.language'
+  | 'common.appointments'
   | 'common.profileMenuAria'
   | 'common.appearancePaletteAria'
   | 'common.themeToggleAria'
@@ -163,6 +204,21 @@ export type TranslationKey =
   | 'settings.googleConnectedSuccessfully'
   | 'settings.errors.load'
   | 'settings.errors.save'
-  | 'settings.errors.connectGoogle';
+  | 'settings.errors.connectGoogle'
+  | 'appointments.pageTitle'
+  | 'appointments.pageSubtitle'
+  | 'appointments.specialistFilter'
+  | 'appointments.allSpecialists'
+  | 'appointments.create'
+  | 'appointments.createTitle'
+  | 'appointments.editTitle'
+  | 'appointments.save'
+  | 'appointments.close'
+  | 'appointments.emptyDay'
+  | 'appointments.cancelAction'
+  | 'appointments.fields.scheduledAt'
+  | 'appointments.fields.status'
+  | 'appointments.fields.meetingLink'
+  | 'appointments.fields.notes';
 
 export const DEFAULT_LOCALE: Locale = 'ru';

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -28,3 +28,24 @@ export type GoogleOAuthStartResponse = {
   authorizeUrl: string;
   state: string;
 };
+
+export type AppointmentStatus = 'new' | 'confirmed' | 'cancelled';
+
+export type SpecialistItem = {
+  id: number;
+  name: string;
+};
+
+export type AppointmentItem = {
+  id: number;
+  specialistId: number;
+  scheduledAt: string;
+  status: AppointmentStatus;
+  meetingLink: string;
+  notes: string;
+};
+
+export type AppointmentListResponse = {
+  appointments: AppointmentItem[];
+  specialists: SpecialistItem[];
+};

--- a/web/src/shared/types/roles.ts
+++ b/web/src/shared/types/roles.ts
@@ -1,4 +1,5 @@
 export enum WebUserRole {
   Owner = 'owner',
+  Admin = 'admin',
   Specialist = 'specialist',
 }

--- a/web/src/shared/ui/AppIcons.tsx
+++ b/web/src/shared/ui/AppIcons.tsx
@@ -1,4 +1,5 @@
 import DarkModeRounded from '@mui/icons-material/DarkModeRounded';
+import EventRounded from '@mui/icons-material/EventRounded';
 import LightModeRounded from '@mui/icons-material/LightModeRounded';
 import LoginRounded from '@mui/icons-material/LoginRounded';
 import LogoutRounded from '@mui/icons-material/LogoutRounded';
@@ -9,6 +10,7 @@ import SettingsRounded from '@mui/icons-material/SettingsRounded';
 
 export const AppIcons = {
   darkMode: DarkModeRounded,
+  calendar: EventRounded,
   lightMode: LightModeRounded,
   login: LoginRounded,
   logout: LogoutRounded,


### PR DESCRIPTION
### Motivation

- Deliver the first end-to-end Appointments MVP slice to support listing, creating, editing, cancelling and rescheduling appointments. 
- Provide role-aware access so `owner/admin` can see all specialists and `specialist` users only see their own appointments. 
- Keep data isolation by scoping all appointments queries to `account_id` and provide fallback client/service creation for minimal data model. 
- Expose a simple calendar UI in the web app so users can create/edit appointments and perform cancel/reschedule flows.

### Description

- Server: added request validation schemas (`appointmentCreateSchema`, `appointmentUpdateSchema`, `appointmentRescheduleSchema`) and wired `appointmentRoutes` into `createApp` under `/api/appointments`. 
- Data layer: added `server/src/repositories/appointmentRepository.ts` with list/find/create/update helpers and fallback client/service creators, and extended `specialistRepository` with specialist lookup/list helpers. 
- Business logic: implemented `server/src/services/appointmentService.ts` to map DB records to DTOs, enforce role checks, compose/decompose meetingLink stored inside `comment`, and provide `get/create/update/cancel/reschedule` flows. 
- Auth/domain: propagated `accountId` into `User` domain type and updated `authService` mapping to include `account_id` for correct scoping. 
- Web: added appointments page, container and router entry (`/appointments`) including month calendar, day list, create/edit dialog, specialist filter for owners/admins, i18n strings, API types, and UI icon support. 

### Testing

- Ran static checks and build: `npm run typecheck` and `npm run build` completed successfully. 
- Spin-up/dev smoke: basic dev servers were exercised locally to verify the new routes and UI render (no new automated integration/e2e tests added in this change). 
- No automated unit/integration tests were introduced for appointments in this PR; test coverage tasks remain in the TODO (smoke scenarios for create/reschedule/cancel).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75871bdf083339e9c5015ec99c48e)