### PR TITLE
Add Google Calendar event metadata to external busy slots UI

### DIFF
--- a/server/src/services/calendarAvailabilityService.ts
+++ b/server/src/services/calendarAvailabilityService.ts
@@ -7,6 +7,9 @@ export type ExternalBusySlot = {
   scheduledAt: string;
   durationMin: number;
   source: 'google';
+  title: string;
+  organizerEmail: string;
+  creatorEmail: string;
 };
 
 type GoogleCalendarEventDateTime = {
@@ -15,8 +18,15 @@ type GoogleCalendarEventDateTime = {
 
 type GoogleCalendarEvent = {
   status?: string;
+  summary?: string;
   start?: GoogleCalendarEventDateTime;
   end?: GoogleCalendarEventDateTime;
+  organizer?: {
+    email?: string;
+  };
+  creator?: {
+    email?: string;
+  };
 };
 
 type GoogleCalendarEventsResponse = {
@@ -105,6 +115,9 @@ export async function listExternalBusySlots(input: {
               scheduledAt: new Date(event.start.dateTime).toISOString(),
               durationMin,
               source: 'google' as const,
+              title: event.summary?.trim() ?? '',
+              organizerEmail: event.organizer?.email?.trim() ?? '',
+              creatorEmail: event.creator?.email?.trim() ?? '',
             };
           })
           .filter((slot): slot is ExternalBusySlot => Boolean(slot));

--- a/web/src/components/appointments/AppointmentsCalendar.tsx
+++ b/web/src/components/appointments/AppointmentsCalendar.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   ToggleButton,
   ToggleButtonGroup,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
@@ -57,6 +58,23 @@ export function AppointmentsCalendar({
   getGridDayKey,
 }: Props) {
   const theme = useTheme();
+
+  const getGoogleSlotTitle = (slot: AppointmentListResponse['busySlots'][number]) => {
+    if (slot.title) {
+      return slot.title;
+    }
+
+    return slot.organizerEmail || slot.creatorEmail || 'Busy (Google)';
+  };
+
+  const getGoogleSlotTooltip = (slot: AppointmentListResponse['busySlots'][number]) =>
+    [
+      slot.title ? `Title: ${slot.title}` : '',
+      slot.organizerEmail ? `Organizer: ${slot.organizerEmail}` : '',
+      slot.creatorEmail ? `Creator: ${slot.creatorEmail}` : '',
+    ]
+      .filter(Boolean)
+      .join(' · ');
 
   return (
     <>
@@ -182,13 +200,20 @@ export function AppointmentsCalendar({
                         >
                           <Stack spacing={0.5}>
                             {externalBusy.map((slot) => (
-                              <Chip
+                              <Tooltip
                                 key={`${slot.specialistId}-${slot.scheduledAt}-${slot.source}`}
-                                size="small"
-                                label="Busy (Google)"
-                                color="warning"
-                                variant="outlined"
-                              />
+                                title={getGoogleSlotTooltip(slot)}
+                                placement="top"
+                                arrow
+                                disableHoverListener={!getGoogleSlotTooltip(slot)}
+                              >
+                                <Chip
+                                  size="small"
+                                  label={getGoogleSlotTitle(slot)}
+                                  color="warning"
+                                  variant="outlined"
+                                />
+                              </Tooltip>
                             ))}
                             {items.map((item) => (
                               <Box

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -65,5 +65,8 @@ export type AppointmentListResponse = {
     scheduledAt: string;
     durationMin: number;
     source: 'google';
+    title: string;
+    organizerEmail: string;
+    creatorEmail: string;
   }>;
 };


### PR DESCRIPTION
### Motivation
- Provide richer information for external busy slots coming from Google Calendar so the calendar UI can display event title and participant metadata.
- Make the API contract explicit so the frontend can safely access new fields from server responses.
- Improve user experience by showing meaningful labels and a detailed tooltip instead of a generic "Busy (Google)" chip.

### Description
- Extend server-side busy slot mapping in `server/src/services/calendarAvailabilityService.ts` to include `title`, `organizerEmail`, and `creatorEmail` extracted from Google event `summary`, `organizer.email`, and `creator.email`.
- Update shared web type `AppointmentListResponse` in `web/src/shared/types/api.ts` to expose the new `busySlots` fields (`title`, `organizerEmail`, `creatorEmail`).
- Update `AppointmentsCalendar` (`web/src/components/appointments/AppointmentsCalendar.tsx`) to display the event `title` (or fallback to organizer/creator email or `Busy (Google)`), and show a tooltip with `Title`, `Organizer`, and `Creator` when metadata is present, while keeping the old behavior when metadata is absent.

### Testing
- Ran `npm run -w @scheduletm/server typecheck`, which failed in the current environment due to missing type definitions (`Cannot find type definition file for 'node'`).
- Ran `npm run -w @scheduletm/web typecheck`, which failed in the current environment due to missing type definitions (`Cannot find type definition file for 'vite/client'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ea8469b483339931d94912a691f5)