### PR TITLE
Add required specialist selector to appointment form

### DIFF
--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -34,6 +34,7 @@ import { AppButton } from '../shared/ui/AppButton';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type EditFormState = {
+  specialistId: string;
   startDate: string;
   startTime: string;
   endTime: string;
@@ -246,6 +247,7 @@ export function AppointmentsContainer() {
 
   const initialTimes = createFormValuesFromAppointmentAt(new Date().toISOString(), selectedSlotStepMin, formTimeZone);
   const initialFormValues: EditFormState = {
+    specialistId: '',
     startDate: initialTimes.startDate,
     startTime: initialTimes.startTime,
     endTime: initialTimes.endTime,
@@ -380,6 +382,7 @@ export function AppointmentsContainer() {
     const times = createFormValuesFromAppointmentAt(appointmentAtIso, selectedSlotStepMin, BROWSER_TIMEZONE);
 
     reset({
+      specialistId: String(specialistId),
       startDate: times.startDate,
       startTime: times.startTime,
       endTime: times.endTime,
@@ -398,11 +401,9 @@ export function AppointmentsContainer() {
       return;
     }
 
-    const specialistId = selectedSpecialistId === 'all'
-      ? specialists[0]?.id
-      : selectedSpecialistId;
+    const specialistId = Number(form.specialistId);
 
-    if (!specialistId) {
+    if (!Number.isFinite(specialistId) || specialistId <= 0) {
       setError('Specialist is required');
       return;
     }
@@ -454,6 +455,7 @@ export function AppointmentsContainer() {
 
     setEditingItem(item);
     reset({
+      specialistId: String(item.specialistId),
       startDate: times.startDate,
       startTime: times.startTime,
       endTime: times.endTime,
@@ -807,6 +809,26 @@ export function AppointmentsContainer() {
                 </Select>
               </FormControl>
             </Collapse>
+            <Controller
+              name="specialistId"
+              control={control}
+              render={({ field }: any) => (
+                <FormControl>
+                  <InputLabel id="specialist-label">{t('appointments.specialistFilter')}</InputLabel>
+                  <Select
+                    labelId="specialist-label"
+                    label={t('appointments.specialistFilter')}
+                    value={field.value}
+                    disabled={Boolean(editingItem)}
+                    onChange={(event) => field.onChange(String(event.target.value))}
+                  >
+                    {specialists.map((specialist) => (
+                      <MenuItem key={specialist.id} value={String(specialist.id)}>{specialist.name}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+            />
             <Controller
               name="startDate"
               control={control}


### PR DESCRIPTION
### Motivation
- Форма создания/редактирования апоинтмента должна явно содержать выбранного специалиста, чтобы нельзя было создать запись без специалиста и убрать неявную зависимость от текущего фильтра.

### Description
- Добавлено поле `specialistId` в тип `EditFormState` и начальные значения формы, чтобы диалог всегда хранил выбранного специалиста.
- При открытии диалога создания/редактирования теперь в `reset(...)` явно проставляется `specialistId` (создание — предзаполняется текущим/первым специалистом, редактирование — значением из записи). 
- В диалоге добавлен контроллер `Controller` с `Select` для выбора специалиста; поле заблокировано (`disabled`) при редактировании, чтобы не менять существующую сущность случайно.
- В `submitForm` валидируется `Number(form.specialistId)` и при создании запроса на `POST /api/appointments` отправляется выбранный `specialistId`.

### Testing
- Запущена проверка типов: `npm --prefix web run typecheck` (в текущей среде проверка падает из-за отсутствующих модулей/типов `@mui/x-date-pickers/*` и `dayjs`, ошибка не связана с внесёнными изменениями).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ac3db28c8333bfe304e2140a9433)