### PR TITLE
Fix appointment dialog crash when creating from calendar slot

### DIFF
--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -131,7 +131,7 @@ export function AppointmentFormDialog({
   const startTimeValue = watch('startTime');
 
   useEffect(() => {
-    if (!open || editingItem) {
+    if (!open || editingItem || !startDateValue || !startTimeValue) {
       return;
     }
 

--- a/web/src/components/appointments/appointmentsUtils.ts
+++ b/web/src/components/appointments/appointmentsUtils.ts
@@ -53,10 +53,16 @@ export function toDatetimeLocal(iso: string, timeZone: string): string {
 }
 
 export function fromDatetimeLocal(value: string, timeZone: string): string {
+  const parsed = new Date(value);
+  const parsedMs = parsed.getTime();
+  if (!Number.isNaN(parsedMs)) {
+    return parsed.toISOString();
+  }
+
   const [datePart, timePart] = value.split('T');
 
   if (!datePart || !timePart) {
-    return new Date(value).toISOString();
+    return new Date().toISOString();
   }
 
   const [year, month, day] = datePart.split('-').map(Number);


### PR DESCRIPTION
### Motivation
- The appointment creation flow could throw `RangeError: Invalid time value` when the form tried to parse incomplete or invalid datetime-local inputs, crashing the dialog.
- The auto-calculation of `endTime` ran on initial renders even when `startDate`/`startTime` were empty, exposing the parsing bug.

### Description
- Made `fromDatetimeLocal` resilient by first attempting to parse the incoming value with `new Date(value)` and returning the parsed ISO when valid, and using a safe fallback for incomplete values instead of calling `toISOString()` on an `Invalid Date`.
- Changed the auto-end-time effect in `AppointmentFormDialog` to skip calculation unless both `startDate` and `startTime` are present, preventing usage of malformed strings like `T`.
- Files modified: `web/src/components/appointments/appointmentsUtils.ts` (improved `fromDatetimeLocal`) and `web/src/components/appointments/AppointmentFormDialog.tsx` (added guard in `useEffect`).

### Testing
- Ran type checking with `npm --prefix web run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f6dbfbf88333848ecf8e8cab30cc)