### PR TITLE
feat(web): optimistic UI for appointment drag-and-drop rescheduling

### DIFF
--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -474,6 +474,13 @@ export function AppointmentsContainer() {
       createDatetimeLocal(targetDayKey, targetHour, targetMinute),
       displayTimeZone,
     );
+    const previousScheduledAt = current.scheduledAt;
+
+    setAppointments((prev) => prev.map((item) => (
+      item.id === appointmentId
+        ? { ...item, scheduledAt: nextIso }
+        : item
+    )));
 
     try {
       await apiClient.post(`/api/appointments/${appointmentId}/reschedule`, {
@@ -482,9 +489,14 @@ export function AppointmentsContainer() {
         headers: authHeaders(accessToken),
       });
 
-      await loadAppointments(selectedSpecialistId);
+      void loadAppointments(selectedSpecialistId);
       setError('');
     } catch {
+      setAppointments((prev) => prev.map((item) => (
+        item.id === appointmentId
+          ? { ...item, scheduledAt: previousScheduledAt }
+          : item
+      )));
       setError('Unable to reschedule appointment');
     }
   };


### PR DESCRIPTION
### Motivation
- Improve UX for calendar drag-and-drop by reflecting the moved appointment immediately instead of waiting for the server response.

### Description
- Apply optimistic update in `moveAppointment` by setting the appointment's `scheduledAt` locally right after drop. 
- Preserve the previous `scheduledAt` and rollback local state if the reschedule API call fails. 
- Continue synchronizing with server state by calling `loadAppointments(...)` after a successful API request (non-blocking). 
- Changes made in `web/src/containers/AppointmentsContainer.tsx`.

### Testing
- Ran type checking with `npm --prefix web run typecheck`, which failed in this environment due to missing `@mui/x-date-pickers` and `dayjs` type modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89c7465ac8333bbbcd3850b4da5d2)