### PR TITLE
Unify form datetime value creation and fix time-only picker parsing

### DIFF
--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -186,6 +186,19 @@ function composeFormDateTime(date: string, time: string): string {
   return `${date}T${time}`;
 }
 
+function createFormValuesFromAppointmentAt(appointmentAtIso: string, durationMin: number, timeZone: string) {
+  const startAt = toDatetimeLocal(appointmentAtIso, timeZone);
+  const endAt = addMinutesToDatetimeLocal(startAt, durationMin, timeZone);
+  const startParts = splitLocalDateTime(startAt);
+  const endParts = splitLocalDateTime(endAt);
+
+  return {
+    startDate: startParts.date,
+    startTime: startParts.time,
+    endTime: endParts.time,
+  };
+}
+
 function buildStartEndIso(form: EditFormState, timeZone: string) {
   const startLocal = composeFormDateTime(form.startDate, form.startTime);
   const startIso = fromDatetimeLocal(startLocal, timeZone);
@@ -231,13 +244,11 @@ export function AppointmentsContainer() {
     : specialists.find((item) => item.id === selectedSpecialistId) ?? null;
   const selectedSlotStepMin = selectedSpecialist?.slotStepMin ?? DEFAULT_SLOT_STEP_MIN;
 
-  const initialStartAt = toDatetimeLocal(new Date().toISOString(), formTimeZone);
-  const initialStartParts = splitLocalDateTime(initialStartAt);
-  const initialEndParts = splitLocalDateTime(addMinutesToDatetimeLocal(initialStartAt, selectedSlotStepMin, formTimeZone));
+  const initialTimes = createFormValuesFromAppointmentAt(new Date().toISOString(), selectedSlotStepMin, formTimeZone);
   const initialFormValues: EditFormState = {
-    startDate: initialStartParts.date,
-    startTime: initialStartParts.time,
-    endTime: initialEndParts.time,
+    startDate: initialTimes.startDate,
+    startTime: initialTimes.startTime,
+    endTime: initialTimes.endTime,
     status: 'new',
     meetingLink: '',
     notes: '',
@@ -365,14 +376,13 @@ export function AppointmentsContainer() {
       return;
     }
 
-    const startAt = createDatetimeLocal(targetDateKey, hour, minute);
-    const startParts = splitLocalDateTime(startAt);
-    const endParts = splitLocalDateTime(addMinutesToDatetimeLocal(startAt, selectedSlotStepMin, BROWSER_TIMEZONE));
+    const appointmentAtIso = fromDatetimeLocal(createDatetimeLocal(targetDateKey, hour, minute), BROWSER_TIMEZONE);
+    const times = createFormValuesFromAppointmentAt(appointmentAtIso, selectedSlotStepMin, BROWSER_TIMEZONE);
 
     reset({
-      startDate: startParts.date,
-      startTime: startParts.time,
-      endTime: endParts.time,
+      startDate: times.startDate,
+      startTime: times.startTime,
+      endTime: times.endTime,
       status: 'new',
       meetingLink: '',
       notes: '',
@@ -436,16 +446,17 @@ export function AppointmentsContainer() {
   };
 
   const openEdit = (item: AppointmentItem) => {
-    const startAt = toDatetimeLocal(item.scheduledAt, BROWSER_TIMEZONE);
-    const endAt = addMinutesToDatetimeLocal(startAt, item.durationMin || selectedSlotStepMin, BROWSER_TIMEZONE);
-    const startParts = splitLocalDateTime(startAt);
-    const endParts = splitLocalDateTime(endAt);
+    const times = createFormValuesFromAppointmentAt(
+      item.scheduledAt,
+      item.durationMin || selectedSlotStepMin,
+      BROWSER_TIMEZONE,
+    );
 
     setEditingItem(item);
     reset({
-      startDate: startParts.date,
-      startTime: startParts.time,
-      endTime: endParts.time,
+      startDate: times.startDate,
+      startTime: times.startTime,
+      endTime: times.endTime,
       status: item.status,
       meetingLink: item.meetingLink,
       notes: item.notes,

--- a/web/src/shared/ui/AppDateTimeField.tsx
+++ b/web/src/shared/ui/AppDateTimeField.tsx
@@ -12,7 +12,12 @@ type AppDateTimeFieldProps = Omit<TextFieldProps, 'type'> & {
 };
 
 export function AppDateTimeField({ type = 'datetime-local', minutesStep, slotProps, ...props }: AppDateTimeFieldProps) {
-  const pickerValue = typeof props.value === 'string' && props.value ? dayjs(props.value) : null;
+  const pickerValue =
+    typeof props.value === 'string' && props.value
+      ? type === 'time'
+        ? dayjs(`1970-01-01T${props.value}`)
+        : dayjs(props.value)
+      : null;
 
   const emitChange = (formattedValue: string) => {
     const syntheticEvent = {


### PR DESCRIPTION
### Motivation

- Reduce duplicated logic for converting appointment ISO timestamps into form `startDate`/`startTime`/`endTime` values.
- Ensure the date/time picker correctly interprets time-only values for the `time` input type.

### Description

- Add `createFormValuesFromAppointmentAt` helper to compute `startDate`, `startTime`, and `endTime` from an ISO timestamp, duration, and timezone.
- Replace repeated `toDatetimeLocal`/`splitLocalDateTime`/`addMinutesToDatetimeLocal` sequences in `AppointmentsContainer` with the new helper for initial form values, `openCreate`, and `openEdit` flows.
- Update `AppDateTimeField` to parse time-only string values by prepending a reference date so `dayjs` correctly constructs a `Dayjs` value when `type === 'time'`.

### Testing

- Ran TypeScript type checks and project build with `yarn build` and no type/build errors were reported.
- Executed the frontend test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a4cfc4fc8333922da0fb421ccc7b)