### PR TITLE
Introduce AppRhfTextField and migrate form components to react-hook-form

### DIFF
--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -4,7 +4,7 @@ import { Controller, useForm } from 'react-hook-form';
 import logoText from '../static/images/logo_text.svg';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
-import { AppTextField } from '../shared/ui/AppTextField';
+import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type AuthFormValues = {
   email: string;
@@ -90,14 +90,11 @@ export function AuthCard({
             required: 'Email is required'
           }}
           render={({ field, fieldState }: any) => (
-            <AppTextField
-              {...field}
+            <AppRhfTextField
+              field={field}
               label={emailLabel}
               type="email"
-              onChange={(event) => {
-                field.onChange(event);
-                clearErrors('email');
-              }}
+              onValueChange={() => clearErrors('email')}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
             />
@@ -115,15 +112,12 @@ export function AuthCard({
             }
           }}
           render={({ field, fieldState }: any) => (
-            <AppTextField
-              {...field}
+            <AppRhfTextField
+              field={field}
               label={passwordLabel}
               type="password"
-              inputProps={{ minLength: 10 }}
-              onChange={(event) => {
-                field.onChange(event);
-                clearErrors('password');
-              }}
+              slotProps={{ htmlInput: { minLength: 10 } }}
+              onValueChange={() => clearErrors('password')}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
             />

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -5,8 +5,8 @@ import type { SystemSettings, UserSettings } from '../shared/types/api';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
 import { AppIcons } from '../shared/ui/AppIcons';
+import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import { AppTab, AppTabs } from '../shared/ui/AppTabs';
-import { AppTextField } from '../shared/ui/AppTextField';
 
 type SettingsCardCopy = {
   systemTab: string;
@@ -83,25 +83,29 @@ export function SettingsCard({
           <Controller
             name="timezone"
             control={systemControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.timezone} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.timezone} />
+            )}
           />
 
           <Controller
             name="locale"
             control={systemControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.locale} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.locale} />
+            )}
           />
 
           <Controller
             name="defaultMeetingDuration"
             control={systemControl}
             render={({ field }: any) => (
-              <AppTextField
-                {...field}
+              <AppRhfTextField
+                field={field}
                 label={copy.defaultMeetingDuration}
                 type="number"
-                inputProps={{ min: 15, max: 180 }}
-                onChange={(event) => field.onChange(Number(event.target.value))}
+                slotProps={{ htmlInput: { min: 15, max: 180 } }}
+                parseValue={(value) => Number(value)}
               />
             )}
           />
@@ -141,13 +145,17 @@ export function SettingsCard({
           <Controller
             name="timezone"
             control={userControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.timezone} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.timezone} />
+            )}
           />
 
           <Controller
             name="locale"
             control={userControl}
-            render={({ field }: any) => <AppTextField {...field} label={copy.locale} />}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.locale} />
+            )}
           />
 
           <AppButton type="submit" startIcon={<AppIcons.save />} disabled={isSavingUser}>

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -17,10 +17,12 @@ import {
   Typography,
 } from '@mui/material';
 import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { apiClient, authHeaders } from '../shared/api/client';
 import { useAuth } from '../shared/auth/AuthContext';
 import { useI18n } from '../shared/i18n/I18nContext';
 import { AppPage } from '../shared/ui/AppPage';
+import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import type { AppointmentItem, AppointmentListResponse, AppointmentStatus, SpecialistItem } from '../shared/types/api';
 import { WebUserRole } from '../shared/types/roles';
 
@@ -98,11 +100,15 @@ export function AppointmentsContainer() {
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<AppointmentItem | null>(null);
-  const [form, setForm] = useState<EditFormState>({
+  const initialFormValues: EditFormState = {
     scheduledAt: toDatetimeLocal(new Date().toISOString()),
     status: 'new',
     meetingLink: '',
     notes: '',
+  };
+
+  const { control, handleSubmit, reset } = useForm<EditFormState>({
+    defaultValues: initialFormValues,
   });
 
   const canManageAll = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin;
@@ -173,7 +179,7 @@ export function AppointmentsContainer() {
       return;
     }
 
-    setForm({
+    reset({
       scheduledAt: toDatetimeLocal(targetDate.toISOString()),
       status: 'new',
       meetingLink: '',
@@ -183,7 +189,7 @@ export function AppointmentsContainer() {
     setIsCreateOpen(true);
   };
 
-  const submitForm = async () => {
+  const submitForm = async (form: EditFormState) => {
     if (!accessToken) {
       return;
     }
@@ -228,7 +234,7 @@ export function AppointmentsContainer() {
 
   const openEdit = (item: AppointmentItem) => {
     setEditingItem(item);
-    setForm({
+    reset({
       scheduledAt: toDatetimeLocal(item.scheduledAt),
       status: item.status,
       meetingLink: item.meetingLink,
@@ -465,37 +471,50 @@ export function AppointmentsContainer() {
         <DialogTitle>{editingItem ? t('appointments.editTitle') : t('appointments.createTitle')}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
-            <TextField
-              label={t('appointments.fields.scheduledAt')}
-              type="datetime-local"
-              value={form.scheduledAt}
-              onChange={(event) => setForm((prev) => ({ ...prev, scheduledAt: event.target.value }))}
-              slotProps={{ inputLabel: { shrink: true } }}
+            <Controller
+              name="scheduledAt"
+              control={control}
+              render={({ field }: any) => (
+                <AppRhfTextField
+                  field={field}
+                  label={t('appointments.fields.scheduledAt')}
+                  type="datetime-local"
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+              )}
             />
-            <FormControl>
-              <InputLabel id="status-label">{t('appointments.fields.status')}</InputLabel>
-              <Select
-                labelId="status-label"
-                label={t('appointments.fields.status')}
-                value={form.status}
-                onChange={(event) => setForm((prev) => ({ ...prev, status: event.target.value as AppointmentStatus }))}
-              >
-                {STATUS_OPTIONS.map((status) => (
-                  <MenuItem key={status} value={status}>{statusLabel(status)}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <TextField
-              label={t('appointments.fields.meetingLink')}
-              value={form.meetingLink}
-              onChange={(event) => setForm((prev) => ({ ...prev, meetingLink: event.target.value }))}
+            <Controller
+              name="status"
+              control={control}
+              render={({ field }: any) => (
+                <FormControl>
+                  <InputLabel id="status-label">{t('appointments.fields.status')}</InputLabel>
+                  <Select
+                    labelId="status-label"
+                    label={t('appointments.fields.status')}
+                    value={field.value}
+                    onChange={(event) => field.onChange(event.target.value as AppointmentStatus)}
+                  >
+                    {STATUS_OPTIONS.map((status) => (
+                      <MenuItem key={status} value={status}>{statusLabel(status)}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
             />
-            <TextField
-              label={t('appointments.fields.notes')}
-              value={form.notes}
-              onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
-              multiline
-              minRows={3}
+            <Controller
+              name="meetingLink"
+              control={control}
+              render={({ field }: any) => (
+                <AppRhfTextField field={field} label={t('appointments.fields.meetingLink')} />
+              )}
+            />
+            <Controller
+              name="notes"
+              control={control}
+              render={({ field }: any) => (
+                <AppRhfTextField field={field} label={t('appointments.fields.notes')} multiline minRows={3} />
+              )}
             />
           </Stack>
         </DialogContent>
@@ -504,7 +523,7 @@ export function AppointmentsContainer() {
             <Button color="error" onClick={cancelAppointment}>{t('appointments.cancelAction')}</Button>
           )}
           <Button onClick={() => setIsCreateOpen(false)}>{t('appointments.close')}</Button>
-          <Button variant="contained" onClick={submitForm}>{t('appointments.save')}</Button>
+          <Button variant="contained" onClick={handleSubmit(submitForm)}>{t('appointments.save')}</Button>
         </DialogActions>
       </Dialog>
     </AppPage>

--- a/web/src/shared/ui/AppRhfTextField.tsx
+++ b/web/src/shared/ui/AppRhfTextField.tsx
@@ -1,0 +1,44 @@
+import type { TextFieldProps } from '@mui/material';
+import type { ChangeEvent } from 'react';
+import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
+import { AppTextField } from './AppTextField';
+
+type AppRhfTextFieldProps<TFieldValues extends FieldValues> = Omit<
+  TextFieldProps,
+  'name' | 'value' | 'onBlur' | 'onChange' | 'inputRef'
+> & {
+  field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>;
+  parseValue?: (value: string) => unknown;
+  onValueChange?: (value: string) => void;
+};
+
+export function AppRhfTextField<TFieldValues extends FieldValues>({
+  field,
+  parseValue,
+  onValueChange,
+  ...props
+}: AppRhfTextFieldProps<TFieldValues>) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const value = event.target.value;
+
+    if (parseValue) {
+      field.onChange(parseValue(value));
+    } else {
+      field.onChange(event);
+      field.onChange(value);
+    }
+
+    onValueChange?.(value);
+  };
+
+  return (
+    <AppTextField
+      {...props}
+      name={field.name}
+      value={field.value ?? ''}
+      onBlur={field.onBlur}
+      inputRef={field.ref}
+      onChange={handleChange}
+    />
+  );
+}

--- a/web/src/shared/ui/AppTextField.tsx
+++ b/web/src/shared/ui/AppTextField.tsx
@@ -1,9 +1,5 @@
 import { TextField, type TextFieldProps } from '@mui/material';
 
-type Props = TextFieldProps & {
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-};
-
-export function AppTextField(props: Props) {
+export function AppTextField(props: TextFieldProps) {
   return <TextField fullWidth size="medium" {...props} />;
 }


### PR DESCRIPTION
### Motivation

- Reduce repeated `Controller` boilerplate and make MUI `TextField` usage consistent with `react-hook-form` across the app.
- Migrate the appointments edit/create dialog to a single source of truth using `useForm` instead of ad-hoc local form state.

### Description

- Add `AppRhfTextField` wrapper component that adapts `AppTextField` to `react-hook-form` `Controller` fields and supports `parseValue` and `onValueChange` props.
- Replace `AppTextField` usages in `AuthCard`, `SettingsCard`, and `AppointmentsContainer` with `AppRhfTextField` and update handlers to use `onValueChange`, `parseValue`, and `slotProps` where appropriate.
- Refactor `AppointmentsContainer` to use `useForm` (`control`, `handleSubmit`, `reset`) and replace the previous local `form` state with controlled `Controller` fields, and wire the submit button to `handleSubmit(submitForm)`.
- Simplify `AppTextField` signature to accept `TextFieldProps` directly.

### Testing

- Ran TypeScript typecheck and local build with `yarn build`, which succeeded.
- Ran the existing unit and UI test suite with `yarn test`, which passed.
- Ran linting with `yarn lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76bdc1f5c8333b7f36c93e84d66a9)