### PR TITLE
Move schedule settings to specialists; add per-specialist slot step and appointment durations

### DIFF
--- a/bot/src/repositories/specialist.repository.ts
+++ b/bot/src/repositories/specialist.repository.ts
@@ -5,6 +5,11 @@ type SpecialistCalendarCredentialsRow = {
   google_calendar_id: string | null;
 };
 
+const DEFAULT_WORK_START_HOUR = 9;
+const DEFAULT_WORK_END_HOUR = 20;
+const DEFAULT_SLOT_DURATION_MIN = 90;
+const DEFAULT_SLOT_STEP_MIN = 30;
+
 export async function findActiveSpecialists(accountId: number) {
   return db('specialists')
     .where({ account_id: accountId, is_active: true })
@@ -46,4 +51,29 @@ export async function findSpecialistCalendarCredentials(accountId: number, speci
     );
 
   return row ?? null;
+}
+
+type SpecialistScheduleRow = {
+  work_start_hour: number | null;
+  work_end_hour: number | null;
+  slot_duration_min: number | null;
+  slot_step_min: number | null;
+};
+
+export async function findSpecialistScheduleSettings(accountId: number, specialistId: number) {
+  const row = await db('specialists')
+    .where({ account_id: accountId, id: specialistId })
+    .first<SpecialistScheduleRow>(
+      'work_start_hour',
+      'work_end_hour',
+      'slot_duration_min',
+      'slot_step_min',
+    );
+
+  return {
+    workStartHour: row?.work_start_hour ?? DEFAULT_WORK_START_HOUR,
+    workEndHour: row?.work_end_hour ?? DEFAULT_WORK_END_HOUR,
+    slotDurationMin: row?.slot_duration_min ?? DEFAULT_SLOT_DURATION_MIN,
+    slotStepMin: row?.slot_step_min ?? DEFAULT_SLOT_STEP_MIN,
+  };
 }

--- a/bot/src/services/slot.service.ts
+++ b/bot/src/services/slot.service.ts
@@ -1,20 +1,21 @@
 import { findBusyAppointmentsByDate } from '../repositories/appointment.repository';
 import { getAppSettings } from '../repositories/app-settings.repository';
 import { findServiceById } from '../repositories/service.repository';
+import { findSpecialistScheduleSettings } from '../repositories/specialist.repository';
 import { getBusyIntervalsFromExternalCalendars } from './calendar-sync.service';
 
-const SLOT_STEP_MIN = 30;
 const MINUTES_IN_DAY = 24 * 60;
 
-function buildDaySlots(durationMin: number, workStartHour: number, workEndHour: number) {
+function buildDaySlots(durationMin: number, workStartHour: number, workEndHour: number, slotStepMin: number) {
   const startMinutes = workStartHour * 60;
   const endMinutes = workEndHour * 60;
+  const step = slotStepMin > 0 ? slotStepMin : 30;
   const slots: string[] = [];
 
   for (
     let minute = startMinutes;
     minute + durationMin <= endMinutes;
-    minute += SLOT_STEP_MIN
+    minute += step
   ) {
     const hours = String(Math.floor(minute / 60)).padStart(2, '0');
     const mins = String(minute % 60).padStart(2, '0');
@@ -46,10 +47,16 @@ export async function getAvailableSlots(params: {
   serviceId: number;
 }) {
   const service = await findServiceById(params.accountId, params.serviceId);
+  const specialistSettings = await findSpecialistScheduleSettings(params.accountId, params.specialistId);
   const settings = await getAppSettings(params.accountId);
-  const durationMin = service?.duration_min ?? 90;
+  const durationMin = service?.duration_min ?? specialistSettings.slotDurationMin;
 
-  const allSlots = buildDaySlots(durationMin, settings.workStartHour, settings.workEndHour);
+  const allSlots = buildDaySlots(
+    durationMin,
+    specialistSettings.workStartHour,
+    specialistSettings.workEndHour,
+    specialistSettings.slotStepMin,
+  );
   const busyAppointments = await findBusyAppointmentsByDate(
     params.accountId,
     params.date,

--- a/bot/src/services/tests/slot.service.test.ts
+++ b/bot/src/services/tests/slot.service.test.ts
@@ -12,6 +12,12 @@ vi.mock('../../repositories/app-settings.repository', () => {
   };
 });
 
+vi.mock('../../repositories/specialist.repository', () => {
+  return {
+    findSpecialistScheduleSettings: vi.fn(),
+  };
+});
+
 vi.mock('../../repositories/service.repository', () => {
   return {
     findServiceById: vi.fn(),
@@ -27,6 +33,7 @@ vi.mock('../calendar-sync.service', () => {
 import { findBusyAppointmentsByDate } from '../../repositories/appointment.repository';
 import { getAppSettings } from '../../repositories/app-settings.repository';
 import { findServiceById } from '../../repositories/service.repository';
+import { findSpecialistScheduleSettings } from '../../repositories/specialist.repository';
 import { getBusyIntervalsFromExternalCalendars } from '../calendar-sync.service';
 import { getAvailableSlots } from '../slot.service';
 
@@ -41,10 +48,13 @@ describe('getAvailableSlots', () => {
 
   it('filters out overlapping slots for appointments on the same day', async () => {
     vi.mocked(findServiceById).mockResolvedValue({ duration_min: 60 } as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 9,
       workEndHour: 12,
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       { date: '2026-04-18', time: '10:00', durationMin: 60 },
     ] as any);
@@ -62,10 +72,13 @@ describe('getAvailableSlots', () => {
 
   it('does not treat touching intervals as overlap (slot starts when appointment ends)', async () => {
     vi.mocked(findServiceById).mockResolvedValue({ duration_min: 60 } as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 9,
       workEndHour: 12,
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       { date: '2026-04-18', time: '09:00', durationMin: 60 },
     ] as any);
@@ -83,10 +96,13 @@ describe('getAvailableSlots', () => {
 
   it('filters out slots overlapped by an appointment starting the previous day (cross-midnight)', async () => {
     vi.mocked(findServiceById).mockResolvedValue({ duration_min: 60 } as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 0,
       workEndHour: 2,
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       // 23:30-01:30 overlaps the next day 00:00-02:00 work window
       { date: '2026-04-17', time: '23:30', durationMin: 120 },
@@ -105,10 +121,13 @@ describe('getAvailableSlots', () => {
 
   it('uses default duration when service is missing', async () => {
     vi.mocked(findServiceById).mockResolvedValue(null as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 9,
       workEndHour: 12,
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
     vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
@@ -125,10 +144,13 @@ describe('getAvailableSlots', () => {
 
   it('returns no slots when duration exceeds the work window', async () => {
     vi.mocked(findServiceById).mockResolvedValue({ duration_min: 180 } as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 9,
       workEndHour: 11,
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
     vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
 
@@ -144,10 +166,13 @@ describe('getAvailableSlots', () => {
 
   it('does not exclude slots due to appointments on other days that do not overlap', async () => {
     vi.mocked(findServiceById).mockResolvedValue({ duration_min: 60 } as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 9,
       workEndHour: 12,
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([
       { date: '2026-04-19', time: '09:00', durationMin: 60 },
     ] as any);
@@ -165,11 +190,13 @@ describe('getAvailableSlots', () => {
 
   it('filters slots by Google Calendar busy intervals as well', async () => {
     vi.mocked(findServiceById).mockResolvedValue({ duration_min: 60 } as any);
-    vi.mocked(getAppSettings).mockResolvedValue({
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
       workStartHour: 9,
       workEndHour: 12,
-      timezone: 'Europe/Moscow',
+      slotDurationMin: 90,
+      slotStepMin: 30,
     } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
     vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
     vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([
       { date: '2026-04-18', time: '10:00', durationMin: 60 },
@@ -183,5 +210,27 @@ describe('getAvailableSlots', () => {
     });
 
     expect(slots).toEqual(['09:00', '11:00']);
+  });
+
+  it('uses specialist slot step for time picker interval', async () => {
+    vi.mocked(findServiceById).mockResolvedValue({ duration_min: 60 } as any);
+    vi.mocked(findSpecialistScheduleSettings).mockResolvedValue({
+      workStartHour: 9,
+      workEndHour: 12,
+      slotDurationMin: 90,
+      slotStepMin: 60,
+    } as any);
+    vi.mocked(getAppSettings).mockResolvedValue({ timezone: 'Europe/Moscow' } as any);
+    vi.mocked(findBusyAppointmentsByDate).mockResolvedValue([] as any);
+    vi.mocked(getBusyIntervalsFromExternalCalendars).mockResolvedValue([] as any);
+
+    const slots = await getAvailableSlots({
+      accountId: 7,
+      date: '2026-04-18',
+      specialistId: 1,
+      serviceId: 1,
+    });
+
+    expect(slots).toEqual(['09:00', '10:00', '11:00']);
   });
 });

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -77,6 +77,7 @@ const appointmentStatusSchema = z.enum(['new', 'confirmed', 'cancelled']);
 export const appointmentCreateSchema = z.object({
   specialistId: z.coerce.number().int().positive('Укажите специалиста'),
   scheduledAt: z.string().datetime('Укажите корректную дату и время'),
+  durationMin: z.coerce.number().int().min(15, 'Минимальная длительность — 15 минут').max(480, 'Максимальная длительность — 480 минут').optional(),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url('Укажите корректную ссылку').max(2048).optional().or(z.literal('')),
   notes: z.string().trim().max(2000, 'Комментарий слишком длинный').optional(),
@@ -84,6 +85,7 @@ export const appointmentCreateSchema = z.object({
 
 export const appointmentUpdateSchema = z.object({
   scheduledAt: z.string().datetime('Укажите корректную дату и время').optional(),
+  durationMin: z.coerce.number().int().min(15, 'Минимальная длительность — 15 минут').max(480, 'Максимальная длительность — 480 минут').optional(),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url('Укажите корректную ссылку').max(2048).optional().or(z.literal('')),
   notes: z.string().trim().max(2000, 'Комментарий слишком длинный').optional(),

--- a/server/src/db/migrations/20260422103000_move_schedule_settings_to_specialists.ts
+++ b/server/src/db/migrations/20260422103000_move_schedule_settings_to_specialists.ts
@@ -1,0 +1,95 @@
+import type { Knex } from 'knex';
+
+const SPECIALISTS_TABLE = 'specialists';
+const APP_SETTINGS_TABLE = 'app_settings';
+
+const DEFAULT_WORK_START_HOUR = 9;
+const DEFAULT_WORK_END_HOUR = 20;
+const DEFAULT_SLOT_DURATION_MIN = 90;
+const DEFAULT_SLOT_STEP_MIN = 30;
+
+export async function up(knex: Knex): Promise<void> {
+  const hasSpecialists = await knex.schema.hasTable(SPECIALISTS_TABLE);
+  if (!hasSpecialists) {
+    return;
+  }
+
+  const hasWorkStartHour = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'work_start_hour');
+  const hasWorkEndHour = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'work_end_hour');
+  const hasSlotDurationMin = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'slot_duration_min');
+  const hasSlotStepMin = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'slot_step_min');
+
+  await knex.schema.alterTable(SPECIALISTS_TABLE, (table) => {
+    if (!hasWorkStartHour) {
+      table.integer('work_start_hour').notNullable().defaultTo(DEFAULT_WORK_START_HOUR);
+    }
+
+    if (!hasWorkEndHour) {
+      table.integer('work_end_hour').notNullable().defaultTo(DEFAULT_WORK_END_HOUR);
+    }
+
+    if (!hasSlotDurationMin) {
+      table.integer('slot_duration_min').notNullable().defaultTo(DEFAULT_SLOT_DURATION_MIN);
+    }
+
+    if (!hasSlotStepMin) {
+      table.integer('slot_step_min').notNullable().defaultTo(DEFAULT_SLOT_STEP_MIN);
+    }
+  });
+
+  const hasAppSettings = await knex.schema.hasTable(APP_SETTINGS_TABLE);
+  if (!hasAppSettings) {
+    return;
+  }
+
+  await knex.raw(
+    `
+      UPDATE specialists AS s
+      SET
+        work_start_hour = COALESCE(a.work_start_hour, ?),
+        work_end_hour = COALESCE(a.work_end_hour, ?),
+        slot_duration_min = COALESCE(a.slot_duration_min, ?)
+      FROM (
+        SELECT DISTINCT ON (account_id)
+          account_id,
+          work_start_hour,
+          work_end_hour,
+          slot_duration_min
+        FROM app_settings
+        ORDER BY account_id, id ASC
+      ) AS a
+      WHERE a.account_id = s.account_id
+    `,
+    [DEFAULT_WORK_START_HOUR, DEFAULT_WORK_END_HOUR, DEFAULT_SLOT_DURATION_MIN],
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasSpecialists = await knex.schema.hasTable(SPECIALISTS_TABLE);
+  if (!hasSpecialists) {
+    return;
+  }
+
+  const hasWorkStartHour = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'work_start_hour');
+  const hasWorkEndHour = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'work_end_hour');
+  const hasSlotDurationMin = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'slot_duration_min');
+  const hasSlotStepMin = await knex.schema.hasColumn(SPECIALISTS_TABLE, 'slot_step_min');
+
+  await knex.schema.alterTable(SPECIALISTS_TABLE, (table) => {
+    if (hasWorkStartHour) {
+      table.dropColumn('work_start_hour');
+    }
+
+    if (hasWorkEndHour) {
+      table.dropColumn('work_end_hour');
+    }
+
+    if (hasSlotDurationMin) {
+      table.dropColumn('slot_duration_min');
+    }
+
+    if (hasSlotStepMin) {
+      table.dropColumn('slot_step_min');
+    }
+  });
+}

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -40,6 +40,7 @@ type UpdateAppointmentInput = {
   scheduledAt?: Date;
   status?: AppointmentStatus;
   notes?: string | null;
+  durationMin?: number;
 };
 
 export async function listAppointments(filters: AppointmentListFilters): Promise<AppointmentRecord[]> {
@@ -106,6 +107,10 @@ export async function updateAppointment(input: UpdateAppointmentInput): Promise<
 
   if (Object.prototype.hasOwnProperty.call(input, 'notes')) {
     payload.comment = input.notes;
+  }
+
+  if (input.durationMin !== undefined) {
+    payload.duration_min = input.durationMin;
   }
 
   const [row] = await db('appointments')

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -55,6 +55,7 @@ export type SpecialistRecord = {
   is_active: boolean;
   user_id: number | null;
   timezone: string;
+  slot_step_min: number | null;
 };
 
 export type SpecialistCalendarCredentials = {
@@ -85,6 +86,7 @@ export async function listSpecialistsByAccount(accountId: number): Promise<Speci
       's.name',
       's.is_active',
       's.user_id',
+      's.slot_step_min',
       db.raw("COALESCE(wu.timezone, 'UTC') as timezone"),
     );
 }

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -23,6 +23,7 @@ type AppointmentDto = {
   id: number;
   specialistId: number;
   scheduledAt: string;
+  durationMin: number;
   status: AppointmentStatus;
   meetingLink: string;
   notes: string;
@@ -30,13 +31,14 @@ type AppointmentDto = {
 
 type AppointmentListResult = {
   appointments: AppointmentDto[];
-  specialists: Array<{ id: number; name: string; timezone: string }>;
+  specialists: Array<{ id: number; name: string; timezone: string; slotStepMin: number }>;
   busySlots: ExternalBusySlot[];
 };
 
 type CreateAppointmentPayload = {
   specialistId: number;
   scheduledAt: string;
+  durationMin?: number;
   status?: AppointmentStatus;
   meetingLink?: string;
   notes?: string;
@@ -44,6 +46,7 @@ type CreateAppointmentPayload = {
 
 type UpdateAppointmentPayload = {
   scheduledAt?: string;
+  durationMin?: number;
   status?: AppointmentStatus;
   meetingLink?: string;
   notes?: string;
@@ -93,6 +96,7 @@ function mapAppointment(row: AppointmentRecord): AppointmentDto {
     id: row.id,
     specialistId: row.specialist_id,
     scheduledAt: row.appointment_at.toISOString(),
+    durationMin: row.duration_min,
     status: row.status,
     notes: parsed.notes,
     meetingLink: parsed.meetingLink,
@@ -125,6 +129,7 @@ function mapSpecialistsForUi(rows: SpecialistRecord[]) {
     id: item.id,
     name: item.name,
     timezone: item.timezone || 'UTC',
+    slotStepMin: item.slot_step_min ?? 30,
   }));
 }
 
@@ -201,7 +206,7 @@ export async function createAppointmentForActor(
     notes: composeNotes(payload.meetingLink, payload.notes),
     userId,
     serviceId,
-    durationMin: 60,
+    durationMin: payload.durationMin ?? 30,
   });
 
   return mapAppointment(created);
@@ -230,6 +235,7 @@ export async function updateAppointmentForActor(
     accountId,
     id: appointmentId,
     scheduledAt: payload.scheduledAt ? new Date(payload.scheduledAt) : undefined,
+    durationMin: payload.durationMin,
     status: payload.status,
     notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink')
       ? composeNotes(payload.meetingLink, payload.notes)

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   Box,
   Button,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -11,7 +12,6 @@ import {
   MenuItem,
   Select,
   Stack,
-  Chip,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
@@ -21,13 +21,14 @@ import { Controller, useForm } from 'react-hook-form';
 import { apiClient, authHeaders } from '../shared/api/client';
 import { useAuth } from '../shared/auth/AuthContext';
 import { useI18n } from '../shared/i18n/I18nContext';
-import { AppPage } from '../shared/ui/AppPage';
-import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import type { AppointmentItem, AppointmentListResponse, AppointmentStatus, SpecialistItem } from '../shared/types/api';
 import { WebUserRole } from '../shared/types/roles';
+import { AppPage } from '../shared/ui/AppPage';
+import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type EditFormState = {
-  scheduledAt: string;
+  startAt: string;
+  endAt: string;
   status: AppointmentStatus;
   meetingLink: string;
   notes: string;
@@ -36,7 +37,8 @@ type EditFormState = {
 type CalendarViewMode = 'day' | 'week';
 
 const STATUS_OPTIONS: AppointmentStatus[] = ['new', 'confirmed', 'cancelled'];
-const HOURS = Array.from({ length: 24 }, (_, index) => index);
+const DEFAULT_SLOT_STEP_MIN = 30;
+const SLOT_ROWS = Array.from({ length: 48 }, (_, index) => index * 30);
 const BROWSER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 
 function getDateTimeParts(date: Date, timeZone: string) {
@@ -105,13 +107,26 @@ function toDateKeyInTimezone(date: Date, timeZone: string): string {
   return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`;
 }
 
-function toHourInTimezone(date: Date, timeZone: string): number {
-  return getDateTimeParts(date, timeZone).hour;
+function toTimeKeyInTimezone(date: Date, timeZone: string): string {
+  const parts = getDateTimeParts(date, timeZone);
+  return `${String(parts.hour).padStart(2, '0')}:${String(parts.minute).padStart(2, '0')}`;
 }
 
 function createDatetimeLocal(dateKey: string, hour: number, minute = 0): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${dateKey}T${pad(hour)}:${pad(minute)}`;
+}
+
+function addMinutesToDatetimeLocal(value: string, minutesToAdd: number, timeZone: string): string {
+  const iso = fromDatetimeLocal(value, timeZone);
+  return toDatetimeLocal(new Date(new Date(iso).getTime() + minutesToAdd * 60_000).toISOString(), timeZone);
+}
+
+function diffMinutesBetweenLocalDateTimes(startValue: string, endValue: string, timeZone: string): number {
+  const startIso = fromDatetimeLocal(startValue, timeZone);
+  const endIso = fromDatetimeLocal(endValue, timeZone);
+  const diffMs = new Date(endIso).getTime() - new Date(startIso).getTime();
+  return Math.round(diffMs / 60_000);
 }
 
 function getUtcNowByTimeZone(timeZone: string): Date {
@@ -131,12 +146,6 @@ function formatLocalTime(iso: string): string {
     hour: '2-digit',
     minute: '2-digit',
   });
-}
-
-function toLocalDateKey(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0');
-
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 }
 
 function statusLabel(status: AppointmentStatus): string {
@@ -181,21 +190,36 @@ export function AppointmentsContainer() {
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<AppointmentItem | null>(null);
-  const initialFormValues: EditFormState = {
-    scheduledAt: toDatetimeLocal(new Date().toISOString(), displayTimeZone),
-    status: 'new',
-    meetingLink: '',
-    notes: '',
-  };
-
-  const { control, handleSubmit, reset } = useForm<EditFormState>({
-    defaultValues: initialFormValues,
-  });
 
   const canManageAll = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin;
   const selectedSpecialist = selectedSpecialistId === 'all'
     ? null
     : specialists.find((item) => item.id === selectedSpecialistId) ?? null;
+  const selectedSlotStepMin = selectedSpecialist?.slotStepMin ?? DEFAULT_SLOT_STEP_MIN;
+
+  const initialStartAt = toDatetimeLocal(new Date().toISOString(), displayTimeZone);
+  const initialFormValues: EditFormState = {
+    startAt: initialStartAt,
+    endAt: addMinutesToDatetimeLocal(initialStartAt, selectedSlotStepMin, displayTimeZone),
+    status: 'new',
+    meetingLink: '',
+    notes: '',
+  };
+
+  const { control, handleSubmit, reset, watch, setValue } = useForm<EditFormState>({
+    defaultValues: initialFormValues,
+  });
+
+  const startAtValue = watch('startAt');
+
+  useEffect(() => {
+    if (!isCreateOpen || editingItem) {
+      return;
+    }
+
+    const nextEnd = addMinutesToDatetimeLocal(startAtValue, selectedSlotStepMin, displayTimeZone);
+    setValue('endAt', nextEnd, { shouldDirty: true });
+  }, [displayTimeZone, editingItem, isCreateOpen, selectedSlotStepMin, setValue, startAtValue]);
 
   const visibleDays = useMemo(() => {
     if (viewMode === 'day') {
@@ -212,7 +236,7 @@ export function AppointmentsContainer() {
     for (const item of appointments) {
       const date = new Date(item.scheduledAt);
       const dayKey = toDateKeyInTimezone(date, displayTimeZone);
-      const key = `${dayKey}:${toHourInTimezone(date, displayTimeZone)}`;
+      const key = `${dayKey}:${toTimeKeyInTimezone(date, displayTimeZone)}`;
       const list = map.get(key) ?? [];
       list.push(item);
       map.set(key, list);
@@ -231,7 +255,7 @@ export function AppointmentsContainer() {
     for (const slot of busySlots) {
       const date = new Date(slot.scheduledAt);
       const dayKey = toDateKeyInTimezone(date, displayTimeZone);
-      const key = `${dayKey}:${toHourInTimezone(date, displayTimeZone)}`;
+      const key = `${dayKey}:${toTimeKeyInTimezone(date, displayTimeZone)}`;
       const list = map.get(key) ?? [];
       list.push(slot);
       map.set(key, list);
@@ -292,7 +316,7 @@ export function AppointmentsContainer() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessToken, focusDate, viewMode, selectedSpecialistId]);
 
-  const openCreate = (targetDateKey: string, hour: number) => {
+  const openCreate = (targetDateKey: string, hour: number, minute = 0) => {
     const specialistId = selectedSpecialistId === 'all'
       ? specialists[0]?.id
       : selectedSpecialistId;
@@ -302,8 +326,11 @@ export function AppointmentsContainer() {
       return;
     }
 
+    const startAt = createDatetimeLocal(targetDateKey, hour, minute);
+
     reset({
-      scheduledAt: createDatetimeLocal(targetDateKey, hour),
+      startAt,
+      endAt: addMinutesToDatetimeLocal(startAt, selectedSlotStepMin, displayTimeZone),
       status: 'new',
       meetingLink: '',
       notes: '',
@@ -326,10 +353,16 @@ export function AppointmentsContainer() {
       return;
     }
 
+    const durationMin = Math.max(
+      selectedSlotStepMin,
+      diffMinutesBetweenLocalDateTimes(form.startAt, form.endAt, displayTimeZone),
+    );
+
     try {
       if (editingItem) {
         await apiClient.patch(`/api/appointments/${editingItem.id}`, {
-          scheduledAt: fromDatetimeLocal(form.scheduledAt, displayTimeZone),
+          scheduledAt: fromDatetimeLocal(form.startAt, displayTimeZone),
+          durationMin,
           status: form.status,
           meetingLink: form.meetingLink,
           notes: form.notes,
@@ -339,7 +372,8 @@ export function AppointmentsContainer() {
       } else {
         await apiClient.post('/api/appointments', {
           specialistId,
-          scheduledAt: fromDatetimeLocal(form.scheduledAt, displayTimeZone),
+          scheduledAt: fromDatetimeLocal(form.startAt, displayTimeZone),
+          durationMin,
           status: form.status,
           meetingLink: form.meetingLink,
           notes: form.notes,
@@ -356,9 +390,12 @@ export function AppointmentsContainer() {
   };
 
   const openEdit = (item: AppointmentItem) => {
+    const startAt = toDatetimeLocal(item.scheduledAt, displayTimeZone);
+
     setEditingItem(item);
     reset({
-      scheduledAt: toDatetimeLocal(item.scheduledAt, displayTimeZone),
+      startAt,
+      endAt: addMinutesToDatetimeLocal(startAt, item.durationMin || selectedSlotStepMin, displayTimeZone),
       status: item.status,
       meetingLink: item.meetingLink,
       notes: item.notes,
@@ -383,7 +420,7 @@ export function AppointmentsContainer() {
     }
   };
 
-  const moveAppointment = async (appointmentId: number, targetDayKey: string, targetHour: number) => {
+  const moveAppointment = async (appointmentId: number, targetDayKey: string, targetHour: number, targetMinute: number) => {
     if (!accessToken) {
       return;
     }
@@ -394,10 +431,8 @@ export function AppointmentsContainer() {
       return;
     }
 
-    const sourceDate = new Date(current.scheduledAt);
-    const sourceMinute = sourceDate.getMinutes();
     const nextIso = fromDatetimeLocal(
-      createDatetimeLocal(targetDayKey, targetHour, sourceMinute),
+      createDatetimeLocal(targetDayKey, targetHour, targetMinute),
       displayTimeZone,
     );
 
@@ -413,10 +448,6 @@ export function AppointmentsContainer() {
     } catch {
       setError('Unable to reschedule appointment');
     }
-  };
-
-  const onSpecialistChange = (value: number | 'all') => {
-    setSelectedSpecialistId(value);
   };
 
   const movePeriod = (direction: -1 | 1) => {
@@ -445,7 +476,7 @@ export function AppointmentsContainer() {
               value={selectedSpecialistId}
               onChange={(event) => {
                 const raw = event.target.value;
-                void onSpecialistChange(raw === 'all' ? 'all' : Number(raw));
+                setSelectedSpecialistId(raw === 'all' ? 'all' : Number(raw));
               }}
             >
               <MenuItem value="all">{t('appointments.allSpecialists')}</MenuItem>
@@ -493,8 +524,8 @@ export function AppointmentsContainer() {
         <Typography variant="body2" color="text.secondary">{t('appointments.dragHint')}</Typography>
         <Typography variant="caption" color="text.secondary">
           {selectedSpecialist
-            ? `Displayed in your browser timezone: ${BROWSER_TIMEZONE}. Specialist timezone: ${selectedSpecialist.timezone}.`
-            : `Displayed in your browser timezone: ${BROWSER_TIMEZONE}.`}
+            ? `Displayed in your browser timezone: ${BROWSER_TIMEZONE}. Specialist timezone: ${selectedSpecialist.timezone}. Slot step: ${selectedSlotStepMin} min.`
+            : `Displayed in your browser timezone: ${BROWSER_TIMEZONE}. Slot step: ${DEFAULT_SLOT_STEP_MIN} min.`}
         </Typography>
 
         <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 2, overflowX: 'auto' }}>
@@ -517,96 +548,111 @@ export function AppointmentsContainer() {
               </Box>
             ))}
 
-            {HOURS.map((hour) => (
-              <Fragment key={`row-${hour}`}>
-                <Box
-                  sx={{
-                    borderTop: 1,
-                    borderRight: 1,
-                    borderColor: 'divider',
-                    px: 1,
-                    py: 1.5,
-                    bgcolor: 'background.default',
-                  }}
-                >
-                  <Typography variant="caption" color="text.secondary">{`${String(hour).padStart(2, '0')}:00`}</Typography>
-                </Box>
+            {SLOT_ROWS.map((totalMinute) => {
+              const hour = Math.floor(totalMinute / 60);
+              const minute = totalMinute % 60;
 
-                {visibleDays.map((day) => {
-                  const dayKey = getGridDayKey(day);
-                  const key = `${dayKey}:${hour}`;
-                  const items = appointmentsByCell.get(key) ?? [];
-                  const externalBusy = busySlotsByCell.get(key) ?? [];
+              return (
+                <Fragment key={`row-${hour}-${minute}`}>
+                  <Box
+                    sx={{
+                      borderTop: 1,
+                      borderRight: 1,
+                      borderColor: 'divider',
+                      px: 1,
+                      py: 1,
+                      bgcolor: 'background.default',
+                    }}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`}
+                    </Typography>
+                  </Box>
 
-                  return (
-                    <Box
-                      key={`${key}-cell`}
-                      sx={{
-                        borderTop: 1,
-                        borderRight: 1,
-                        borderColor: 'divider',
-                        minHeight: 76,
-                        p: 0.5,
-                        bgcolor: 'background.paper',
-                      }}
-                      onDragOver={(event) => {
-                        event.preventDefault();
-                      }}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        const rawId = event.dataTransfer.getData('text/appointment-id');
-                        const id = Number(rawId);
+                  {visibleDays.map((day) => {
+                    const dayKey = getGridDayKey(day);
+                    const timeKey = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+                    const key = `${dayKey}:${timeKey}`;
+                    const items = appointmentsByCell.get(key) ?? [];
+                    const externalBusy = busySlotsByCell.get(key) ?? [];
 
-                        if (!Number.isNaN(id)) {
-                          void moveAppointment(id, dayKey, hour);
-                        }
-                      }}
-                      onDoubleClick={() => openCreate(dayKey, hour)}
-                    >
-                      <Stack spacing={0.5}>
-                        {externalBusy.map((slot) => (
-                          <Chip
-                            key={`${slot.specialistId}-${slot.scheduledAt}-${slot.source}`}
-                            size="small"
-                            label="Busy (Google)"
-                            color="warning"
-                            variant="outlined"
-                          />
-                        ))}
-                        {items.map((item) => (
-                          <Box
-                            key={item.id}
-                            draggable
-                            onDragStart={(event) => event.dataTransfer.setData('text/appointment-id', String(item.id))}
-                            onClick={() => openEdit(item)}
-                            sx={{
-                              borderRadius: 1,
-                              border: 1,
-                              borderColor: item.status === 'cancelled' ? 'error.main' : 'primary.light',
-                              bgcolor: item.status === 'cancelled' ? 'rgba(211, 47, 47, 0.08)' : 'rgba(25, 118, 210, 0.08)',
-                              px: 0.75,
-                              py: 0.5,
-                              cursor: 'pointer',
-                            }}
-                          >
-                            <Typography variant="caption" sx={{ fontWeight: 600, display: 'block' }}>
-                              {formatLocalTime(item.scheduledAt)}
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                              {statusLabel(item.status)}
-                            </Typography>
-                          </Box>
-                        ))}
-                      </Stack>
-                    </Box>
-                  );
-                })}
-              </Fragment>
-            ))}
+                    return (
+                      <Box
+                        key={`${key}-cell`}
+                        sx={{
+                          borderTop: 1,
+                          borderRight: 1,
+                          borderColor: 'divider',
+                          minHeight: 36,
+                          p: 0.5,
+                          bgcolor: 'background.paper',
+                          transition: 'background-color 0.15s ease',
+                          '&:hover': {
+                            bgcolor: 'action.hover',
+                          },
+                        }}
+                        onDragOver={(event) => {
+                          event.preventDefault();
+                        }}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          const rawId = event.dataTransfer.getData('text/appointment-id');
+                          const id = Number(rawId);
+
+                          if (!Number.isNaN(id)) {
+                            void moveAppointment(id, dayKey, hour, minute);
+                          }
+                        }}
+                        onClick={() => openCreate(dayKey, hour, minute)}
+                      >
+                        <Stack spacing={0.5}>
+                          {externalBusy.map((slot) => (
+                            <Chip
+                              key={`${slot.specialistId}-${slot.scheduledAt}-${slot.source}`}
+                              size="small"
+                              label="Busy (Google)"
+                              color="warning"
+                              variant="outlined"
+                            />
+                          ))}
+                          {items.map((item) => (
+                            <Box
+                              key={item.id}
+                              draggable
+                              onDragStart={(event) => event.dataTransfer.setData('text/appointment-id', String(item.id))}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                openEdit(item);
+                              }}
+                              sx={{
+                                borderRadius: 1,
+                                border: 1,
+                                borderColor: item.status === 'cancelled' ? 'error.main' : 'primary.light',
+                                bgcolor: item.status === 'cancelled' ? 'rgba(211, 47, 47, 0.08)' : 'rgba(25, 118, 210, 0.08)',
+                                px: 0.75,
+                                py: 0.5,
+                                cursor: 'pointer',
+                              }}
+                            >
+                              <Typography variant="caption" sx={{ fontWeight: 600, display: 'block' }}>
+                                {formatLocalTime(item.scheduledAt)}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                                {statusLabel(item.status)} · {item.durationMin}m
+                              </Typography>
+                            </Box>
+                          ))}
+                        </Stack>
+                      </Box>
+                    );
+                  })}
+                </Fragment>
+              );
+            })}
           </Box>
         </Box>
 
-        <Button onClick={() => openCreate(getGridDayKey(visibleDays[0]), 9)} variant="outlined" size="small" sx={{ alignSelf: 'flex-start' }}>
+        <Button onClick={() => openCreate(getGridDayKey(visibleDays[0]), 9, 0)} variant="outlined" size="small" sx={{ alignSelf: 'flex-start' }}>
           {t('appointments.create')}
         </Button>
 
@@ -618,14 +664,32 @@ export function AppointmentsContainer() {
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
             <Controller
-              name="scheduledAt"
+              name="startAt"
               control={control}
               render={({ field }: any) => (
                 <AppRhfTextField
                   field={field}
-                  label={t('appointments.fields.scheduledAt')}
+                  label="Start time"
                   type="datetime-local"
-                  slotProps={{ inputLabel: { shrink: true } }}
+                  slotProps={{
+                    inputLabel: { shrink: true },
+                    htmlInput: { step: selectedSlotStepMin * 60 },
+                  }}
+                />
+              )}
+            />
+            <Controller
+              name="endAt"
+              control={control}
+              render={({ field }: any) => (
+                <AppRhfTextField
+                  field={field}
+                  label="End time"
+                  type="datetime-local"
+                  slotProps={{
+                    inputLabel: { shrink: true },
+                    htmlInput: { step: selectedSlotStepMin * 60 },
+                  }}
                 />
               )}
             />

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -39,12 +39,14 @@ export type SpecialistItem = {
   id: number;
   name: string;
   timezone: string;
+  slotStepMin: number;
 };
 
 export type AppointmentItem = {
   id: number;
   specialistId: number;
   scheduledAt: string;
+  durationMin: number;
   status: AppointmentStatus;
   meetingLink: string;
   notes: string;


### PR DESCRIPTION
### Motivation

- Make schedule configuration per-specialist instead of global so specialists can have different work windows, slot durations and step intervals.
- Surface appointment duration to APIs and UI to allow creating and editing appointments with custom lengths and to use slot step for time picker/grid behavior.

### Description

- Add migration `20260422103000_move_schedule_settings_to_specialists.ts` to create `work_start_hour`, `work_end_hour`, `slot_duration_min` and `slot_step_min` columns on `specialists` and migrate values from `app_settings` with sensible defaults.  
- Backend: introduce `findSpecialistScheduleSettings` in `specialist.repository`, use specialist settings in `slot.service` to build slots (duration, work window and `slotStepMin`), expose `durationMin` in appointment APIs and persist `duration_min` on update in `appointmentRepository`, and add optional `durationMin` to create/update validation in `server/src/config/schemas.ts`.  
- API/service mapping: `appointmentService` now includes `durationMin` on DTOs, uses `payload.durationMin` when creating appointments, and maps `duration_min` from DB into responses.  
- Frontend: `AppointmentsContainer.tsx` replaces single `scheduledAt` field with `startAt`/`endAt`, computes `durationMin`, applies per-specialist `slotStepMin` to datetime-local `step` attributes, renders finer-grained time grid (`SLOT_ROWS`) and shows appointment durations, and updates drag/drop and reschedule to preserve minute precision.  
- Types: update `web/src/shared/types/api.ts` and several repository/record types to include `durationMin` and `slotStepMin` where needed.  

### Testing

- Updated unit tests `slot.service.test.ts` to mock `findSpecialistScheduleSettings` and cover per-specialist `slotStepMin` behavior, and ran the test suite for slot service which succeeded.  
- Type changes and frontend UI adjustments were validated by running the TypeScript build and unit tests, which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87a61c3bc8333b1c0a6ec7deb9159)