### PR TITLE
Filter Google busy slots overlapping appointments and surface event metadata in UI

### DIFF
--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -133,6 +133,42 @@ function mapSpecialistsForUi(rows: SpecialistRecord[]) {
   }));
 }
 
+function toTimeRange(scheduledAtIso: string, durationMin: number) {
+  const start = new Date(scheduledAtIso).getTime();
+  const end = start + durationMin * 60 * 1000;
+
+  return { start, end };
+}
+
+function intersectsByTime(
+  left: { scheduledAt: string; durationMin: number },
+  right: { scheduledAt: string; durationMin: number },
+) {
+  const leftRange = toTimeRange(left.scheduledAt, left.durationMin);
+  const rightRange = toTimeRange(right.scheduledAt, right.durationMin);
+
+  return leftRange.start < rightRange.end && rightRange.start < leftRange.end;
+}
+
+function filterBusySlotsOverlappingAppointments(
+  appointments: AppointmentDto[],
+  busySlots: ExternalBusySlot[],
+): ExternalBusySlot[] {
+  const appointmentsBySpecialist = new Map<number, AppointmentDto[]>();
+
+  for (const appointment of appointments) {
+    const list = appointmentsBySpecialist.get(appointment.specialistId) ?? [];
+    list.push(appointment);
+    appointmentsBySpecialist.set(appointment.specialistId, list);
+  }
+
+  return busySlots.filter((busySlot) => {
+    const specialistAppointments = appointmentsBySpecialist.get(busySlot.specialistId) ?? [];
+
+    return !specialistAppointments.some((appointment) => intersectsByTime(appointment, busySlot));
+  });
+}
+
 export async function getAppointments(
   actor: User,
   filters: { from?: string; to?: string; specialistId?: number },
@@ -167,11 +203,12 @@ export async function getAppointments(
     from: fromDate,
     to: toDate,
   });
+  const appointmentsForUi = items.map(mapAppointment);
 
   return {
-    appointments: items.map(mapAppointment),
+    appointments: appointmentsForUi,
     specialists,
-    busySlots,
+    busySlots: filterBusySlotsOverlappingAppointments(appointmentsForUi, busySlots),
   };
 }
 

--- a/server/src/services/calendarAvailabilityService.ts
+++ b/server/src/services/calendarAvailabilityService.ts
@@ -7,6 +7,9 @@ export type ExternalBusySlot = {
   scheduledAt: string;
   durationMin: number;
   source: 'google';
+  title: string;
+  organizerEmail: string;
+  creatorEmail: string;
 };
 
 type GoogleCalendarEventDateTime = {
@@ -15,8 +18,15 @@ type GoogleCalendarEventDateTime = {
 
 type GoogleCalendarEvent = {
   status?: string;
+  summary?: string;
   start?: GoogleCalendarEventDateTime;
   end?: GoogleCalendarEventDateTime;
+  organizer?: {
+    email?: string;
+  };
+  creator?: {
+    email?: string;
+  };
 };
 
 type GoogleCalendarEventsResponse = {
@@ -105,6 +115,9 @@ export async function listExternalBusySlots(input: {
               scheduledAt: new Date(event.start.dateTime).toISOString(),
               durationMin,
               source: 'google' as const,
+              title: event.summary?.trim() ?? '',
+              organizerEmail: event.organizer?.email?.trim() ?? '',
+              creatorEmail: event.creator?.email?.trim() ?? '',
             };
           })
           .filter((slot): slot is ExternalBusySlot => Boolean(slot));

--- a/web/src/components/appointments/AppointmentsCalendar.tsx
+++ b/web/src/components/appointments/AppointmentsCalendar.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   ToggleButton,
   ToggleButtonGroup,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
@@ -57,6 +58,23 @@ export function AppointmentsCalendar({
   getGridDayKey,
 }: Props) {
   const theme = useTheme();
+
+  const getGoogleSlotTitle = (slot: AppointmentListResponse['busySlots'][number]) => {
+    if (slot.title) {
+      return slot.title;
+    }
+
+    return slot.organizerEmail || slot.creatorEmail || 'Busy (Google)';
+  };
+
+  const getGoogleSlotTooltip = (slot: AppointmentListResponse['busySlots'][number]) =>
+    [
+      slot.title ? `Title: ${slot.title}` : '',
+      slot.organizerEmail ? `Organizer: ${slot.organizerEmail}` : '',
+      slot.creatorEmail ? `Creator: ${slot.creatorEmail}` : '',
+    ]
+      .filter(Boolean)
+      .join(' · ');
 
   return (
     <>
@@ -182,13 +200,20 @@ export function AppointmentsCalendar({
                         >
                           <Stack spacing={0.5}>
                             {externalBusy.map((slot) => (
-                              <Chip
+                              <Tooltip
                                 key={`${slot.specialistId}-${slot.scheduledAt}-${slot.source}`}
-                                size="small"
-                                label="Busy (Google)"
-                                color="warning"
-                                variant="outlined"
-                              />
+                                title={getGoogleSlotTooltip(slot)}
+                                placement="top"
+                                arrow
+                                disableHoverListener={!getGoogleSlotTooltip(slot)}
+                              >
+                                <Chip
+                                  size="small"
+                                  label={getGoogleSlotTitle(slot)}
+                                  color="warning"
+                                  variant="outlined"
+                                />
+                              </Tooltip>
                             ))}
                             {items.map((item) => (
                               <Box

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -65,5 +65,8 @@ export type AppointmentListResponse = {
     scheduledAt: string;
     durationMin: number;
     source: 'google';
+    title: string;
+    organizerEmail: string;
+    creatorEmail: string;
   }>;
 };


### PR DESCRIPTION
### Motivation
- Prevent external (Google) busy slots from hiding appointments when they overlap existing appointments for the same specialist. 
- Surface Google event metadata (title, organizer and creator emails) in API and UI to provide clearer context for busy slots.

### Description
- Added `toTimeRange`, `intersectsByTime`, and `filterBusySlotsOverlappingAppointments` to `appointmentService.ts` and used them to filter `busySlots` returned by `getAppointments`. 
- Mapped appointments once in `getAppointments` (`appointmentsForUi`) to avoid repeated mapping and to feed the overlap filter.
- Extended `ExternalBusySlot` in `calendarAvailabilityService.ts` and the shared API types to include `title`, `organizerEmail`, and `creatorEmail`, and parsed these fields from Google Calendar events.
- Updated the calendar UI (`AppointmentsCalendar.tsx`) to render busy slot chips with tooltips and use the new metadata for labels and tooltip content.

### Testing
- Ran TypeScript type checks and the project test suite with `yarn test`, and they completed successfully. 
- Built the frontend with `yarn build` and verified the calendar component renders busy slots with tooltips in development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ea8469b483339931d94912a691f5)