### PR TITLE
Support Google OAuth refresh tokens and disconnect flow (DB, API, service, UI)

### DIFF
--- a/server/src/db/migrations/20260422120000_add_google_refresh_token_to_web_users.ts
+++ b/server/src/db/migrations/20260422120000_add_google_refresh_token_to_web_users.ts
@@ -1,0 +1,43 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'web_users';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasGoogleRefreshToken = await knex.schema.hasColumn(TABLE, 'google_refresh_token');
+  const hasGoogleTokenExpiresAt = await knex.schema.hasColumn(TABLE, 'google_token_expires_at');
+
+  await knex.schema.alterTable(TABLE, (table) => {
+    if (!hasGoogleRefreshToken) {
+      table.string('google_refresh_token');
+    }
+
+    if (!hasGoogleTokenExpiresAt) {
+      table.timestamp('google_token_expires_at', { useTz: true });
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasGoogleRefreshToken = await knex.schema.hasColumn(TABLE, 'google_refresh_token');
+  const hasGoogleTokenExpiresAt = await knex.schema.hasColumn(TABLE, 'google_token_expires_at');
+
+  await knex.schema.alterTable(TABLE, (table) => {
+    if (hasGoogleTokenExpiresAt) {
+      table.dropColumn('google_token_expires_at');
+    }
+
+    if (hasGoogleRefreshToken) {
+      table.dropColumn('google_refresh_token');
+    }
+  });
+}

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -60,7 +60,10 @@ export type SpecialistRecord = {
 
 export type SpecialistCalendarCredentials = {
   specialistId: number;
+  webUserId: number;
   googleApiKey: string;
+  googleRefreshToken: string | null;
+  googleTokenExpiresAt: Date | null;
   googleCalendarId: string | null;
 };
 
@@ -116,7 +119,10 @@ export async function findSpecialistsCalendarCredentials(
     .whereNotNull('wu.google_api_key')
     .select(
       's.id as specialistId',
+      'wu.id as webUserId',
       'wu.google_api_key as googleApiKey',
+      'wu.google_refresh_token as googleRefreshToken',
+      'wu.google_token_expires_at as googleTokenExpiresAt',
       'wu.google_calendar_id as googleCalendarId',
     );
 

--- a/server/src/repositories/webUserRepository.ts
+++ b/server/src/repositories/webUserRepository.ts
@@ -10,6 +10,8 @@ export type WebUserRecord = {
   password_salt: string;
   is_active: boolean;
   google_api_key: string | null;
+  google_refresh_token: string | null;
+  google_token_expires_at: Date | null;
   google_calendar_id: string | null;
   google_connected_at: Date | null;
   timezone: string;
@@ -75,18 +77,46 @@ type UpdateWebUserGoogleCredentialsInput = {
   accountId: number;
   id: number;
   googleApiKey: string;
+  googleRefreshToken?: string | null;
+  googleTokenExpiresAt?: Date | null;
   googleCalendarId?: string | null;
 };
 
 export async function updateWebUserGoogleCredentials(
   input: UpdateWebUserGoogleCredentialsInput,
 ): Promise<void> {
+  const patch: Record<string, unknown> = {
+    google_api_key: input.googleApiKey,
+    google_connected_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  };
+
+  if (input.googleRefreshToken !== undefined) {
+    patch.google_refresh_token = input.googleRefreshToken;
+  }
+
+  if (input.googleTokenExpiresAt !== undefined) {
+    patch.google_token_expires_at = input.googleTokenExpiresAt;
+  }
+
+  if (input.googleCalendarId !== undefined) {
+    patch.google_calendar_id = input.googleCalendarId;
+  }
+
   await db('web_users')
     .where({ account_id: input.accountId, id: input.id })
+    .update(patch);
+}
+
+export async function clearWebUserGoogleCredentials(accountId: number, id: number): Promise<void> {
+  await db('web_users')
+    .where({ account_id: accountId, id })
     .update({
-      google_api_key: input.googleApiKey,
-      google_calendar_id: input.googleCalendarId ?? null,
-      google_connected_at: db.fn.now(),
+      google_api_key: null,
+      google_refresh_token: null,
+      google_token_expires_at: null,
+      google_calendar_id: null,
+      google_connected_at: null,
       updated_at: db.fn.now(),
     });
 }

--- a/server/src/routes/integrationRoutes.ts
+++ b/server/src/routes/integrationRoutes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { env } from '../config/env.js';
 import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
-import { completeGoogleOAuth, createGoogleOAuthUrl } from '../services/googleOAuthService.js';
+import { completeGoogleOAuth, createGoogleOAuthUrl, disconnectGoogleOAuth } from '../services/googleOAuthService.js';
 
 export const integrationRoutes = Router();
 
@@ -42,4 +42,17 @@ integrationRoutes.get('/google/oauth/callback', async (req, res) => {
   }
 
   return res.redirect(`${env.APP_URL}/settings?google_oauth=success`);
+});
+
+integrationRoutes.post('/google/disconnect', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const ok = await disconnectGoogleOAuth(user.id);
+  if (!ok) {
+    return res.status(400).json({ message: 'Invalid user id' });
+  }
+
+  return res.json({
+    provider: 'google',
+    connected: false,
+  });
 });

--- a/server/src/services/calendarAvailabilityService.ts
+++ b/server/src/services/calendarAvailabilityService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { findSpecialistsCalendarCredentials } from '../repositories/specialistRepository.js';
+import { refreshGoogleAccessToken } from './googleOAuthService.js';
 
 export type ExternalBusySlot = {
   specialistId: number;
@@ -21,6 +22,15 @@ type GoogleCalendarEvent = {
 type GoogleCalendarEventsResponse = {
   items?: GoogleCalendarEvent[];
 };
+
+function isAccessTokenExpired(expiresAt: Date | null): boolean {
+  if (!expiresAt) {
+    return true;
+  }
+
+  const safetyWindowMs = 30 * 1000;
+  return expiresAt.getTime() <= Date.now() + safetyWindowMs;
+}
 
 function toDurationMin(startIso?: string, endIso?: string): number | null {
   if (!startIso || !endIso) {
@@ -52,13 +62,26 @@ export async function listExternalBusySlots(input: {
 
   const busySlots = await Promise.all(
     credentials.map(async (item) => {
+      let googleApiKey = item.googleApiKey;
+      if (isAccessTokenExpired(item.googleTokenExpiresAt) && item.googleRefreshToken) {
+        const refreshed = await refreshGoogleAccessToken({
+          accountId: input.accountId,
+          webUserId: item.webUserId,
+          refreshToken: item.googleRefreshToken,
+        });
+
+        if (refreshed) {
+          googleApiKey = refreshed.googleApiKey;
+        }
+      }
+
       const calendarId = item.googleCalendarId?.trim() || 'primary';
       const url = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`;
 
       try {
         const response = await axios.get<GoogleCalendarEventsResponse>(url, {
           headers: {
-            Authorization: `Bearer ${item.googleApiKey}`,
+            Authorization: `Bearer ${googleApiKey}`,
           },
           params: {
             singleEvents: true,

--- a/server/src/services/googleOAuthService.ts
+++ b/server/src/services/googleOAuthService.ts
@@ -4,7 +4,7 @@ import { URLSearchParams } from 'node:url';
 import { env } from '../config/env.js';
 import { getDefaultAccountId } from '../repositories/accountRepository.js';
 import { createGoogleOAuthState, consumeGoogleOAuthState } from '../repositories/googleOAuthStateRepository.js';
-import { updateWebUserGoogleCredentials } from '../repositories/webUserRepository.js';
+import { clearWebUserGoogleCredentials, updateWebUserGoogleCredentials } from '../repositories/webUserRepository.js';
 
 type GoogleTokenResponse = {
   access_token: string;
@@ -15,6 +15,12 @@ type GoogleTokenResponse = {
   id_token?: string;
 };
 
+type RefreshGoogleAccessTokenInput = {
+  accountId: number;
+  webUserId: number;
+  refreshToken: string;
+};
+
 const GOOGLE_AUTH_BASE_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_DEFAULT_SCOPES = [
@@ -22,6 +28,10 @@ const GOOGLE_DEFAULT_SCOPES = [
   'https://www.googleapis.com/auth/userinfo.email',
   'https://www.googleapis.com/auth/calendar.readonly'
 ];
+
+const resolveTokenExpiresAt = (expiresIn: number) => {
+  return new Date(Date.now() + expiresIn * 1000);
+};
 
 const isGoogleOAuthConfigured = () => {
   return Boolean(
@@ -98,7 +108,9 @@ export const completeGoogleOAuth = async (state: string, code: string) => {
     await updateWebUserGoogleCredentials({
       accountId,
       id: pending.web_user_id,
-      googleApiKey: tokenResponse.data.access_token
+      googleApiKey: tokenResponse.data.access_token,
+      googleRefreshToken: tokenResponse.data.refresh_token,
+      googleTokenExpiresAt: resolveTokenExpiresAt(tokenResponse.data.expires_in),
     });
 
     return {
@@ -115,4 +127,53 @@ export const completeGoogleOAuth = async (state: string, code: string) => {
   } catch {
     return { ok: false as const, reason: 'token_exchange_failed' };
   }
+};
+
+export const refreshGoogleAccessToken = async (input: RefreshGoogleAccessTokenInput) => {
+  if (!isGoogleOAuthConfigured()) {
+    return null;
+  }
+
+  try {
+    const payload = new URLSearchParams({
+      client_id: env.GOOGLE_OAUTH_CLIENT_ID,
+      client_secret: env.GOOGLE_OAUTH_CLIENT_SECRET,
+      refresh_token: input.refreshToken,
+      grant_type: 'refresh_token',
+    });
+
+    const tokenResponse = await axios.post<GoogleTokenResponse>(GOOGLE_TOKEN_URL, payload.toString(), {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      timeout: 10000,
+    });
+
+    const googleTokenExpiresAt = resolveTokenExpiresAt(tokenResponse.data.expires_in);
+    await updateWebUserGoogleCredentials({
+      accountId: input.accountId,
+      id: input.webUserId,
+      googleApiKey: tokenResponse.data.access_token,
+      googleRefreshToken: tokenResponse.data.refresh_token,
+      googleTokenExpiresAt,
+    });
+
+    return {
+      googleApiKey: tokenResponse.data.access_token,
+      googleTokenExpiresAt,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const disconnectGoogleOAuth = async (userId: string) => {
+  const webUserId = Number(userId);
+  if (!Number.isInteger(webUserId)) {
+    return false;
+  }
+
+  const accountId = await getDefaultAccountId();
+  await clearWebUserGoogleCredentials(accountId, webUserId);
+  return true;
 };

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -23,6 +23,8 @@ type SettingsCardCopy = {
   integrationsSubtitle: string;
   connectGoogle: string;
   connectingGoogle: string;
+  disconnectGoogle: string;
+  disconnectingGoogle: string;
   googleConnected: string;
 };
 
@@ -32,11 +34,13 @@ type SettingsCardProps = {
   copy: SettingsCardCopy;
   canManageSystemSettings: boolean;
   isGoogleConnecting: boolean;
+  isGoogleDisconnecting: boolean;
   isSavingSystem?: boolean;
   isSavingUser?: boolean;
   onSaveSystem: (next: SystemSettings) => Promise<void> | void;
   onSaveUser: (next: UserSettings) => Promise<void> | void;
   onConnectGoogle: () => void;
+  onDisconnectGoogle: () => void;
 };
 
 export function SettingsCard({
@@ -45,11 +49,13 @@ export function SettingsCard({
   copy,
   canManageSystemSettings,
   isGoogleConnecting,
+  isGoogleDisconnecting,
   isSavingSystem = false,
   isSavingUser = false,
   onSaveSystem,
   onSaveUser,
-  onConnectGoogle
+  onConnectGoogle,
+  onDisconnectGoogle
 }: SettingsCardProps) {
   const [tab, setTab] = useState(canManageSystemSettings ? 0 : 1);
 
@@ -171,15 +177,23 @@ export function SettingsCard({
             <AppButton
               variant="outlined"
               onClick={onConnectGoogle}
-              disabled={userSettings.googleConnected}
+              disabled={userSettings.googleConnected || isGoogleDisconnecting}
               isLoading={isGoogleConnecting}
             >
-              {userSettings.googleConnected
-                ? copy.googleConnected
-                : isGoogleConnecting
-                  ? copy.connectingGoogle
-                  : copy.connectGoogle}
+              {isGoogleConnecting ? copy.connectingGoogle : copy.connectGoogle}
             </AppButton>
+
+            {userSettings.googleConnected && (
+              <AppButton
+                variant="outlined"
+                color="error"
+                onClick={onDisconnectGoogle}
+                isLoading={isGoogleDisconnecting}
+                disabled={isGoogleConnecting}
+              >
+                {isGoogleDisconnecting ? copy.disconnectingGoogle : copy.disconnectGoogle}
+              </AppButton>
+            )}
           </Stack>
         </AppForm>
       )}

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -6,7 +6,7 @@ import { apiClient, authHeaders } from '../shared/api/client';
 import { useAuth } from '../shared/auth/AuthContext';
 import { useI18n } from '../shared/i18n/I18nContext';
 import { AppPage } from '../shared/ui/AppPage';
-import type { GoogleOAuthStartResponse, SystemSettings, UserSettings } from '../shared/types/api';
+import type { GoogleOAuthDisconnectResponse, GoogleOAuthStartResponse, SystemSettings, UserSettings } from '../shared/types/api';
 
 const defaultSystemSettings: SystemSettings = {
   timezone: 'UTC',
@@ -34,6 +34,7 @@ export function SettingsContainer() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [isGoogleConnecting, setIsGoogleConnecting] = useState(false);
+  const [isGoogleDisconnecting, setIsGoogleDisconnecting] = useState(false);
   const [isSavingSystem, setIsSavingSystem] = useState(false);
   const [isSavingUser, setIsSavingUser] = useState(false);
   const [isLoadingSettings, setIsLoadingSettings] = useState(true);
@@ -160,6 +161,30 @@ export function SettingsContainer() {
     }
   };
 
+  const disconnectGoogle = async () => {
+    if (!accessToken || isGoogleDisconnecting) {
+      return;
+    }
+
+    setIsGoogleDisconnecting(true);
+
+    try {
+      await apiClient.post<GoogleOAuthDisconnectResponse>(
+        '/api/integrations/google/disconnect',
+        {},
+        { headers: authHeaders(accessToken) }
+      );
+      setUserSettings((prev) => ({ ...prev, googleConnected: false }));
+      setError('');
+      setSuccess('');
+    } catch {
+      setError(t('settings.errors.disconnectGoogle'));
+      setSuccess('');
+    } finally {
+      setIsGoogleDisconnecting(false);
+    }
+  };
+
   return (
     <AppPage title={t('settings.pageTitle')} subtitle={t('settings.pageSubtitle')}>
       {error && (
@@ -203,14 +228,18 @@ export function SettingsContainer() {
               integrationsSubtitle: t('settings.integrationsSubtitle'),
               connectGoogle: t('settings.connectGoogle'),
               connectingGoogle: t('settings.connectingGoogle'),
+              disconnectGoogle: t('settings.disconnectGoogle'),
+              disconnectingGoogle: t('settings.disconnectingGoogle'),
               googleConnected: t('settings.googleConnected')
             }}
             isGoogleConnecting={isGoogleConnecting}
+            isGoogleDisconnecting={isGoogleDisconnecting}
             isSavingSystem={isSavingSystem}
             isSavingUser={isSavingUser}
             onSaveSystem={saveSystemSettings}
             onSaveUser={saveUserSettings}
             onConnectGoogle={connectGoogle}
+            onDisconnectGoogle={disconnectGoogle}
           />
         )}
       </Box>

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -50,12 +50,15 @@ export const dictionaries = {
       integrationsSubtitle: 'Connect external services to automate bookings and reminders.',
       connectGoogle: 'Connect Google',
       connectingGoogle: 'Redirecting to Google...',
+      disconnectGoogle: 'Disconnect Google',
+      disconnectingGoogle: 'Disconnecting...',
       googleConnected: 'Google connected',
       googleConnectedSuccessfully: 'Google Calendar connected successfully.',
       errors: {
         load: 'Unable to load settings.',
         save: 'Unable to save settings.',
-        connectGoogle: 'Unable to connect Google.'
+        connectGoogle: 'Unable to connect Google.',
+        disconnectGoogle: 'Unable to disconnect Google.'
       }
     },
     appointments: {
@@ -134,12 +137,15 @@ export const dictionaries = {
       integrationsSubtitle: 'Подключите внешние сервисы, чтобы автоматизировать бронирования и напоминания.',
       connectGoogle: 'Подключить Google',
       connectingGoogle: 'Переходим в Google...',
+      disconnectGoogle: 'Отключить Google',
+      disconnectingGoogle: 'Отключаем...',
       googleConnected: 'Google подключен',
       googleConnectedSuccessfully: 'Google Calendar успешно подключен.',
       errors: {
         load: 'Не удалось загрузить настройки.',
         save: 'Не удалось сохранить настройки.',
-        connectGoogle: 'Не удалось подключить Google.'
+        connectGoogle: 'Не удалось подключить Google.',
+        disconnectGoogle: 'Не удалось отключить Google.'
       }
     },
     appointments: {
@@ -213,11 +219,14 @@ export type TranslationKey =
   | 'settings.integrationsSubtitle'
   | 'settings.connectGoogle'
   | 'settings.connectingGoogle'
+  | 'settings.disconnectGoogle'
+  | 'settings.disconnectingGoogle'
   | 'settings.googleConnected'
   | 'settings.googleConnectedSuccessfully'
   | 'settings.errors.load'
   | 'settings.errors.save'
   | 'settings.errors.connectGoogle'
+  | 'settings.errors.disconnectGoogle'
   | 'appointments.pageTitle'
   | 'appointments.pageSubtitle'
   | 'appointments.specialistFilter'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -33,6 +33,11 @@ export type GoogleOAuthStartResponse = {
   state: string;
 };
 
+export type GoogleOAuthDisconnectResponse = {
+  provider: 'google';
+  connected: boolean;
+};
+
 export type AppointmentStatus = 'new' | 'confirmed' | 'cancelled';
 
 export type SpecialistItem = {


### PR DESCRIPTION
### Motivation
- Persist Google OAuth `refresh_token` and token expiry on `web_users` so the server can refresh access tokens when needed.
- Refresh expired Google access tokens automatically for calendar availability lookups to avoid broken integrations.
- Allow users to disconnect Google from the UI and clear stored credentials server-side.

### Description
- Add a DB migration `20260422120000_add_google_refresh_token_to_web_users.ts` that creates `google_refresh_token` and `google_token_expires_at` columns on `web_users` and drops them on rollback.
- Extend repository shapes and functions: update `WebUserRecord` and `SpecialistCalendarCredentials` to include `google_refresh_token` and `google_token_expires_at`, add `clearWebUserGoogleCredentials` and enhance `updateWebUserGoogleCredentials` in `webUserRepository.ts` to accept optional refresh token and expires-at fields.
- Update `googleOAuthService.ts` to persist `refresh_token` and computed `google_token_expires_at` during `completeGoogleOAuth`, add `refreshGoogleAccessToken` to exchange a refresh token for a new access token (and persist it), and add `disconnectGoogleOAuth` which clears stored credentials for a user.
- Update `calendarAvailabilityService.ts` to check `google_token_expires_at`, call `refreshGoogleAccessToken` when the token is expired and a refresh token exists, and use the refreshed access token for Google Calendar API requests.
- Add an API endpoint `POST /api/integrations/google/disconnect` in `integrationRoutes.ts` wired to `disconnectGoogleOAuth` to allow server-side disconnection.
- Frontend changes: add disconnect UI and logic in `SettingsCard.tsx` and `SettingsContainer.tsx`, wire new i18n strings and response types in `dictionaries.ts` and `shared/types/api.ts` to support disconnect flow and loading states.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e282399c833390a60c0ec79644e8)