### PR TITLE
Introduce AppRhfTextField and migrate form fields to RHF-friendly component

### DIFF
--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -4,7 +4,7 @@ import { Controller, useForm } from 'react-hook-form';
 import logoText from '../static/images/logo_text.svg';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
-import { AppTextField } from '../shared/ui/AppTextField';
+import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type AuthFormValues = {
   email: string;
@@ -90,14 +90,11 @@ export function AuthCard({
             required: 'Email is required'
           }}
           render={({ field, fieldState }: any) => (
-            <AppTextField
-              {...field}
+            <AppRhfTextField
+              field={field}
               label={emailLabel}
               type="email"
-              onChange={(event) => {
-                field.onChange(event);
-                clearErrors('email');
-              }}
+              onValueChange={() => clearErrors('email')}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
             />
@@ -115,15 +112,12 @@ export function AuthCard({
             }
           }}
           render={({ field, fieldState }: any) => (
-            <AppTextField
-              {...field}
+            <AppRhfTextField
+              field={field}
               label={passwordLabel}
               type="password"
-              inputProps={{ minLength: 10 }}
-              onChange={(event) => {
-                field.onChange(event);
-                clearErrors('password');
-              }}
+              slotProps={{ htmlInput: { minLength: 10 } }}
+              onValueChange={() => clearErrors('password')}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
             />

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -5,8 +5,8 @@ import type { SystemSettings, UserSettings } from '../shared/types/api';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
 import { AppIcons } from '../shared/ui/AppIcons';
+import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import { AppTab, AppTabs } from '../shared/ui/AppTabs';
-import { AppTextField } from '../shared/ui/AppTextField';
 
 type SettingsCardCopy = {
   systemTab: string;
@@ -83,25 +83,29 @@ export function SettingsCard({
           <Controller
             name="timezone"
             control={systemControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.timezone} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.timezone} />
+            )}
           />
 
           <Controller
             name="locale"
             control={systemControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.locale} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.locale} />
+            )}
           />
 
           <Controller
             name="defaultMeetingDuration"
             control={systemControl}
             render={({ field }: any) => (
-              <AppTextField
-                {...field}
+              <AppRhfTextField
+                field={field}
                 label={copy.defaultMeetingDuration}
                 type="number"
-                inputProps={{ min: 15, max: 180 }}
-                onChange={(event) => field.onChange(Number(event.target.value))}
+                slotProps={{ htmlInput: { min: 15, max: 180 } }}
+                parseValue={(value) => Number(value)}
               />
             )}
           />
@@ -141,13 +145,17 @@ export function SettingsCard({
           <Controller
             name="timezone"
             control={userControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.timezone} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.timezone} />
+            )}
           />
 
           <Controller
             name="locale"
             control={userControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.locale} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.locale} />
+            )}
           />
 
           <AppButton type="submit" startIcon={<AppIcons.save />} disabled={isSavingUser}>

--- a/web/src/shared/ui/AppRhfTextField.tsx
+++ b/web/src/shared/ui/AppRhfTextField.tsx
@@ -1,0 +1,37 @@
+import type { TextFieldProps } from '@mui/material';
+import type { ChangeEvent } from 'react';
+import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
+import { AppTextField } from './AppTextField';
+
+type AppRhfTextFieldProps<TFieldValues extends FieldValues> = Omit<
+  TextFieldProps,
+  'name' | 'value' | 'onBlur' | 'onChange' | 'inputRef'
+> & {
+  field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>;
+  parseValue?: (value: string) => unknown;
+  onValueChange?: (value: string) => void;
+};
+
+export function AppRhfTextField<TFieldValues extends FieldValues>({
+  field,
+  parseValue,
+  onValueChange,
+  ...props
+}: AppRhfTextFieldProps<TFieldValues>) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    field.onChange(parseValue ? parseValue(value) : value);
+    onValueChange?.(value);
+  };
+
+  return (
+    <AppTextField
+      {...props}
+      name={field.name}
+      value={field.value ?? ''}
+      onBlur={field.onBlur}
+      inputRef={field.ref}
+      onChange={handleChange}
+    />
+  );
+}

--- a/web/src/shared/ui/AppTextField.tsx
+++ b/web/src/shared/ui/AppTextField.tsx
@@ -1,9 +1,5 @@
 import { TextField, type TextFieldProps } from '@mui/material';
 
-type Props = TextFieldProps & {
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-};
-
-export function AppTextField(props: Props) {
+export function AppTextField(props: TextFieldProps) {
   return <TextField fullWidth size="medium" {...props} />;
 }


### PR DESCRIPTION
### Motivation
- Provide a small adapter to integrate MUI text fields with `react-hook-form` `Controller` usage to avoid spreading controller props directly into the base `AppTextField`.
- Simplify value parsing and change handling (e.g. numeric parsing, min/max/minLength handling) in a single reusable component.
- Reduce repetition around clearing field errors and converting DOM input values before passing them to RHF.

### Description
- Add `AppRhfTextField` component that accepts a `field` from `react-hook-form` `Controller`, optional `parseValue`, and optional `onValueChange`, and wires `name`, `value`, `onBlur`, `ref`, and `onChange` appropriately.
- Replace usages of `AppTextField` with `AppRhfTextField` in `AuthCard.tsx` and `SettingsCard.tsx`, and adjust props: use `onValueChange` for clearing errors and `parseValue`/`slotProps` for numeric parsing and input constraints.
- Update `AppTextField` signature to accept generic `TextFieldProps` only and remove the previous custom `inputProps` typing.
- Update imports and propagate the RHF-friendly adapter across the affected forms (`AuthCard` and both system/user sections of `SettingsCard`).

### Testing
- Ran `yarn build` to verify TypeScript and bundling errors, and the build completed successfully.
- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76bdc1f5c8333b7f36c93e84d66a9)