### PR TITLE
fix(server): allow creating web appointments without telegram_id

### DIFF
--- a/server/src/db/migrations/20260421180000_make_clients_telegram_id_nullable.ts
+++ b/server/src/db/migrations/20260421180000_make_clients_telegram_id_nullable.ts
@@ -1,0 +1,25 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'clients';
+const COLUMN_NAME = 'telegram_id';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasClients = await knex.schema.hasTable(TABLE_NAME);
+  if (!hasClients) {
+    return;
+  }
+
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" ALTER COLUMN "${COLUMN_NAME}" DROP NOT NULL`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasClients = await knex.schema.hasTable(TABLE_NAME);
+  if (!hasClients) {
+    return;
+  }
+
+  await knex.raw(
+    `UPDATE "${TABLE_NAME}" SET "${COLUMN_NAME}" = id * -1 WHERE "${COLUMN_NAME}" IS NULL`,
+  );
+  await knex.raw(`ALTER TABLE "${TABLE_NAME}" ALTER COLUMN "${COLUMN_NAME}" SET NOT NULL`);
+}


### PR DESCRIPTION
### Motivation
- Web-created appointments insert fallback client records into `clients` without a Telegram identity, which caused `POST /api/appointments` to fail with PostgreSQL error `23502` due to `clients.telegram_id` being `NOT NULL`.
- Making the column nullable allows web fallback clients to be created without requiring front-end changes or additional fields.

### Description
- Added a new migration `server/src/db/migrations/20260421180000_make_clients_telegram_id_nullable.ts` that drops the `NOT NULL` constraint on `clients.telegram_id` in `up`.
- The `down` migration fills `NULL` `telegram_id` values with deterministic negative values (`id * -1`) before restoring the `NOT NULL` constraint to keep rollback safe.
- No changes to application logic were required; the migration enables existing fallback client creation behavior.

### Testing
- Ran type-checking with `npm --prefix server run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76f098d848333ba0a1c2974206941)