### PR TITLE
Prevent creating and dragging appointments into past slots

### DIFF
--- a/web/src/components/appointments/AppointmentsCalendar.tsx
+++ b/web/src/components/appointments/AppointmentsCalendar.tsx
@@ -13,12 +13,14 @@ import {
   alpha,
   useTheme,
 } from '@mui/material';
-import { Fragment } from 'react';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { Fragment, useState } from 'react';
 import type { AppointmentItem, AppointmentListResponse } from '../../shared/types/api';
 import {
   CalendarViewMode,
   formatLocalDate,
   formatLocalTime,
+  isSlotInPast,
   SLOT_ROWS,
   statusLabel,
   toDateKeyInTimezone,
@@ -39,6 +41,7 @@ type Props = {
   onOpenCreate: (dayKey: string, hour: number, minute: number) => void;
   onOpenEdit: (item: AppointmentItem) => void;
   onMoveAppointment: (appointmentId: number, targetDayKey: string, targetHour: number, targetMinute: number) => void;
+  onPastSlotActionBlocked: () => void;
   getGridDayKey: (day: Date) => string;
 };
 
@@ -55,9 +58,12 @@ export function AppointmentsCalendar({
   onOpenCreate,
   onOpenEdit,
   onMoveAppointment,
+  onPastSlotActionBlocked,
   getGridDayKey,
 }: Props) {
   const theme = useTheme();
+  const [draggingAppointmentId, setDraggingAppointmentId] = useState<number | null>(null);
+  const [blockedCellKey, setBlockedCellKey] = useState<string | null>(null);
 
   const getGoogleSlotTitle = (slot: AppointmentListResponse['busySlots'][number]) => {
     if (slot.title) {
@@ -173,6 +179,7 @@ export function AppointmentsCalendar({
                         <Box
                           key={`${key}-cell`}
                           sx={{
+                            position: 'relative',
                             borderTop: 1,
                             borderRight: 1,
                             borderColor: 'divider',
@@ -186,9 +193,30 @@ export function AppointmentsCalendar({
                           }}
                           onDragOver={(event) => {
                             event.preventDefault();
+                            if (!draggingAppointmentId) {
+                              return;
+                            }
+
+                            if (isSlotInPast(dayKey, hour, minute, displayTimeZone)) {
+                              event.dataTransfer.dropEffect = 'none';
+                              setBlockedCellKey(key);
+                            } else {
+                              event.dataTransfer.dropEffect = 'move';
+                              setBlockedCellKey(null);
+                            }
+                          }}
+                          onDragLeave={() => {
+                            setBlockedCellKey((prev) => (prev === key ? null : prev));
                           }}
                           onDrop={(event) => {
                             event.preventDefault();
+                            setBlockedCellKey(null);
+
+                            if (isSlotInPast(dayKey, hour, minute, displayTimeZone)) {
+                              onPastSlotActionBlocked();
+                              return;
+                            }
+
                             const rawId = event.dataTransfer.getData('text/appointment-id');
                             const id = Number(rawId);
 
@@ -196,8 +224,31 @@ export function AppointmentsCalendar({
                               onMoveAppointment(id, dayKey, hour, minute);
                             }
                           }}
-                          onClick={() => onOpenCreate(dayKey, hour, minute)}
+                          onClick={() => {
+                            if (isSlotInPast(dayKey, hour, minute, displayTimeZone)) {
+                              onPastSlotActionBlocked();
+                              return;
+                            }
+
+                            onOpenCreate(dayKey, hour, minute);
+                          }}
                         >
+                          {draggingAppointmentId && blockedCellKey === key && (
+                            <Box
+                              sx={{
+                                position: 'absolute',
+                                inset: 0,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                bgcolor: alpha(theme.palette.error.main, 0.08),
+                                pointerEvents: 'none',
+                                zIndex: 2,
+                              }}
+                            >
+                              <CloseRoundedIcon color="error" fontSize="small" />
+                            </Box>
+                          )}
                           <Stack spacing={0.5}>
                             {externalBusy.map((slot) => (
                               <Tooltip
@@ -219,7 +270,14 @@ export function AppointmentsCalendar({
                               <Box
                                 key={item.id}
                                 draggable
-                                onDragStart={(event) => event.dataTransfer.setData('text/appointment-id', String(item.id))}
+                                onDragStart={(event) => {
+                                  setDraggingAppointmentId(item.id);
+                                  event.dataTransfer.setData('text/appointment-id', String(item.id));
+                                }}
+                                onDragEnd={() => {
+                                  setDraggingAppointmentId(null);
+                                  setBlockedCellKey(null);
+                                }}
                                 onClick={(event) => {
                                   event.stopPropagation();
                                   onOpenEdit(item);

--- a/web/src/components/appointments/appointmentsUtils.ts
+++ b/web/src/components/appointments/appointmentsUtils.ts
@@ -98,6 +98,11 @@ export function createDatetimeLocal(dateKey: string, hour: number, minute = 0): 
   return `${dateKey}T${pad(hour)}:${pad(minute)}`;
 }
 
+export function isSlotInPast(dateKey: string, hour: number, minute: number, timeZone: string): boolean {
+  const slotIso = fromDatetimeLocal(createDatetimeLocal(dateKey, hour, minute), timeZone);
+  return new Date(slotIso).getTime() < Date.now();
+}
+
 export function addMinutesToDatetimeLocal(value: string, minutesToAdd: number, timeZone: string): string {
   const iso = fromDatetimeLocal(value, timeZone);
   return toDatetimeLocal(new Date(new Date(iso).getTime() + minutesToAdd * 60_000).toISOString(), timeZone);

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -24,6 +24,7 @@ import {
   DEFAULT_SLOT_STEP_MIN,
   fromDatetimeLocal,
   getUtcNowByTimeZone,
+  isSlotInPast,
   startOfDay,
   toDateKeyInTimezone,
   toTimeKeyInTimezone,
@@ -57,6 +58,7 @@ export function AppointmentsContainer() {
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<AppointmentItem | null>(null);
+  const pastSlotError = 'Cannot create or move an appointment to a past date/time';
 
   const canManageAll = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin;
   const selectedSpecialist = selectedSpecialistId === 'all'
@@ -160,6 +162,11 @@ export function AppointmentsContainer() {
   }, [accessToken, focusDate, viewMode, selectedSpecialistId]);
 
   const openCreate = (targetDateKey: string, hour: number, minute = 0) => {
+    if (isSlotInPast(targetDateKey, hour, minute, displayTimeZone)) {
+      setError(pastSlotError);
+      return;
+    }
+
     const specialistId = selectedSpecialistId === 'all'
       ? specialists[0]?.id
       : selectedSpecialistId;
@@ -193,6 +200,11 @@ export function AppointmentsContainer() {
     setIsSubmittingForm(true);
 
     try {
+      if (!editingItem && new Date(payload.startIso).getTime() < Date.now()) {
+        setError(pastSlotError);
+        return;
+      }
+
       if (editingItem) {
         await apiClient.patch(`/api/appointments/${editingItem.id}`, {
           scheduledAt: payload.startIso,
@@ -248,6 +260,10 @@ export function AppointmentsContainer() {
 
   const moveAppointment = async (appointmentId: number, targetDayKey: string, targetHour: number, targetMinute: number) => {
     if (!accessToken) {
+      return;
+    }
+    if (isSlotInPast(targetDayKey, targetHour, targetMinute, displayTimeZone)) {
+      setError(pastSlotError);
       return;
     }
 
@@ -366,6 +382,7 @@ export function AppointmentsContainer() {
           onMoveAppointment={(id, dayKey, hour, minute) => {
             void moveAppointment(id, dayKey, hour, minute);
           }}
+          onPastSlotActionBlocked={() => setError(pastSlotError)}
           getGridDayKey={getGridDayKey}
         />
       </Stack>


### PR DESCRIPTION
### Motivation
- Prevent users from creating or rescheduling appointments into past date/time slots and provide clear UI feedback when such actions are attempted.
- Keep the past-slot check centralized to avoid duplicated logic and ensure consistent behavior across UI and orchestration layers.

### Description
- Added a helper `isSlotInPast(dateKey, hour, minute, timeZone)` to `web/src/components/appointments/appointmentsUtils.ts` to centralize past-slot detection.
- Blocked creation from calendar cells by validating in `openCreate` in `web/src/containers/AppointmentsContainer.tsx` and showing an error when the target slot is in the past.
- Added a protective check in `submitForm` to avoid creating a new appointment if the submitted `startIso` is already in the past.
- Prevented drag-and-drop rescheduling into past slots by: (a) checking in container-level `moveAppointment`, (b) adding drag handlers in `web/src/components/appointments/AppointmentsCalendar.tsx` that set `dataTransfer.dropEffect = 'none'`, show a red cross overlay (`CloseRoundedIcon`) on invalid hover, and call `onPastSlotActionBlocked()` on attempted drop.

### Testing
- Ran TypeScript typecheck via `npm run -w web typecheck`, which failed in this environment due to a missing type definition for `vite/client` and not due to the feature logic.
- No other automated tests were modified or executed as part of this change in the current run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f2fb3bf08333afbb5bf98826a523)