### PR TITLE
Support minutesStep for RHF datetime inputs (AppDateTimeField + AppRhfTextField update)

### DIFF
--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -671,10 +671,7 @@ export function AppointmentsContainer() {
                   field={field}
                   label="Start time"
                   type="datetime-local"
-                  slotProps={{
-                    inputLabel: { shrink: true },
-                    htmlInput: { step: selectedSlotStepMin * 60 },
-                  }}
+                  minutesStep={selectedSlotStepMin}
                 />
               )}
             />
@@ -686,10 +683,7 @@ export function AppointmentsContainer() {
                   field={field}
                   label="End time"
                   type="datetime-local"
-                  slotProps={{
-                    inputLabel: { shrink: true },
-                    htmlInput: { step: selectedSlotStepMin * 60 },
-                  }}
+                  minutesStep={selectedSlotStepMin}
                 />
               )}
             />

--- a/web/src/shared/ui/AppDateTimeField.tsx
+++ b/web/src/shared/ui/AppDateTimeField.tsx
@@ -1,0 +1,30 @@
+import type { TextFieldProps } from '@mui/material';
+import { AppTextField } from './AppTextField';
+
+type AppDateTimeFieldProps = Omit<TextFieldProps, 'type'> & {
+  minutesStep?: number;
+};
+
+export function AppDateTimeField({ minutesStep, slotProps, ...props }: AppDateTimeFieldProps) {
+  const htmlInputSlotProps = typeof slotProps?.htmlInput === 'object' && slotProps.htmlInput
+    ? slotProps.htmlInput
+    : {};
+
+  return (
+    <AppTextField
+      {...props}
+      type="datetime-local"
+      slotProps={{
+        ...slotProps,
+        inputLabel: {
+          ...(typeof slotProps?.inputLabel === 'object' && slotProps.inputLabel ? slotProps.inputLabel : {}),
+          shrink: true,
+        },
+        htmlInput: {
+          ...htmlInputSlotProps,
+          step: minutesStep ? minutesStep * 60 : undefined,
+        },
+      }}
+    />
+  );
+}

--- a/web/src/shared/ui/AppRhfTextField.tsx
+++ b/web/src/shared/ui/AppRhfTextField.tsx
@@ -1,6 +1,7 @@
 import type { TextFieldProps } from '@mui/material';
 import type { ChangeEvent } from 'react';
 import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
+import { AppDateTimeField } from './AppDateTimeField';
 import { AppTextField } from './AppTextField';
 
 type AppRhfTextFieldProps<TFieldValues extends FieldValues> = Omit<
@@ -10,12 +11,14 @@ type AppRhfTextFieldProps<TFieldValues extends FieldValues> = Omit<
   field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>;
   parseValue?: (value: string) => unknown;
   onValueChange?: (value: string) => void;
+  minutesStep?: number;
 };
 
 export function AppRhfTextField<TFieldValues extends FieldValues>({
   field,
   parseValue,
   onValueChange,
+  minutesStep,
   ...props
 }: AppRhfTextFieldProps<TFieldValues>) {
   const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -24,21 +27,26 @@ export function AppRhfTextField<TFieldValues extends FieldValues>({
     if (parseValue) {
       field.onChange(parseValue(value));
     } else {
-      field.onChange(event);
       field.onChange(value);
     }
 
     onValueChange?.(value);
   };
 
-  return (
-    <AppTextField
-      {...props}
-      name={field.name}
-      value={field.value ?? ''}
-      onBlur={field.onBlur}
-      inputRef={field.ref}
-      onChange={handleChange}
-    />
-  );
+  const { type, ...restProps } = props;
+
+  const commonProps = {
+    ...restProps,
+    name: field.name,
+    value: field.value ?? '',
+    onBlur: field.onBlur,
+    inputRef: field.ref,
+    onChange: handleChange,
+  };
+
+  if (type === 'datetime-local') {
+    return <AppDateTimeField {...commonProps} minutesStep={minutesStep} />;
+  }
+
+  return <AppTextField {...commonProps} />;
 }


### PR DESCRIPTION
### Motivation
- Provide a single, reusable way to render `datetime-local` inputs with a configurable minutes step instead of repeating `slotProps` logic across forms.
- Ensure the RHF-connected text field component can render the correct input type (datetime vs plain text) to keep forms DRY and consistent.

### Description
- Added `AppDateTimeField` that wraps `AppTextField` and applies `minutesStep` by setting the native `step` (in seconds) and forcing label `shrink` behavior (`web/src/shared/ui/AppDateTimeField.tsx`).
- Updated `AppRhfTextField` to accept `minutesStep` and to render `AppDateTimeField` when `type === 'datetime-local'`, while keeping existing RHF wiring for other input types (`web/src/shared/ui/AppRhfTextField.tsx`).
- Simplified appointment form fields to pass `minutesStep={selectedSlotStepMin}` for `startAt` and `endAt` instead of repeating `slotProps` in each controller (`web/src/containers/AppointmentsContainer.tsx`).

### Testing
- Ran type checking with `npm run typecheck --workspace @scheduletm/web` and it completed successfully.
- Attempted to install `@mui/x-date-pickers` and `dayjs` with `npm install --workspace @scheduletm/web @mui/x-date-pickers dayjs` but the install failed due to a registry/security `403 Forbidden`, so a local `AppDateTimeField` wrapper was implemented instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88d0de31883338ac6a159a1805981)