### PR TITLE
Sync appointments with external (Google) calendars and surface external busy slots in UI

### DIFF
--- a/bot/src/routes/telegramWebhook.ts
+++ b/bot/src/routes/telegramWebhook.ts
@@ -59,7 +59,10 @@ import {
   buildCalendarLink,
   buildMicrosoftCalendarLink,
 } from '../utils/calendar-links';
-import { createGoogleCalendarEvents } from '../services/google-calendar.service';
+import {
+  syncAppointmentRescheduledInExternalCalendars,
+  syncAppointmentsToExternalCalendars,
+} from '../services/calendar-sync.service';
 import {
   beginProcessingUpdate,
   markProcessedUpdate,
@@ -573,6 +576,14 @@ telegramWebhookRouter.post(
               reminderComment: user.reminder_comment,
             });
 
+            await syncAppointmentRescheduledInExternalCalendars({
+              accountId: user.account_id,
+              specialistId: rescheduled.calendarSyncContext.specialistId,
+              appointmentId: payload.editingAppointmentId,
+              appointmentAt: rescheduled.calendarSyncContext.appointmentAtIso,
+              durationMin: rescheduled.calendarSyncContext.durationMin,
+            });
+
             await editMessageText(
               chatId,
               messageId,
@@ -870,7 +881,7 @@ telegramWebhookRouter.post(
             ),
           );
 
-          await createGoogleCalendarEvents({
+          await syncAppointmentsToExternalCalendars({
             accountId: user.account_id,
             specialistId: payload.specialistId!,
             appointments: appointmentResult.appointments.map((appointment) => ({

--- a/bot/src/services/appointment.service.ts
+++ b/bot/src/services/appointment.service.ts
@@ -304,6 +304,11 @@ export async function rescheduleUserAppointment(input: RescheduleAppointmentInpu
         specialistName: appointment.specialistName,
         appointmentAtIso: String(updated.appointment_at),
       },
+      calendarSyncContext: {
+        specialistId: appointment.specialistId,
+        durationMin: appointment.durationMin,
+        appointmentAtIso: String(updated.appointment_at),
+      },
     };
   } catch (error) {
     if (isSlotConflictError(error)) {

--- a/bot/src/services/calendar-sync.service.ts
+++ b/bot/src/services/calendar-sync.service.ts
@@ -1,0 +1,44 @@
+import {
+  createGoogleCalendarEvents,
+  getBusyIntervalsFromGoogleCalendar,
+  rescheduleGoogleCalendarEvent,
+} from './google-calendar.service';
+
+type CalendarBusyInterval = {
+  date: string;
+  time: string;
+  durationMin: number;
+};
+
+export async function getBusyIntervalsFromExternalCalendars(input: {
+  accountId: number;
+  specialistId: number;
+  date: string;
+  timezone: string;
+}): Promise<CalendarBusyInterval[]> {
+  const googleBusyIntervals = await getBusyIntervalsFromGoogleCalendar(input);
+  return googleBusyIntervals;
+}
+
+export async function syncAppointmentsToExternalCalendars(input: {
+  accountId: number;
+  specialistId: number;
+  appointments: Array<{ id: number; appointment_at: string | Date; duration_min: number }>;
+  serviceName: string;
+  specialistName: string;
+  clientName?: string;
+  clientPhone?: string;
+  clientEmail?: string;
+}) {
+  return createGoogleCalendarEvents(input);
+}
+
+export async function syncAppointmentRescheduledInExternalCalendars(input: {
+  accountId: number;
+  specialistId: number;
+  appointmentId: number;
+  appointmentAt: string | Date;
+  durationMin: number;
+}) {
+  return rescheduleGoogleCalendarEvent(input);
+}

--- a/bot/src/services/google-calendar.service.ts
+++ b/bot/src/services/google-calendar.service.ts
@@ -8,6 +8,7 @@ type GoogleCalendarEventDateTime = {
 };
 
 type GoogleCalendarEvent = {
+  id?: string;
   status?: string;
   start?: GoogleCalendarEventDateTime;
   end?: GoogleCalendarEventDateTime;
@@ -152,6 +153,11 @@ export async function createGoogleCalendarEvents(input: {
         {
           summary: input.serviceName,
           description: descriptionLines.join('\n'),
+          extendedProperties: {
+            private: {
+              appointmentId: String(appointment.id),
+            },
+          },
           start: { dateTime: startIso },
           end: { dateTime: endIso },
         },
@@ -176,4 +182,93 @@ export async function createGoogleCalendarEvents(input: {
     sent,
     skipped: input.appointments.length - sent,
   };
+}
+
+async function findEventIdByAppointmentId(input: {
+  googleApiKey: string;
+  googleCalendarId: string;
+  appointmentId: number;
+}) {
+  const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(input.googleCalendarId)}/events`;
+
+  const byPrivateProperty = await axios.get<GoogleCalendarEventsResponse>(url, {
+    params: {
+      key: input.googleApiKey,
+      singleEvents: true,
+      privateExtendedProperty: `appointmentId=${input.appointmentId}`,
+      maxResults: 1,
+    },
+  });
+
+  const eventByPrivateProperty = byPrivateProperty.data.items?.[0];
+  if (eventByPrivateProperty?.id) {
+    return eventByPrivateProperty.id;
+  }
+
+  const byDescription = await axios.get<GoogleCalendarEventsResponse>(url, {
+    params: {
+      key: input.googleApiKey,
+      singleEvents: true,
+      q: `Appointment ID: ${input.appointmentId}`,
+      maxResults: 1,
+    },
+  });
+
+  return byDescription.data.items?.[0]?.id ?? null;
+}
+
+export async function rescheduleGoogleCalendarEvent(input: {
+  accountId: number;
+  specialistId: number;
+  appointmentId: number;
+  appointmentAt: string | Date;
+  durationMin: number;
+}) {
+  const credentials = await findSpecialistCalendarCredentials(input.accountId, input.specialistId);
+  const calendarConfig = getGoogleCalendarConfig(credentials ?? {});
+  if (!calendarConfig) {
+    return { updated: false };
+  }
+
+  try {
+    const eventId = await findEventIdByAppointmentId({
+      googleApiKey: calendarConfig.googleApiKey,
+      googleCalendarId: calendarConfig.googleCalendarId,
+      appointmentId: input.appointmentId,
+    });
+
+    if (!eventId) {
+      return { updated: false };
+    }
+
+    const startIso = new Date(input.appointmentAt).toISOString();
+    const endIso = new Date(
+      new Date(input.appointmentAt).getTime() + input.durationMin * 60 * 1000,
+    ).toISOString();
+
+    const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarConfig.googleCalendarId)}/events/${encodeURIComponent(eventId)}`;
+    await axios.patch(url, {
+      start: { dateTime: startIso },
+      end: { dateTime: endIso },
+      extendedProperties: {
+        private: {
+          appointmentId: String(input.appointmentId),
+        },
+      },
+    }, {
+      params: {
+        key: calendarConfig.googleApiKey,
+      },
+    });
+
+    return { updated: true };
+  } catch (error) {
+    logWarn('google_calendar.reschedule_event_failed', {
+      account_id: input.accountId,
+      specialist_id: input.specialistId,
+      appointment_id: input.appointmentId,
+    });
+
+    return { updated: false };
+  }
 }

--- a/bot/src/services/slot.service.ts
+++ b/bot/src/services/slot.service.ts
@@ -1,7 +1,7 @@
 import { findBusyAppointmentsByDate } from '../repositories/appointment.repository';
 import { getAppSettings } from '../repositories/app-settings.repository';
 import { findServiceById } from '../repositories/service.repository';
-import { getBusyIntervalsFromGoogleCalendar } from './google-calendar.service';
+import { getBusyIntervalsFromExternalCalendars } from './calendar-sync.service';
 
 const SLOT_STEP_MIN = 30;
 const MINUTES_IN_DAY = 24 * 60;
@@ -56,7 +56,7 @@ export async function getAvailableSlots(params: {
     params.specialistId,
     settings.timezone,
   );
-  const googleBusyAppointments = await getBusyIntervalsFromGoogleCalendar({
+  const googleBusyAppointments = await getBusyIntervalsFromExternalCalendars({
     accountId: params.accountId,
     specialistId: params.specialistId,
     date: params.date,

--- a/bot/src/services/tests/google-calendar.service.test.ts
+++ b/bot/src/services/tests/google-calendar.service.test.ts
@@ -4,6 +4,7 @@ vi.mock('axios', () => ({
   default: {
     get: vi.fn(),
     post: vi.fn(),
+    patch: vi.fn(),
   },
 }));
 
@@ -14,7 +15,11 @@ vi.mock('../../repositories/specialist.repository', () => ({
 
 import axios from 'axios';
 import { findSpecialistById, findSpecialistCalendarCredentials } from '../../repositories/specialist.repository';
-import { createGoogleCalendarEvents, getBusyIntervalsFromGoogleCalendar } from '../google-calendar.service';
+import {
+  createGoogleCalendarEvents,
+  getBusyIntervalsFromGoogleCalendar,
+  rescheduleGoogleCalendarEvent,
+} from '../google-calendar.service';
 
 describe('google-calendar.service', () => {
   afterEach(() => {
@@ -63,6 +68,33 @@ describe('google-calendar.service', () => {
     });
 
     expect(out).toEqual([{ date: '2026-04-18', time: '10:00', durationMin: 90 }]);
+  });
+
+
+
+  it('reschedules existing Google event linked to appointment id', async () => {
+    vi.mocked(findSpecialistCalendarCredentials).mockResolvedValue({
+      google_api_key: 'api-key',
+      google_calendar_id: 'calendar-id',
+    } as any);
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: 'event-1' }],
+        },
+      } as any);
+    vi.mocked(axios.patch).mockResolvedValue({ data: {} } as any);
+
+    const out = await rescheduleGoogleCalendarEvent({
+      accountId: 7,
+      specialistId: 1,
+      appointmentId: 10,
+      appointmentAt: '2026-04-19T06:00:00.000Z',
+      durationMin: 90,
+    });
+
+    expect(out).toEqual({ updated: true });
+    expect(vi.mocked(axios.patch)).toHaveBeenCalledTimes(1);
   });
 
   it('sends Google Calendar events for each appointment', async () => {

--- a/bot/src/services/tests/slot.service.test.ts
+++ b/bot/src/services/tests/slot.service.test.ts
@@ -18,16 +18,16 @@ vi.mock('../../repositories/service.repository', () => {
   };
 });
 
-vi.mock('../google-calendar.service', () => {
+vi.mock('../calendar-sync.service', () => {
   return {
-    getBusyIntervalsFromGoogleCalendar: vi.fn(),
+    getBusyIntervalsFromExternalCalendars: vi.fn(),
   };
 });
 
 import { findBusyAppointmentsByDate } from '../../repositories/appointment.repository';
 import { getAppSettings } from '../../repositories/app-settings.repository';
 import { findServiceById } from '../../repositories/service.repository';
-import { getBusyIntervalsFromGoogleCalendar } from '../google-calendar.service';
+import { getBusyIntervalsFromExternalCalendars } from '../calendar-sync.service';
 import { getAvailableSlots } from '../slot.service';
 
 describe('getAvailableSlots', () => {
@@ -48,7 +48,7 @@ describe('getAvailableSlots', () => {
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       { date: '2026-04-18', time: '10:00', durationMin: 60 },
     ] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
     const slots = await getAvailableSlots({
       accountId: 7,
@@ -69,7 +69,7 @@ describe('getAvailableSlots', () => {
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       { date: '2026-04-18', time: '09:00', durationMin: 60 },
     ] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
     const slots = await getAvailableSlots({
       accountId: 7,
@@ -91,7 +91,7 @@ describe('getAvailableSlots', () => {
       // 23:30-01:30 overlaps the next day 00:00-02:00 work window
       { date: '2026-04-17', time: '23:30', durationMin: 120 },
     ] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
     const slots = await getAvailableSlots({
       accountId: 7,
@@ -110,7 +110,7 @@ describe('getAvailableSlots', () => {
       workEndHour: 12,
     } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
     const slots = await getAvailableSlots({
       accountId: 7,
@@ -130,7 +130,7 @@ describe('getAvailableSlots', () => {
       workEndHour: 11,
     } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
     const slots = await getAvailableSlots({
       accountId: 7,
@@ -151,7 +151,7 @@ describe('getAvailableSlots', () => {
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       { date: '2026-04-19', time: '09:00', durationMin: 60 },
     ] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
     const slots = await getAvailableSlots({
       accountId: 7,
@@ -171,7 +171,7 @@ describe('getAvailableSlots', () => {
       timezone: 'Europe/Moscow',
     } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
-    vi.mocked(getBusyIntervalsFromGoogleCalendar).mockResolvedValue([
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([
       { date: '2026-04-18', time: '10:00', durationMin: 60 },
     ] as any);
 

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -54,6 +54,13 @@ export type SpecialistRecord = {
   name: string;
   is_active: boolean;
   user_id: number | null;
+  timezone: string;
+};
+
+export type SpecialistCalendarCredentials = {
+  specialistId: number;
+  googleApiKey: string;
+  googleCalendarId: string | null;
 };
 
 export async function findSpecialistById(accountId: number, specialistId: number): Promise<SpecialistRecord | null> {
@@ -65,9 +72,21 @@ export async function findSpecialistById(accountId: number, specialistId: number
 }
 
 export async function listSpecialistsByAccount(accountId: number): Promise<SpecialistRecord[]> {
-  return db('specialists')
-    .where({ account_id: accountId })
-    .orderBy('name', 'asc');
+  return db('specialists as s')
+    .leftJoin('web_users as wu', function joinWebUsers() {
+      this.on('wu.id', '=', 's.user_id').andOn('wu.account_id', '=', 's.account_id');
+    })
+    .where('s.account_id', accountId)
+    .orderBy('s.name', 'asc')
+    .select(
+      's.id',
+      's.account_id',
+      's.code',
+      's.name',
+      's.is_active',
+      's.user_id',
+      db.raw("COALESCE(wu.timezone, 'UTC') as timezone"),
+    );
 }
 
 export async function findSpecialistByWebUserId(accountId: number, webUserId: number): Promise<SpecialistRecord | null> {
@@ -76,4 +95,28 @@ export async function findSpecialistByWebUserId(accountId: number, webUserId: nu
     .first<SpecialistRecord>();
 
   return row ?? null;
+}
+
+export async function findSpecialistsCalendarCredentials(
+  accountId: number,
+  specialistIds: number[],
+): Promise<SpecialistCalendarCredentials[]> {
+  if (!specialistIds.length) {
+    return [];
+  }
+
+  const rows = await db('specialists as s')
+    .join('web_users as wu', function joinWebUsers() {
+      this.on('wu.id', '=', 's.user_id').andOn('wu.account_id', '=', 's.account_id');
+    })
+    .where('s.account_id', accountId)
+    .whereIn('s.id', specialistIds)
+    .whereNotNull('wu.google_api_key')
+    .select(
+      's.id as specialistId',
+      'wu.google_api_key as googleApiKey',
+      'wu.google_calendar_id as googleCalendarId',
+    );
+
+  return rows.filter((row) => Boolean(row.googleApiKey));
 }

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -15,6 +15,7 @@ import {
   listSpecialistsByAccount,
   type SpecialistRecord,
 } from '../repositories/specialistRepository.js';
+import { listExternalBusySlots, type ExternalBusySlot } from './calendarAvailabilityService.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 
@@ -29,7 +30,8 @@ type AppointmentDto = {
 
 type AppointmentListResult = {
   appointments: AppointmentDto[];
-  specialists: Array<{ id: number; name: string }>;
+  specialists: Array<{ id: number; name: string; timezone: string }>;
+  busySlots: ExternalBusySlot[];
 };
 
 type CreateAppointmentPayload = {
@@ -119,7 +121,11 @@ async function resolveAllowedSpecialistId(actor: User, accountId: number): Promi
 }
 
 function mapSpecialistsForUi(rows: SpecialistRecord[]) {
-  return rows.map((item) => ({ id: item.id, name: item.name }));
+  return rows.map((item) => ({
+    id: item.id,
+    name: item.name,
+    timezone: item.timezone || 'UTC',
+  }));
 }
 
 export async function getAppointments(
@@ -144,9 +150,23 @@ export async function getAppointments(
         (await listSpecialistsByAccount(accountId)).filter((item) => item.user_id === Number(actor.id)),
       );
 
+  const fromDate = filters.from ? new Date(filters.from) : new Date();
+  const toDate = filters.to ? new Date(filters.to) : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const busySpecialistIds = specialistId
+    ? [specialistId]
+    : specialists.map((specialist) => specialist.id);
+
+  const busySlots = await listExternalBusySlots({
+    accountId,
+    specialistIds: busySpecialistIds,
+    from: fromDate,
+    to: toDate,
+  });
+
   return {
     appointments: items.map(mapAppointment),
     specialists,
+    busySlots,
   };
 }
 

--- a/server/src/services/calendarAvailabilityService.ts
+++ b/server/src/services/calendarAvailabilityService.ts
@@ -1,0 +1,95 @@
+import axios from 'axios';
+import { findSpecialistsCalendarCredentials } from '../repositories/specialistRepository.js';
+
+export type ExternalBusySlot = {
+  specialistId: number;
+  scheduledAt: string;
+  durationMin: number;
+  source: 'google';
+};
+
+type GoogleCalendarEventDateTime = {
+  dateTime?: string;
+};
+
+type GoogleCalendarEvent = {
+  status?: string;
+  start?: GoogleCalendarEventDateTime;
+  end?: GoogleCalendarEventDateTime;
+};
+
+type GoogleCalendarEventsResponse = {
+  items?: GoogleCalendarEvent[];
+};
+
+function toDurationMin(startIso?: string, endIso?: string): number | null {
+  if (!startIso || !endIso) {
+    return null;
+  }
+
+  const start = new Date(startIso).getTime();
+  const end = new Date(endIso).getTime();
+  const durationMin = Math.round((end - start) / (60 * 1000));
+
+  if (durationMin <= 0) {
+    return null;
+  }
+
+  return durationMin;
+}
+
+export async function listExternalBusySlots(input: {
+  accountId: number;
+  specialistIds: number[];
+  from: Date;
+  to: Date;
+}): Promise<ExternalBusySlot[]> {
+  const credentials = await findSpecialistsCalendarCredentials(input.accountId, input.specialistIds);
+
+  if (!credentials.length) {
+    return [];
+  }
+
+  const busySlots = await Promise.all(
+    credentials.map(async (item) => {
+      const calendarId = item.googleCalendarId?.trim() || 'primary';
+      const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`;
+
+      try {
+        const response = await axios.get<GoogleCalendarEventsResponse>(url, {
+          headers: {
+            Authorization: `Bearer ${item.googleApiKey}`,
+          },
+          params: {
+            singleEvents: true,
+            orderBy: 'startTime',
+            timeMin: input.from.toISOString(),
+            timeMax: input.to.toISOString(),
+            maxResults: 2500,
+          },
+        });
+
+        return (response.data.items ?? [])
+          .filter((event) => event.status !== 'cancelled')
+          .map((event) => {
+            const durationMin = toDurationMin(event.start?.dateTime, event.end?.dateTime);
+            if (!durationMin || !event.start?.dateTime) {
+              return null;
+            }
+
+            return {
+              specialistId: item.specialistId,
+              scheduledAt: new Date(event.start.dateTime).toISOString(),
+              durationMin,
+              source: 'google' as const,
+            };
+          })
+          .filter((slot): slot is ExternalBusySlot => Boolean(slot));
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+  return busySlots.flat();
+}

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -11,6 +11,7 @@ import {
   MenuItem,
   Select,
   Stack,
+  Chip,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -38,14 +39,99 @@ type CalendarViewMode = 'day' | 'week';
 const STATUS_OPTIONS: AppointmentStatus[] = ['new', 'confirmed', 'cancelled'];
 const HOURS = Array.from({ length: 24 }, (_, index) => index);
 
-function toDatetimeLocal(iso: string): string {
-  const date = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+function getDateTimeParts(date: Date, timeZone: string) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date);
+
+  const pick = (type: Intl.DateTimeFormatPartTypes) => parts.find((item) => item.type === type)?.value ?? '00';
+
+  return {
+    year: Number(pick('year')),
+    month: Number(pick('month')),
+    day: Number(pick('day')),
+    hour: Number(pick('hour')),
+    minute: Number(pick('minute')),
+  };
 }
 
-function fromDatetimeLocal(value: string): string {
-  return new Date(value).toISOString();
+function toDatetimeLocal(iso: string, timeZone: string): string {
+  const date = new Date(iso);
+  const parts = getDateTimeParts(date, timeZone);
+  const pad = (n: number) => String(n).padStart(2, '0');
+
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}T${pad(parts.hour)}:${pad(parts.minute)}`;
+}
+
+function fromDatetimeLocal(value: string, timeZone: string): string {
+  const [datePart, timePart] = value.split('T');
+
+  if (!datePart || !timePart) {
+    return new Date(value).toISOString();
+  }
+
+  const [year, month, day] = datePart.split('-').map(Number);
+  const [hour, minute] = timePart.split(':').map(Number);
+  const targetMinutes = (((year * 12 + month) * 31 + day) * 24 + hour) * 60 + minute;
+
+  let guessUtcMs = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+
+  for (let i = 0; i < 3; i += 1) {
+    const guessDate = new Date(guessUtcMs);
+    const guessParts = getDateTimeParts(guessDate, timeZone);
+    const guessMinutes = (((guessParts.year * 12 + guessParts.month) * 31 + guessParts.day) * 24 + guessParts.hour) * 60 + guessParts.minute;
+    const diffMinutes = guessMinutes - targetMinutes;
+
+    if (diffMinutes === 0) {
+      break;
+    }
+
+    guessUtcMs -= diffMinutes * 60 * 1000;
+  }
+
+  return new Date(guessUtcMs).toISOString();
+}
+
+function formatDateInTimezone(date: Date, timeZone: string, options?: Intl.DateTimeFormatOptions): string {
+  return date.toLocaleDateString(undefined, { timeZone, ...options });
+}
+
+function formatTimeInTimezone(iso: string, timeZone: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone,
+  });
+}
+
+function toDateKeyInTimezone(date: Date, timeZone: string): string {
+  const parts = getDateTimeParts(date, timeZone);
+  const pad = (n: number) => String(n).padStart(2, '0');
+
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`;
+}
+
+function toHourInTimezone(date: Date, timeZone: string): number {
+  return getDateTimeParts(date, timeZone).hour;
+}
+
+function createDatetimeLocal(dateKey: string, hour: number, minute = 0): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${dateKey}T${pad(hour)}:${pad(minute)}`;
+}
+
+function getUtcNowByTimeZone(timeZone: string): Date {
+  const now = new Date();
+  const nowLocal = toDatetimeLocal(now.toISOString(), timeZone);
+  const todayKey = nowLocal.slice(0, 10);
+
+  return new Date(fromDatetimeLocal(`${todayKey}T00:00`, timeZone));
 }
 
 function statusLabel(status: AppointmentStatus): string {
@@ -56,12 +142,6 @@ function statusLabel(status: AppointmentStatus): string {
 
 function startOfDay(date: Date): Date {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-}
-
-function sameDay(left: Date, right: Date): boolean {
-  return left.getUTCFullYear() === right.getUTCFullYear()
-    && left.getUTCMonth() === right.getUTCMonth()
-    && left.getUTCDate() === right.getUTCDate();
 }
 
 function weekStart(date: Date): Date {
@@ -78,30 +158,27 @@ function addDays(date: Date, days: number): Date {
   return next;
 }
 
-function atHour(date: Date, hour: number): Date {
-  const next = new Date(date);
-  next.setUTCHours(hour, 0, 0, 0);
-  return next;
-}
-
 export function AppointmentsContainer() {
   const { t } = useI18n();
   const { accessToken, user } = useAuth();
 
   const [appointments, setAppointments] = useState<AppointmentItem[]>([]);
   const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
+  const [busySlots, setBusySlots] = useState<AppointmentListResponse['busySlots']>([]);
   const [selectedSpecialistId, setSelectedSpecialistId] = useState<number | 'all'>('all');
+  const [viewerTimezone, setViewerTimezone] = useState('UTC');
 
-  const [focusDate, setFocusDate] = useState(() => startOfDay(new Date()));
+  const [focusDate, setFocusDate] = useState(() => startOfDay(getUtcNowByTimeZone('UTC')));
   const [viewMode, setViewMode] = useState<CalendarViewMode>('week');
 
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const displayTimeZone = viewerTimezone || 'UTC';
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<AppointmentItem | null>(null);
   const initialFormValues: EditFormState = {
-    scheduledAt: toDatetimeLocal(new Date().toISOString()),
+    scheduledAt: toDatetimeLocal(new Date().toISOString(), displayTimeZone),
     status: 'new',
     meetingLink: '',
     notes: '',
@@ -112,6 +189,33 @@ export function AppointmentsContainer() {
   });
 
   const canManageAll = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin;
+  const selectedSpecialist = selectedSpecialistId === 'all'
+    ? null
+    : specialists.find((item) => item.id === selectedSpecialistId) ?? null;
+
+  useEffect(() => {
+    if (!accessToken) {
+      return;
+    }
+
+    const loadViewerTimezone = async () => {
+      try {
+        const response = await apiClient.get<{ timezone: string }>('/api/settings/user', {
+          headers: authHeaders(accessToken),
+        });
+
+        setViewerTimezone(response.data.timezone || 'UTC');
+      } catch {
+        setViewerTimezone('UTC');
+      }
+    };
+
+    void loadViewerTimezone();
+  }, [accessToken]);
+
+  useEffect(() => {
+    setFocusDate(startOfDay(getUtcNowByTimeZone(displayTimeZone)));
+  }, [displayTimeZone]);
 
   const visibleDays = useMemo(() => {
     if (viewMode === 'day') {
@@ -127,8 +231,8 @@ export function AppointmentsContainer() {
 
     for (const item of appointments) {
       const date = new Date(item.scheduledAt);
-      const dayKey = startOfDay(date).toISOString();
-      const key = `${dayKey}:${date.getUTCHours()}`;
+      const dayKey = toDateKeyInTimezone(date, displayTimeZone);
+      const key = `${dayKey}:${toHourInTimezone(date, displayTimeZone)}`;
       const list = map.get(key) ?? [];
       list.push(item);
       map.set(key, list);
@@ -139,7 +243,40 @@ export function AppointmentsContainer() {
     });
 
     return map;
-  }, [appointments]);
+  }, [appointments, displayTimeZone]);
+
+  const busySlotsByCell = useMemo(() => {
+    const map = new Map<string, AppointmentListResponse['busySlots']>();
+
+    for (const slot of busySlots) {
+      const date = new Date(slot.scheduledAt);
+      const dayKey = toDateKeyInTimezone(date, displayTimeZone);
+      const key = `${dayKey}:${toHourInTimezone(date, displayTimeZone)}`;
+      const list = map.get(key) ?? [];
+      list.push(slot);
+      map.set(key, list);
+    }
+
+    return map;
+  }, [busySlots, displayTimeZone]);
+
+  function getGridDayKey(day: Date) {
+    const noon = new Date(day);
+    noon.setUTCHours(12, 0, 0, 0);
+    return toDateKeyInTimezone(noon, displayTimeZone);
+  }
+
+  function getVisibleRange() {
+    const firstDay = visibleDays[0] ?? startOfDay(new Date());
+    const lastDay = visibleDays[visibleDays.length - 1] ?? firstDay;
+    const firstDayKey = getGridDayKey(firstDay);
+    const lastDayKey = getGridDayKey(lastDay);
+
+    return {
+      from: fromDatetimeLocal(`${firstDayKey}T00:00`, displayTimeZone),
+      to: fromDatetimeLocal(`${lastDayKey}T23:59`, displayTimeZone),
+    };
+  }
 
   const loadAppointments = async (nextSpecialistId: number | 'all' = selectedSpecialistId) => {
     if (!accessToken) {
@@ -149,13 +286,19 @@ export function AppointmentsContainer() {
     setIsLoading(true);
 
     try {
+      const { from, to } = getVisibleRange();
       const response = await apiClient.get<AppointmentListResponse>('/api/appointments', {
         headers: authHeaders(accessToken),
-        params: nextSpecialistId === 'all' ? undefined : { specialistId: nextSpecialistId },
+        params: {
+          from,
+          to,
+          ...(nextSpecialistId === 'all' ? {} : { specialistId: nextSpecialistId }),
+        },
       });
 
       setAppointments(response.data.appointments);
       setSpecialists(response.data.specialists);
+      setBusySlots(response.data.busySlots ?? []);
       setError('');
     } catch {
       setError('Unable to load appointments');
@@ -165,11 +308,11 @@ export function AppointmentsContainer() {
   };
 
   useEffect(() => {
-    void loadAppointments();
+    void loadAppointments(selectedSpecialistId);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accessToken]);
+  }, [accessToken, focusDate, viewMode, selectedSpecialistId, displayTimeZone]);
 
-  const openCreate = (targetDate: Date) => {
+  const openCreate = (targetDateKey: string, hour: number) => {
     const specialistId = selectedSpecialistId === 'all'
       ? specialists[0]?.id
       : selectedSpecialistId;
@@ -180,7 +323,7 @@ export function AppointmentsContainer() {
     }
 
     reset({
-      scheduledAt: toDatetimeLocal(targetDate.toISOString()),
+      scheduledAt: createDatetimeLocal(targetDateKey, hour),
       status: 'new',
       meetingLink: '',
       notes: '',
@@ -206,7 +349,7 @@ export function AppointmentsContainer() {
     try {
       if (editingItem) {
         await apiClient.patch(`/api/appointments/${editingItem.id}`, {
-          scheduledAt: fromDatetimeLocal(form.scheduledAt),
+          scheduledAt: fromDatetimeLocal(form.scheduledAt, displayTimeZone),
           status: form.status,
           meetingLink: form.meetingLink,
           notes: form.notes,
@@ -216,7 +359,7 @@ export function AppointmentsContainer() {
       } else {
         await apiClient.post('/api/appointments', {
           specialistId,
-          scheduledAt: fromDatetimeLocal(form.scheduledAt),
+          scheduledAt: fromDatetimeLocal(form.scheduledAt, displayTimeZone),
           status: form.status,
           meetingLink: form.meetingLink,
           notes: form.notes,
@@ -235,7 +378,7 @@ export function AppointmentsContainer() {
   const openEdit = (item: AppointmentItem) => {
     setEditingItem(item);
     reset({
-      scheduledAt: toDatetimeLocal(item.scheduledAt),
+      scheduledAt: toDatetimeLocal(item.scheduledAt, displayTimeZone),
       status: item.status,
       meetingLink: item.meetingLink,
       notes: item.notes,
@@ -260,7 +403,7 @@ export function AppointmentsContainer() {
     }
   };
 
-  const moveAppointment = async (appointmentId: number, targetDate: Date) => {
+  const moveAppointment = async (appointmentId: number, targetDayKey: string, targetHour: number) => {
     if (!accessToken) {
       return;
     }
@@ -272,12 +415,15 @@ export function AppointmentsContainer() {
     }
 
     const sourceDate = new Date(current.scheduledAt);
-    const next = new Date(targetDate);
-    next.setUTCMinutes(sourceDate.getUTCMinutes(), 0, 0);
+    const sourceMinute = getDateTimeParts(sourceDate, displayTimeZone).minute;
+    const nextIso = fromDatetimeLocal(
+      createDatetimeLocal(targetDayKey, targetHour, sourceMinute),
+      displayTimeZone,
+    );
 
     try {
       await apiClient.post(`/api/appointments/${appointmentId}/reschedule`, {
-        scheduledAt: next.toISOString(),
+        scheduledAt: nextIso,
       }, {
         headers: authHeaders(accessToken),
       });
@@ -289,9 +435,8 @@ export function AppointmentsContainer() {
     }
   };
 
-  const onSpecialistChange = async (value: number | 'all') => {
+  const onSpecialistChange = (value: number | 'all') => {
     setSelectedSpecialistId(value);
-    await loadAppointments(value);
   };
 
   const movePeriod = (direction: -1 | 1) => {
@@ -334,14 +479,20 @@ export function AppointmentsContainer() {
         <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} sx={{ justifyContent: 'space-between', alignItems: { xs: 'stretch', md: 'center' } }}>
           <Stack direction="row" spacing={1}>
             <Button size="small" variant="outlined" onClick={() => movePeriod(-1)}>{'<'}</Button>
-            <Button size="small" variant="outlined" onClick={() => setFocusDate(startOfDay(new Date()))}>{t('appointments.today')}</Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => setFocusDate(startOfDay(getUtcNowByTimeZone(displayTimeZone)))}
+            >
+              {t('appointments.today')}
+            </Button>
             <Button size="small" variant="outlined" onClick={() => movePeriod(1)}>{'>'}</Button>
           </Stack>
 
           <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
             {viewMode === 'week'
-              ? `${visibleDays[0].toLocaleDateString()} — ${visibleDays[visibleDays.length - 1].toLocaleDateString()}`
-              : visibleDays[0].toLocaleDateString()}
+              ? `${formatDateInTimezone(visibleDays[0], displayTimeZone)} — ${formatDateInTimezone(visibleDays[visibleDays.length - 1], displayTimeZone)}`
+              : formatDateInTimezone(visibleDays[0], displayTimeZone)}
           </Typography>
 
           <ToggleButtonGroup
@@ -360,6 +511,11 @@ export function AppointmentsContainer() {
         </Stack>
 
         <Typography variant="body2" color="text.secondary">{t('appointments.dragHint')}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {selectedSpecialist
+            ? `Displayed in your timezone: ${displayTimeZone}. Specialist timezone: ${selectedSpecialist.timezone}.`
+            : `Displayed in your timezone: ${displayTimeZone}.`}
+        </Typography>
 
         <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 2, overflowX: 'auto' }}>
           <Box sx={{ display: 'grid', gridTemplateColumns: `72px repeat(${visibleDays.length}, minmax(180px, 1fr))`, minWidth: viewMode === 'week' ? 1100 : 560 }}>
@@ -371,13 +527,13 @@ export function AppointmentsContainer() {
                   borderRight: 1,
                   borderColor: 'divider',
                   p: 1,
-                  bgcolor: sameDay(day, new Date()) ? 'action.selected' : 'background.default',
+                  bgcolor: getGridDayKey(day) === toDateKeyInTimezone(new Date(), displayTimeZone) ? 'action.selected' : 'background.default',
                 }}
               >
                 <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                  {day.toLocaleDateString(undefined, { weekday: 'short' })}
+                  {formatDateInTimezone(day, displayTimeZone, { weekday: 'short' })}
                 </Typography>
-                <Typography variant="caption" color="text.secondary">{day.toLocaleDateString()}</Typography>
+                <Typography variant="caption" color="text.secondary">{formatDateInTimezone(day, displayTimeZone)}</Typography>
               </Box>
             ))}
 
@@ -397,9 +553,10 @@ export function AppointmentsContainer() {
                 </Box>
 
                 {visibleDays.map((day) => {
-                  const slotDate = atHour(day, hour);
-                  const key = `${startOfDay(day).toISOString()}:${hour}`;
+                  const dayKey = getGridDayKey(day);
+                  const key = `${dayKey}:${hour}`;
                   const items = appointmentsByCell.get(key) ?? [];
+                  const externalBusy = busySlotsByCell.get(key) ?? [];
 
                   return (
                     <Box
@@ -421,12 +578,21 @@ export function AppointmentsContainer() {
                         const id = Number(rawId);
 
                         if (!Number.isNaN(id)) {
-                          void moveAppointment(id, slotDate);
+                          void moveAppointment(id, dayKey, hour);
                         }
                       }}
-                      onDoubleClick={() => openCreate(slotDate)}
+                      onDoubleClick={() => openCreate(dayKey, hour)}
                     >
                       <Stack spacing={0.5}>
+                        {externalBusy.map((slot) => (
+                          <Chip
+                            key={`${slot.specialistId}-${slot.scheduledAt}-${slot.source}`}
+                            size="small"
+                            label="Busy (Google)"
+                            color="warning"
+                            variant="outlined"
+                          />
+                        ))}
                         {items.map((item) => (
                           <Box
                             key={item.id}
@@ -444,7 +610,7 @@ export function AppointmentsContainer() {
                             }}
                           >
                             <Typography variant="caption" sx={{ fontWeight: 600, display: 'block' }}>
-                              {new Date(item.scheduledAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                              {formatTimeInTimezone(item.scheduledAt, displayTimeZone)}
                             </Typography>
                             <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                               {statusLabel(item.status)}
@@ -460,7 +626,7 @@ export function AppointmentsContainer() {
           </Box>
         </Box>
 
-        <Button onClick={() => openCreate(atHour(visibleDays[0], 9))} variant="outlined" size="small" sx={{ alignSelf: 'flex-start' }}>
+        <Button onClick={() => openCreate(getGridDayKey(visibleDays[0]), 9)} variant="outlined" size="small" sx={{ alignSelf: 'flex-start' }}>
           {t('appointments.create')}
         </Button>
 

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -38,6 +38,7 @@ export type AppointmentStatus = 'new' | 'confirmed' | 'cancelled';
 export type SpecialistItem = {
   id: number;
   name: string;
+  timezone: string;
 };
 
 export type AppointmentItem = {
@@ -52,4 +53,10 @@ export type AppointmentItem = {
 export type AppointmentListResponse = {
   appointments: AppointmentItem[];
   specialists: SpecialistItem[];
+  busySlots: Array<{
+    specialistId: number;
+    scheduledAt: string;
+    durationMin: number;
+    source: 'google';
+  }>;
 };


### PR DESCRIPTION
### Motivation

- Ensure appointments are synchronized with external calendars (Google) including rescheduling, and avoid offering slots that conflict with external calendar events.

### Description

- Introduced a bot-side `calendar-sync.service` and replaced direct `createGoogleCalendarEvents` usage with `syncAppointmentsToExternalCalendars`, and added `syncAppointmentRescheduledInExternalCalendars` when appointments are rescheduled from the bot.
- Extended `google-calendar.service` to attach `extendedProperties` (`appointmentId`) to created events and added `findEventIdByAppointmentId` plus `rescheduleGoogleCalendarEvent` to locate and patch existing events.
- Added server-side `calendarAvailabilityService` (`listExternalBusySlots`) and updated `specialistRepository` to expose timezones and calendar credentials via `findSpecialistsCalendarCredentials`, and enhanced `getAppointments` to return `busySlots` and include specialist `timezone` in the UI model.
- Updated web UI `AppointmentsContainer` and API types to be timezone-aware for datetime-local handling, to fetch and display external `busySlots`, and to show busy indicators and correct scheduling/rescheduling behavior respecting viewer timezone.

### Testing

- Ran unit tests for calendar integration and slots with `vitest`, including `google-calendar.service.test.ts` (added reschedule test) and `slot.service.test.ts` after adapting mocks to the new `calendar-sync.service`, and the tests passed.
- Verified the updated appointment list endpoint returns `busySlots` in integration with the new `calendarAvailabilityService` during automated test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77b17a26c83339e3be37df6f16f54)