### PR TITLE
Add preloaders and skeletons for auth, settings and appointments

### DIFF
--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -124,7 +124,7 @@ export function AuthCard({
           )}
         />
 
-        <AppButton type="submit" variant="contained" disabled={isSubmitting} sx={{ minHeight: 46 }}>
+        <AppButton type="submit" variant="contained" isLoading={isSubmitting} sx={{ minHeight: 46 }}>
           {submitText}
         </AppButton>
 

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -132,7 +132,7 @@ export function SettingsCard({
             )}
           />
 
-          <AppButton type="submit" startIcon={<AppIcons.save />} disabled={isSavingSystem}>
+          <AppButton type="submit" startIcon={<AppIcons.save />} isLoading={isSavingSystem}>
             {copy.saveSettings}
           </AppButton>
         </AppForm>
@@ -158,7 +158,7 @@ export function SettingsCard({
             )}
           />
 
-          <AppButton type="submit" startIcon={<AppIcons.save />} disabled={isSavingUser}>
+          <AppButton type="submit" startIcon={<AppIcons.save />} isLoading={isSavingUser}>
             {copy.saveSettings}
           </AppButton>
 
@@ -171,7 +171,8 @@ export function SettingsCard({
             <AppButton
               variant="outlined"
               onClick={onConnectGoogle}
-              disabled={userSettings.googleConnected || isGoogleConnecting}
+              disabled={userSettings.googleConnected}
+              isLoading={isGoogleConnecting}
             >
               {userSettings.googleConnected
                 ? copy.googleConnected

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Card,
   CardContent,
-  CircularProgress,
   Collapse,
   Chip,
   Dialog,
@@ -15,6 +14,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Skeleton,
   Stack,
   ToggleButton,
   ToggleButtonGroup,
@@ -30,6 +30,7 @@ import { useI18n } from '../shared/i18n/I18nContext';
 import type { AppointmentItem, AppointmentListResponse, AppointmentStatus, SpecialistItem } from '../shared/types/api';
 import { WebUserRole } from '../shared/types/roles';
 import { AppPage } from '../shared/ui/AppPage';
+import { AppButton } from '../shared/ui/AppButton';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type EditFormState = {
@@ -216,6 +217,8 @@ export function AppointmentsContainer() {
 
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isSubmittingForm, setIsSubmittingForm] = useState(false);
+  const [isCancellingAppointment, setIsCancellingAppointment] = useState(false);
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [showTimezoneSelect, setShowTimezoneSelect] = useState(false);
@@ -397,6 +400,8 @@ export function AppointmentsContainer() {
     const { startIso, endIso } = buildStartEndIso(form, formTimeZone);
     const durationMin = Math.max(selectedSlotStepMin, Math.round((new Date(endIso).getTime() - new Date(startIso).getTime()) / 60_000));
 
+    setIsSubmittingForm(true);
+
     try {
       if (editingItem) {
         await apiClient.patch(`/api/appointments/${editingItem.id}`, {
@@ -425,6 +430,8 @@ export function AppointmentsContainer() {
       await loadAppointments(selectedSpecialistId);
     } catch {
       setError('Unable to save appointment');
+    } finally {
+      setIsSubmittingForm(false);
     }
   };
 
@@ -453,6 +460,8 @@ export function AppointmentsContainer() {
       return;
     }
 
+    setIsCancellingAppointment(true);
+
     try {
       await apiClient.post(`/api/appointments/${editingItem.id}/cancel`, {}, {
         headers: authHeaders(accessToken),
@@ -462,6 +471,8 @@ export function AppointmentsContainer() {
       await loadAppointments(selectedSpecialistId);
     } catch {
       setError('Unable to cancel appointment');
+    } finally {
+      setIsCancellingAppointment(false);
     }
   };
 
@@ -608,10 +619,18 @@ export function AppointmentsContainer() {
           </CardContent>
         </Card>
 
-        <Typography variant="body2" color="text.secondary">{t('appointments.dragHint')}</Typography>
+        {isLoading ? (
+          <Stack spacing={1}>
+            <Skeleton variant="text" width={220} />
+            <Skeleton variant="rounded" height={520} />
+            <Skeleton variant="rounded" height={36} width={160} />
+          </Stack>
+        ) : (
+          <>
+            <Typography variant="body2" color="text.secondary">{t('appointments.dragHint')}</Typography>
 
-        <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, overflowX: 'auto', boxShadow: `0 8px 20px ${alpha(theme.palette.primary.main, 0.08)}` }}>
-          <Box sx={{ display: 'grid', gridTemplateColumns: `72px repeat(${visibleDays.length}, minmax(180px, 1fr))`, minWidth: viewMode === 'week' ? 1100 : 560 }}>
+            <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, overflowX: 'auto', boxShadow: `0 8px 20px ${alpha(theme.palette.primary.main, 0.08)}` }}>
+              <Box sx={{ display: 'grid', gridTemplateColumns: `72px repeat(${visibleDays.length}, minmax(180px, 1fr))`, minWidth: viewMode === 'week' ? 1100 : 560 }}>
             <Box sx={{ borderRight: 1, borderColor: 'divider', p: 1, bgcolor: 'background.default' }} />
             {visibleDays.map((day) => (
               <Box
@@ -735,19 +754,14 @@ export function AppointmentsContainer() {
                 </Fragment>
               );
             })}
-          </Box>
-        </Box>
+              </Box>
+            </Box>
 
-        <Button onClick={() => openCreate(getGridDayKey(visibleDays[0]), 9, 0)} variant="outlined" size="small" sx={{ alignSelf: 'flex-start' }}>
-          {t('appointments.create')}
-        </Button>
-
-        {isLoading ? (
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <CircularProgress size={18} />
-            <Typography variant="body2">{t('appointments.loading')}</Typography>
-          </Stack>
-        ) : null}
+            <Button onClick={() => openCreate(getGridDayKey(visibleDays[0]), 9, 0)} variant="outlined" size="small" sx={{ alignSelf: 'flex-start' }}>
+              {t('appointments.create')}
+            </Button>
+          </>
+        )}
       </Stack>
 
       <Dialog open={isCreateOpen} onClose={() => setIsCreateOpen(false)} maxWidth="sm" fullWidth>
@@ -854,10 +868,14 @@ export function AppointmentsContainer() {
         </DialogContent>
         <DialogActions>
           {editingItem && (
-            <Button color="error" onClick={cancelAppointment}>{t('appointments.cancelAction')}</Button>
+            <AppButton color="error" onClick={cancelAppointment} isLoading={isCancellingAppointment}>
+              {t('appointments.cancelAction')}
+            </AppButton>
           )}
-          <Button onClick={() => setIsCreateOpen(false)}>{t('appointments.close')}</Button>
-          <Button variant="contained" onClick={handleSubmit(submitForm)}>{t('appointments.save')}</Button>
+          <Button onClick={() => setIsCreateOpen(false)} disabled={isSubmittingForm || isCancellingAppointment}>{t('appointments.close')}</Button>
+          <AppButton variant="contained" onClick={handleSubmit(submitForm)} isLoading={isSubmittingForm}>
+            {t('appointments.save')}
+          </AppButton>
         </DialogActions>
       </Dialog>
     </AppPage>

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box } from '@mui/material';
+import { Alert, Box, Skeleton, Stack } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { SettingsCard } from '../components/SettingsCard';
@@ -36,6 +36,7 @@ export function SettingsContainer() {
   const [isGoogleConnecting, setIsGoogleConnecting] = useState(false);
   const [isSavingSystem, setIsSavingSystem] = useState(false);
   const [isSavingUser, setIsSavingUser] = useState(false);
+  const [isLoadingSettings, setIsLoadingSettings] = useState(true);
 
   const googleOauthStatus = useMemo(() => searchParams.get('google_oauth'), [searchParams]);
   const canManageSystemSettings = user?.role === 'owner' || user?.role === 'admin';
@@ -69,6 +70,8 @@ export function SettingsContainer() {
     }
 
     const load = async () => {
+      setIsLoadingSettings(true);
+
       try {
         const userResponse = await apiClient.get<UserSettings>('/api/settings/user', {
           headers: authHeaders(accessToken)
@@ -83,6 +86,8 @@ export function SettingsContainer() {
         }
       } catch {
         setError(t('settings.errors.load'));
+      } finally {
+        setIsLoadingSettings(false);
       }
     };
 
@@ -170,34 +175,44 @@ export function SettingsContainer() {
       )}
 
       <Box sx={{ maxWidth: 720 }}>
-        <SettingsCard
-          systemSettings={systemSettings}
-          userSettings={userSettings}
-          canManageSystemSettings={canManageSystemSettings}
-          copy={{
-            systemTab: t('settings.tabs.system'),
-            userTab: t('settings.tabs.user'),
-            systemTitle: t('settings.systemTitle'),
-            userTitle: t('settings.userTitle'),
-            timezone: t('settings.timezone'),
-            locale: t('settings.locale'),
-            defaultMeetingDuration: t('settings.defaultMeetingDuration'),
-            dailyDigestEnabled: t('settings.dailyDigestEnabled'),
-            weekStartsOnMonday: t('settings.weekStartsOnMonday'),
-            saveSettings: t('common.saveSettings'),
-            integrationsTitle: t('settings.integrationsTitle'),
-            integrationsSubtitle: t('settings.integrationsSubtitle'),
-            connectGoogle: t('settings.connectGoogle'),
-            connectingGoogle: t('settings.connectingGoogle'),
-            googleConnected: t('settings.googleConnected')
-          }}
-          isGoogleConnecting={isGoogleConnecting}
-          isSavingSystem={isSavingSystem}
-          isSavingUser={isSavingUser}
-          onSaveSystem={saveSystemSettings}
-          onSaveUser={saveUserSettings}
-          onConnectGoogle={connectGoogle}
-        />
+        {isLoadingSettings ? (
+          <Stack spacing={2}>
+            <Skeleton variant="rounded" height={42} />
+            <Skeleton variant="rounded" height={56} />
+            <Skeleton variant="rounded" height={56} />
+            <Skeleton variant="rounded" height={56} />
+            <Skeleton variant="rounded" height={46} width={180} />
+          </Stack>
+        ) : (
+          <SettingsCard
+            systemSettings={systemSettings}
+            userSettings={userSettings}
+            canManageSystemSettings={canManageSystemSettings}
+            copy={{
+              systemTab: t('settings.tabs.system'),
+              userTab: t('settings.tabs.user'),
+              systemTitle: t('settings.systemTitle'),
+              userTitle: t('settings.userTitle'),
+              timezone: t('settings.timezone'),
+              locale: t('settings.locale'),
+              defaultMeetingDuration: t('settings.defaultMeetingDuration'),
+              dailyDigestEnabled: t('settings.dailyDigestEnabled'),
+              weekStartsOnMonday: t('settings.weekStartsOnMonday'),
+              saveSettings: t('common.saveSettings'),
+              integrationsTitle: t('settings.integrationsTitle'),
+              integrationsSubtitle: t('settings.integrationsSubtitle'),
+              connectGoogle: t('settings.connectGoogle'),
+              connectingGoogle: t('settings.connectingGoogle'),
+              googleConnected: t('settings.googleConnected')
+            }}
+            isGoogleConnecting={isGoogleConnecting}
+            isSavingSystem={isSavingSystem}
+            isSavingUser={isSavingUser}
+            onSaveSystem={saveSystemSettings}
+            onSaveUser={saveUserSettings}
+            onConnectGoogle={connectGoogle}
+          />
+        )}
       </Box>
     </AppPage>
   );

--- a/web/src/shared/ui/AppButton.tsx
+++ b/web/src/shared/ui/AppButton.tsx
@@ -1,6 +1,22 @@
-import { Button, type ButtonProps } from '@mui/material';
+import { Button, CircularProgress, Stack, type ButtonProps } from '@mui/material';
 
-export function AppButton(props: ButtonProps) {
-  const { variant = 'contained', ...rest } = props;
-  return <Button variant={variant} {...rest} />;
+type AppButtonProps = ButtonProps & {
+  isLoading?: boolean;
+};
+
+export function AppButton(props: AppButtonProps) {
+  const { variant = 'contained', isLoading = false, disabled, children, ...rest } = props;
+
+  return (
+    <Button variant={variant} disabled={disabled || isLoading} {...rest}>
+      {isLoading ? (
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <CircularProgress size={16} color="inherit" />
+          <span>{children}</span>
+        </Stack>
+      ) : (
+        children
+      )}
+    </Button>
+  );
 }


### PR DESCRIPTION
### Motivation
- Provide consistent UX feedback during async actions (form submit, connect, save) by showing preloaders inside buttons. 
- Avoid showing raw "loading" text on page-level lists and grids and replace it with visual skeletons for better perceived performance. 
- Keep UI logic DRY by centralizing button loading UI into a single reusable component.

### Description
- Added `isLoading` prop to `AppButton` and render a `CircularProgress` inside the button while auto-disabling it via `isLoading` (`web/src/shared/ui/AppButton.tsx`).
- Enabled button preloaders on the auth form by wiring `isLoading` to the submit button in `AuthCard` so login/register show loading state (`web/src/components/AuthCard.tsx`).
- Wired `isLoading` to settings actions (system/user save and Google connect) and added a page skeleton while initial settings load using `Skeleton` (`web/src/components/SettingsCard.tsx`, `web/src/containers/SettingsContainer.tsx`).
- Replaced the appointments area text-loading block with a page-level skeleton for the calendar grid and added dialog action preloaders for save and cancel flows by using `AppButton` (`web/src/containers/AppointmentsContainer.tsx`).

### Testing
- Ran `npm run -s --workspace web build`, which failed with existing type resolution errors unrelated to these changes: missing modules/types for `@mui/x-date-pickers/*` and `dayjs` reported from `AppDateTimeField.tsx` (failure). 
- Ran `npm run -s --workspace web typecheck`, which fails for the same dependency/type-resolution issue (failure). 
- No other automated tests were added or executed by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89fa66c38833393facb82e5f3843e)