### PR TITLE
web: add global React error boundary

### DIFF
--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -11,6 +11,7 @@ import {
 } from '../shared/theme/constants';
 import { createAppTheme } from '../shared/theme/createAppTheme';
 import { router } from './router';
+import { AppErrorBoundary } from './AppErrorBoundary';
 
 function getInitialMode(): ThemeMode {
   const persisted = localStorage.getItem('ui-theme-mode');
@@ -42,15 +43,17 @@ export function App() {
   };
 
   return (
-    <ThemeSettingsContext.Provider value={{ mode, paletteVariantId, toggleMode, setPaletteVariantId }}>
-      <ThemeProvider theme={theme}>
-        <I18nProvider>
-          <AuthProvider>
-            <CssBaseline />
-            <RouterProvider router={router} />
-          </AuthProvider>
-        </I18nProvider>
-      </ThemeProvider>
-    </ThemeSettingsContext.Provider>
+    <AppErrorBoundary>
+      <ThemeSettingsContext.Provider value={{ mode, paletteVariantId, toggleMode, setPaletteVariantId }}>
+        <ThemeProvider theme={theme}>
+          <I18nProvider>
+            <AuthProvider>
+              <CssBaseline />
+              <RouterProvider router={router} />
+            </AuthProvider>
+          </I18nProvider>
+        </ThemeProvider>
+      </ThemeSettingsContext.Provider>
+    </AppErrorBoundary>
   );
 }

--- a/web/src/app/AppErrorBoundary.tsx
+++ b/web/src/app/AppErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Alert, Box, Button, Stack, Typography } from '@mui/material';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type AppErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  public state: AppErrorBoundaryState = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('Unhandled application error', error, errorInfo);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <Box
+          sx={{
+            minHeight: '100vh',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            px: 2
+          }}
+        >
+          <Stack spacing={2} sx={{ maxWidth: 560, width: '100%' }}>
+            <Typography variant="h4">Что-то пошло не так</Typography>
+            <Typography color="text.secondary">
+              Произошла непредвиденная ошибка интерфейса. Попробуйте перезагрузить страницу.
+            </Typography>
+            <Alert severity="error">Если проблема повторяется, обратитесь к администратору.</Alert>
+            <Button variant="contained" onClick={this.handleReload}>
+              Перезагрузить страницу
+            </Button>
+          </Stack>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
### Motivation
- Защитить UI от необработанных ошибок рендера и показать пользователю понятный fallback вместо падения приложения.

### Description
- Добавлен компонент `AppErrorBoundary` (`web/src/app/AppErrorBoundary.tsx`) с реализациями `getDerivedStateFromError` и `componentDidCatch`, логированием ошибки и UI с кнопкой перезагрузки.
- Обёрнут корневой дерево провайдеров/роутер в `AppErrorBoundary` в `web/src/app/App.tsx`, чтобы покрыть всё приложение одной границей ошибок.

### Testing
- Выполнена автоматическая проверка типов через `npm --prefix web run typecheck` и она прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f7932e408333ad6e9bd8cbd33e91)