### PR TITLE
Client-aware appointment create/edit flow with strict validation

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -54,6 +54,9 @@
 - [x] Сначала закрыть MVP-слайс: list/create/edit + cancel/reschedule (end-to-end через web + server).
 - [x] Добавить контракт и валидацию для lifecycle appointments (create/update/reschedule schemas + route-smoke coverage (service layer mocked)).
 - [x] Добавить lifecycle endpoints `mark-paid` и `notify` + smoke-тесты.
+- [x] Добавить обязательную валидацию `POST /api/appointments`: `appointmentAt`, `appointmentEndAt`, `firstName`, `lastName`, и один контакт (`username|phone|email`).
+- [x] Добавить выбор существующего клиента в web appointment form + автопредзаполнение полей клиента.
+- [x] Добавить автосоздание клиента при создании appointment, если выбранного клиента нет.
 - [ ] Добавить optimistic locking/versioning для защиты от одновременного редактирования.
 - [ ] Расширить аудит-лог действий (cancel/reschedule/mark-paid/notify): фильтрация, actor context, retention policy.
 - [ ] Добавить идемпотентность на операции с внешними уведомлениями.

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -67,7 +67,17 @@
 - `GET /api/appointments` возвращает:
   - `appointments[]` (UTC timestamps),
   - `specialists[]` с `timezone`,
+  - `clients[]` (клиенты текущего `account_id` для выбора в web-форме appointment),
   - `busySlots[]` из внешнего календаря (Google) в заданном диапазоне `from/to`.
+
+### Appointments create validation (текущее расширение)
+
+- `POST /api/appointments` требует:
+  - `appointmentAt`,
+  - `appointmentEndAt`,
+  - `firstName`,
+  - `lastName`,
+  - хотя бы одно поле контакта: `username` или `phone` или `email`.
 
 ### Timezone policy
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ scheduletm/
 
 ### Appointments MVP: что уже сделано
 
+- В формах создания/редактирования appointment добавлен выбор клиента из `clients` (фильтрация внутри текущего `account_id` на сервере).
+- Если выбран существующий клиент, поля контактов (`username`, `firstName`, `lastName`, `phone`, `email`) предзаполняются.
+- Если клиент не выбран, web позволяет ввести данные вручную; при создании appointment новый клиент автоматически создаётся в таблице `clients`.
+- Для `POST /api/appointments` добавлена обязательная валидация:
+  - `appointmentAt` (начало),
+  - `appointmentEndAt` (окончание),
+  - `firstName`,
+  - `lastName`,
+  - хотя бы одно из: `username` или `phone` или `email`.
 - Server: добавлены endpoint'ы `GET /api/appointments`, `POST /api/appointments`, `PATCH /api/appointments/:id`, `POST /api/appointments/:id/cancel`, `POST /api/appointments/:id/reschedule`.
 - В server добавлена базовая role-aware фильтрация:
   - `owner/admin` видят записи всех специалистов внутри своего `account_id`;

--- a/TODO.md
+++ b/TODO.md
@@ -48,6 +48,9 @@
 - [x] Добавить поля `status`, `paymentStatus`, `scheduledAt`, `meetingLink`, `notes`.
 - [x] Реализовать операции: подтверждение оплаты, отмена, перенос даты, ручное уведомление. *(cancel/reschedule/mark-paid/notify реализованы)*
 - [x] Добавить в web страницу списка и карточку редактирования appointment.
+- [x] Добавить выбор клиента в create/edit appointment + автопредзаполнение контактных полей.
+- [x] Добавить server-валидацию создания appointment (`appointmentAt`, `appointmentEndAt`, `firstName`, `lastName`, `username|phone|email`).
+- [x] При создании appointment автоматически создавать нового клиента, если не выбран существующий.
 
 ### 4.3 Meeting link strategy
 

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -74,21 +74,104 @@ export const specialistUserCreationSchema = z.object({
 
 const appointmentStatusSchema = z.enum(['new', 'confirmed', 'cancelled']);
 
+const appointmentClientSchema = z.object({
+  clientId: z.coerce.number().int().positive().optional(),
+  username: z.string().trim().max(255).optional(),
+  firstName: z.string().trim().min(1, 'Укажите имя').max(255).optional(),
+  lastName: z.string().trim().min(1, 'Укажите фамилию').max(255).optional(),
+  phone: z.string().trim().max(50).optional(),
+  email: z.string().trim().email('Введите корректный email').max(254).optional(),
+});
+
 export const appointmentCreateSchema = z.object({
   specialistId: z.coerce.number().int().positive('Укажите специалиста'),
-  scheduledAt: z.string().datetime('Укажите корректную дату и время'),
-  durationMin: z.coerce.number().int().min(15, 'Минимальная длительность — 15 минут').max(480, 'Максимальная длительность — 480 минут').optional(),
+  appointmentAt: z.string().datetime('Укажите корректную дату и время начала'),
+  appointmentEndAt: z.string().datetime('Укажите корректную дату и время окончания'),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url('Укажите корректную ссылку').max(2048).optional().or(z.literal('')),
   notes: z.string().trim().max(2000, 'Комментарий слишком длинный').optional(),
+}).merge(appointmentClientSchema).superRefine((value, ctx) => {
+  if (!value.firstName) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['firstName'], message: 'Укажите имя' });
+  }
+
+  if (!value.lastName) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['lastName'], message: 'Укажите фамилию' });
+  }
+
+  if (!value.username && !value.phone && !value.email && !value.clientId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['username'],
+      message: 'Укажите telegram username, телефон или email',
+    });
+  }
+
+  const start = new Date(value.appointmentAt).getTime();
+  const end = new Date(value.appointmentEndAt).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['appointmentEndAt'],
+      message: 'Время окончания должно быть позже времени начала',
+    });
+    return;
+  }
+
+  const durationMin = Math.round((end - start) / 60_000);
+  if (durationMin < 15 || durationMin > 480) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['appointmentEndAt'],
+      message: 'Длительность встречи должна быть от 15 до 480 минут',
+    });
+  }
 });
 
 export const appointmentUpdateSchema = z.object({
-  scheduledAt: z.string().datetime('Укажите корректную дату и время').optional(),
+  appointmentAt: z.string().datetime('Укажите корректную дату и время начала').optional(),
+  appointmentEndAt: z.string().datetime('Укажите корректную дату и время окончания').optional(),
   durationMin: z.coerce.number().int().min(15, 'Минимальная длительность — 15 минут').max(480, 'Максимальная длительность — 480 минут').optional(),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url('Укажите корректную ссылку').max(2048).optional().or(z.literal('')),
   notes: z.string().trim().max(2000, 'Комментарий слишком длинный').optional(),
+}).merge(appointmentClientSchema).superRefine((value, ctx) => {
+  if (Object.keys(value).length === 0) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: [], message: 'Передайте хотя бы одно поле для обновления' });
+    return;
+  }
+
+  if ((value.appointmentAt && !value.appointmentEndAt) || (!value.appointmentAt && value.appointmentEndAt)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['appointmentEndAt'],
+      message: 'Передайте и время начала, и время окончания',
+    });
+    return;
+  }
+
+  if (value.appointmentAt && value.appointmentEndAt) {
+    const start = new Date(value.appointmentAt).getTime();
+    const end = new Date(value.appointmentEndAt).getTime();
+
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['appointmentEndAt'],
+        message: 'Время окончания должно быть позже времени начала',
+      });
+      return;
+    }
+
+    const durationMin = Math.round((end - start) / 60_000);
+    if (durationMin < 15 || durationMin > 480) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['appointmentEndAt'],
+        message: 'Длительность встречи должна быть от 15 до 480 минут',
+      });
+    }
+  }
 }).refine((value) => Object.keys(value).length > 0, {
   message: 'Передайте хотя бы одно поле для обновления',
 });

--- a/server/src/db/migrations/20260424130000_add_last_name_to_clients.ts
+++ b/server/src/db/migrations/20260424130000_add_last_name_to_clients.ts
@@ -1,0 +1,31 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'clients';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE_NAME);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasLastName = await knex.schema.hasColumn(TABLE_NAME, 'last_name');
+  if (!hasLastName) {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+      table.string('last_name', 255).notNullable().defaultTo('');
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE_NAME);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasLastName = await knex.schema.hasColumn(TABLE_NAME, 'last_name');
+  if (hasLastName) {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+      table.dropColumn('last_name');
+    });
+  }
+}

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -16,6 +16,11 @@ export type AppointmentRecord = {
   service_id: number;
   created_at: Date;
   updated_at: Date;
+  client_first_name?: string | null;
+  client_last_name?: string | null;
+  client_username?: string | null;
+  client_phone?: string | null;
+  client_email?: string | null;
 };
 
 export type AppointmentAuditEventRecord = {
@@ -54,26 +59,35 @@ type UpdateAppointmentInput = {
   notes?: string | null;
   durationMin?: number;
   isPaid?: boolean;
+  userId?: number;
 };
 
 export async function listAppointments(filters: AppointmentListFilters): Promise<AppointmentRecord[]> {
   const query = db('appointments')
-    .where({ account_id: filters.accountId })
+    .leftJoin('clients', 'clients.id', 'appointments.user_id')
+    .where({ 'appointments.account_id': filters.accountId })
     .orderBy('appointment_at', 'asc');
 
   if (filters.specialistId) {
-    query.andWhere('specialist_id', filters.specialistId);
+    query.andWhere('appointments.specialist_id', filters.specialistId);
   }
 
   if (filters.from) {
-    query.andWhere('appointment_at', '>=', filters.from);
+    query.andWhere('appointments.appointment_at', '>=', filters.from);
   }
 
   if (filters.to) {
-    query.andWhere('appointment_at', '<=', filters.to);
+    query.andWhere('appointments.appointment_at', '<=', filters.to);
   }
 
-  return query.select<AppointmentRecord[]>('*');
+  return query.select<AppointmentRecord[]>(
+    'appointments.*',
+    'clients.first_name as client_first_name',
+    'clients.last_name as client_last_name',
+    'clients.username as client_username',
+    'clients.phone as client_phone',
+    'clients.email as client_email',
+  );
 }
 
 export async function findAppointmentById(accountId: number, id: number): Promise<AppointmentRecord | null> {
@@ -128,6 +142,10 @@ export async function updateAppointment(input: UpdateAppointmentInput): Promise<
 
   if (input.isPaid !== undefined) {
     payload.is_paid = input.isPaid;
+  }
+
+  if (input.userId !== undefined) {
+    payload.user_id = input.userId;
   }
 
   const [row] = await db('appointments')

--- a/server/src/repositories/clientRepository.ts
+++ b/server/src/repositories/clientRepository.ts
@@ -1,0 +1,109 @@
+import { db } from '../db/knex.js';
+
+export type ClientRecord = {
+  id: number;
+  account_id: number;
+  telegram_id: string | null;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  phone: string | null;
+  email: string | null;
+  timezone: string;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export type UpsertClientInput = {
+  accountId: number;
+  username?: string;
+  firstName: string;
+  lastName: string;
+  phone?: string;
+  email?: string;
+};
+
+function normalizeNullable(value?: string): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+export async function listClientsByAccount(accountId: number): Promise<ClientRecord[]> {
+  return db('clients')
+    .where({ account_id: accountId })
+    .orderBy([{ column: 'last_name', order: 'asc' }, { column: 'first_name', order: 'asc' }, { column: 'id', order: 'asc' }])
+    .select<ClientRecord[]>('*');
+}
+
+export async function findClientById(accountId: number, id: number): Promise<ClientRecord | null> {
+  const row = await db('clients')
+    .where({ account_id: accountId, id })
+    .first<ClientRecord>();
+
+  return row ?? null;
+}
+
+export async function findClientByContact(
+  accountId: number,
+  contact: { username?: string; phone?: string; email?: string },
+): Promise<ClientRecord | null> {
+  const username = normalizeNullable(contact.username);
+  const phone = normalizeNullable(contact.phone);
+  const email = normalizeNullable(contact.email)?.toLowerCase();
+
+  if (!username && !phone && !email) {
+    return null;
+  }
+
+  const query = db('clients')
+    .where({ account_id: accountId })
+    .andWhere((builder) => {
+      if (username) {
+        builder.orWhere('username', username);
+      }
+
+      if (phone) {
+        builder.orWhere('phone', phone);
+      }
+
+      if (email) {
+        builder.orWhereRaw('LOWER(email) = ?', [email]);
+      }
+    })
+    .orderBy('id', 'asc')
+    .first<ClientRecord>();
+
+  const row = await query;
+  return row ?? null;
+}
+
+export async function createClient(input: UpsertClientInput): Promise<ClientRecord> {
+  const [row] = await db('clients')
+    .insert({
+      account_id: input.accountId,
+      username: normalizeNullable(input.username),
+      first_name: input.firstName.trim(),
+      last_name: input.lastName.trim(),
+      phone: normalizeNullable(input.phone),
+      email: normalizeNullable(input.email),
+    })
+    .returning<ClientRecord[]>('*');
+
+  return row;
+}
+
+export async function updateClientById(accountId: number, id: number, input: UpsertClientInput): Promise<ClientRecord | null> {
+  const [row] = await db('clients')
+    .where({ account_id: accountId, id })
+    .update({
+      username: normalizeNullable(input.username),
+      first_name: input.firstName.trim(),
+      last_name: input.lastName.trim(),
+      phone: normalizeNullable(input.phone),
+      email: normalizeNullable(input.email),
+      updated_at: db.fn.now(),
+    })
+    .returning<ClientRecord[]>('*');
+
+  return row ?? null;
+}

--- a/server/src/routes/appointmentRoutes.ts
+++ b/server/src/routes/appointmentRoutes.ts
@@ -63,6 +63,10 @@ appointmentRoutes.post('/', async (req, res) => {
       return res.status(404).json({ message: 'Специалист не найден' });
     }
 
+    if (message === 'CLIENT_NOT_FOUND') {
+      return res.status(404).json({ message: 'Клиент не найден' });
+    }
+
     console.error(error);
     return res.status(500).json({ message: 'Не удалось создать запись' });
   }
@@ -92,6 +96,9 @@ appointmentRoutes.patch('/:id', async (req, res) => {
     const message = error instanceof Error ? error.message : 'UNKNOWN';
     if (message === 'FORBIDDEN_SPECIALIST') {
       return res.status(403).json({ message: 'Недостаточно прав для этой записи' });
+    }
+    if (message === 'CLIENT_NOT_FOUND') {
+      return res.status(404).json({ message: 'Клиент не найден' });
     }
 
     console.error(error);

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -5,13 +5,20 @@ import {
   type AppointmentAuditAction,
   type AppointmentStatus,
   createAppointment,
-  ensureFallbackClientForAccount,
   ensureFallbackServiceForAccount,
   findAppointmentById,
   listAppointmentEventsByAppointmentIds,
   listAppointments,
   updateAppointment,
 } from '../repositories/appointmentRepository.js';
+import {
+  createClient,
+  findClientByContact,
+  findClientById,
+  listClientsByAccount,
+  type ClientRecord,
+  updateClientById,
+} from '../repositories/clientRepository.js';
 import {
   findSpecialistById,
   findSpecialistByWebUserId,
@@ -22,6 +29,15 @@ import { listExternalBusySlots, type ExternalBusySlot } from './calendarAvailabi
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 
+type AppointmentClientDto = {
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  email: string;
+};
+
 type AppointmentDto = {
   id: number;
   specialistId: number;
@@ -31,6 +47,7 @@ type AppointmentDto = {
   paymentStatus: 'paid' | 'unpaid';
   meetingLink: string;
   notes: string;
+  client: AppointmentClientDto;
   events: AppointmentEventDto[];
 };
 
@@ -42,25 +59,36 @@ type AppointmentEventDto = {
 type AppointmentListResult = {
   appointments: AppointmentDto[];
   specialists: Array<{ id: number; name: string; timezone: string; slotStepMin: number }>;
+  clients: AppointmentClientDto[];
   busySlots: ExternalBusySlot[];
+};
+
+type AppointmentClientPayload = {
+  clientId?: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
 };
 
 type CreateAppointmentPayload = {
   specialistId: number;
-  scheduledAt: string;
-  durationMin?: number;
+  appointmentAt: string;
+  appointmentEndAt: string;
   status?: AppointmentStatus;
   meetingLink?: string;
   notes?: string;
-};
+} & AppointmentClientPayload;
 
 type UpdateAppointmentPayload = {
-  scheduledAt?: string;
+  appointmentAt?: string;
+  appointmentEndAt?: string;
   durationMin?: number;
   status?: AppointmentStatus;
   meetingLink?: string;
   notes?: string;
-};
+} & AppointmentClientPayload;
 
 function canManageAllAppointments(role: WebUserRole): boolean {
   return role === WebUserRole.Owner || role === WebUserRole.Admin;
@@ -99,6 +127,17 @@ function composeNotes(meetingLink: string | undefined, notes: string | undefined
   return [`meetingLink: ${normalizedMeetingLink}`, normalizedNotes].filter(Boolean).join('\n');
 }
 
+function mapClient(row: ClientRecord): AppointmentClientDto {
+  return {
+    id: row.id,
+    username: row.username ?? '',
+    firstName: row.first_name ?? '',
+    lastName: row.last_name ?? '',
+    phone: row.phone ?? '',
+    email: row.email ?? '',
+  };
+}
+
 function mapAppointment(row: AppointmentRecord): AppointmentDto {
   const parsed = parseMeetingLinkFromNotes(row.comment);
 
@@ -111,6 +150,14 @@ function mapAppointment(row: AppointmentRecord): AppointmentDto {
     paymentStatus: row.is_paid ? 'paid' : 'unpaid',
     notes: parsed.notes,
     meetingLink: parsed.meetingLink,
+    client: {
+      id: row.user_id,
+      username: row.client_username ?? '',
+      firstName: row.client_first_name ?? '',
+      lastName: row.client_last_name ?? '',
+      phone: row.client_phone ?? '',
+      email: row.client_email ?? '',
+    },
     events: [],
   };
 }
@@ -198,6 +245,68 @@ function filterBusySlotsOverlappingAppointments(
   });
 }
 
+function resolveDurationFromRange(appointmentAt: string, appointmentEndAt: string): number {
+  const start = new Date(appointmentAt).getTime();
+  const end = new Date(appointmentEndAt).getTime();
+
+  return Math.round((end - start) / 60_000);
+}
+
+async function resolveClientId(accountId: number, payload: AppointmentClientPayload): Promise<number> {
+  if (payload.clientId) {
+    const existing = await findClientById(accountId, payload.clientId);
+    if (!existing) {
+      throw new Error('CLIENT_NOT_FOUND');
+    }
+
+    if (payload.firstName && payload.lastName) {
+      await updateClientById(accountId, payload.clientId, {
+        accountId,
+        username: payload.username,
+        firstName: payload.firstName,
+        lastName: payload.lastName,
+        phone: payload.phone,
+        email: payload.email,
+      });
+    }
+
+    return existing.id;
+  }
+
+  if (!payload.firstName || !payload.lastName) {
+    throw new Error('CLIENT_NAME_REQUIRED');
+  }
+
+  const matched = await findClientByContact(accountId, {
+    username: payload.username,
+    phone: payload.phone,
+    email: payload.email,
+  });
+
+  if (matched) {
+    await updateClientById(accountId, matched.id, {
+      accountId,
+      username: payload.username,
+      firstName: payload.firstName,
+      lastName: payload.lastName,
+      phone: payload.phone,
+      email: payload.email,
+    });
+    return matched.id;
+  }
+
+  const created = await createClient({
+    accountId,
+    username: payload.username,
+    firstName: payload.firstName,
+    lastName: payload.lastName,
+    phone: payload.phone,
+    email: payload.email,
+  });
+
+  return created.id;
+}
+
 export async function getAppointments(
   actor: User,
   filters: { from?: string; to?: string; specialistId?: number },
@@ -246,6 +355,7 @@ export async function getAppointments(
       events: eventsByAppointmentId.get(item.id) ?? [],
     })),
     specialists,
+    clients: (await listClientsByAccount(accountId)).map(mapClient),
     busySlots: filterBusySlotsOverlappingAppointments(appointmentsForUi, busySlots),
   };
 }
@@ -269,22 +379,25 @@ export async function createAppointmentForActor(
   }
 
   const [userId, serviceId] = await Promise.all([
-    ensureFallbackClientForAccount(accountId),
+    resolveClientId(accountId, payload),
     ensureFallbackServiceForAccount(accountId),
   ]);
 
   const created = await createAppointment({
     accountId,
     specialistId: payload.specialistId,
-    scheduledAt: new Date(payload.scheduledAt),
+    scheduledAt: new Date(payload.appointmentAt),
     status: payload.status ?? 'new',
     notes: composeNotes(payload.meetingLink, payload.notes),
     userId,
     serviceId,
-    durationMin: payload.durationMin ?? 30,
+    durationMin: resolveDurationFromRange(payload.appointmentAt, payload.appointmentEndAt),
   });
 
-  return mapAppointment(created);
+  const rows = await listAppointments({ accountId, specialistId: created.specialist_id });
+  const hydrated = rows.find((item) => item.id === created.id) ?? created;
+
+  return mapAppointment(hydrated);
 }
 
 async function resolveManagedAppointment(actor: User, appointmentId: number) {
@@ -332,18 +445,36 @@ export async function updateAppointmentForActor(
     return null;
   }
 
+  const appointmentAt = payload.appointmentAt;
+  const appointmentEndAt = payload.appointmentEndAt;
+  const durationMin = appointmentAt && appointmentEndAt
+    ? resolveDurationFromRange(appointmentAt, appointmentEndAt)
+    : payload.durationMin;
+
+  const userId = payload.clientId || payload.firstName || payload.lastName || payload.username || payload.phone || payload.email
+    ? await resolveClientId(accountId, payload)
+    : undefined;
+
   const updated = await updateAppointment({
     accountId,
     id: appointmentId,
-    scheduledAt: payload.scheduledAt ? new Date(payload.scheduledAt) : undefined,
-    durationMin: payload.durationMin,
+    scheduledAt: appointmentAt ? new Date(appointmentAt) : undefined,
+    durationMin,
     status: payload.status,
+    userId,
     notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink')
       ? composeNotes(payload.meetingLink, payload.notes)
       : undefined,
   });
 
-  return updated ? mapAppointment(updated) : null;
+  if (!updated) {
+    return null;
+  }
+
+  const rows = await listAppointments({ accountId, specialistId: updated.specialist_id });
+  const hydrated = rows.find((item) => item.id === updated.id) ?? updated;
+
+  return mapAppointment(hydrated);
 }
 
 export async function cancelAppointmentForActor(actor: User, appointmentId: number): Promise<AppointmentDto | null> {
@@ -364,7 +495,15 @@ export async function rescheduleAppointmentForActor(
   appointmentId: number,
   scheduledAt: string,
 ): Promise<AppointmentDto | null> {
-  const updated = await updateAppointmentForActor(actor, appointmentId, { scheduledAt });
+  const { existing } = await resolveManagedAppointment(actor, appointmentId);
+  if (!existing) {
+    return null;
+  }
+
+  const updated = await updateAppointmentForActor(actor, appointmentId, {
+    appointmentAt: scheduledAt,
+    appointmentEndAt: new Date(new Date(scheduledAt).getTime() + existing.duration_min * 60_000).toISOString(),
+  });
 
   if (!updated) {
     return null;
@@ -395,7 +534,10 @@ export async function markPaidAppointmentForActor(actor: User, appointmentId: nu
 
   await appendAuditEvent(accountId, appointmentId, actor, 'mark-paid');
 
-  return mapAppointment(updated);
+  const rows = await listAppointments({ accountId, specialistId: updated.specialist_id });
+  const hydrated = rows.find((item) => item.id === updated.id) ?? updated;
+
+  return mapAppointment(hydrated);
 }
 
 export async function notifyAppointmentForActor(actor: User, appointmentId: number): Promise<AppointmentDto | null> {
@@ -407,5 +549,8 @@ export async function notifyAppointmentForActor(actor: User, appointmentId: numb
 
   await appendAuditEvent(accountId, appointmentId, actor, 'notify');
 
-  return mapAppointment(existing);
+  const rows = await listAppointments({ accountId, specialistId: existing.specialist_id });
+  const hydrated = rows.find((item) => item.id === existing.id);
+
+  return mapAppointment(hydrated ?? existing);
 }

--- a/server/tests/appointments.routes.smoke.test.ts
+++ b/server/tests/appointments.routes.smoke.test.ts
@@ -85,8 +85,11 @@ describe('appointments API route-smoke scenarios (mocked service layer)', () => 
       },
       body: JSON.stringify({
         specialistId: 8,
-        scheduledAt: '2026-04-23T10:30:00.000Z',
-        durationMin: 30,
+        appointmentAt: '2026-04-23T10:30:00.000Z',
+        appointmentEndAt: '2026-04-23T11:00:00.000Z',
+        firstName: 'Smoke',
+        lastName: 'Client',
+        username: 'smoke_client',
         status: 'new',
         notes: 'smoke create',
       }),

--- a/server/tests/appointments.smoke.test.ts
+++ b/server/tests/appointments.smoke.test.ts
@@ -79,8 +79,11 @@ describe('appointments API smoke scenarios', () => {
       },
       body: JSON.stringify({
         specialistId: 8,
-        scheduledAt: '2026-04-23T10:30:00.000Z',
-        durationMin: 30,
+        appointmentAt: '2026-04-23T10:30:00.000Z',
+        appointmentEndAt: '2026-04-23T11:00:00.000Z',
+        firstName: 'Smoke',
+        lastName: 'Client',
+        username: 'smoke_client',
         status: 'new',
         notes: 'smoke create',
       }),

--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import type { AppointmentItem, AppointmentStatus, SpecialistItem } from '../../shared/types/api';
+import type { AppointmentItem, AppointmentStatus, ClientItem, SpecialistItem } from '../../shared/types/api';
 import { AppButton } from '../../shared/ui/AppButton';
 import { AppRhfTextField } from '../../shared/ui/AppRhfTextField';
 import {
@@ -32,11 +32,21 @@ import {
 
 import type { TranslationKey } from '../../shared/i18n/dictionaries';
 
+type AppointmentFormState = EditFormState & {
+  clientId: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  email: string;
+};
+
 type Props = {
   t: (key: TranslationKey) => string;
   open: boolean;
   editingItem: AppointmentItem | null;
   specialists: SpecialistItem[];
+  clients: ClientItem[];
   selectedSpecialistId: number | 'all';
   selectedSlotStepMin: number;
   initialScheduledAtIso: string | null;
@@ -53,19 +63,31 @@ type Props = {
     status: AppointmentStatus;
     meetingLink: string;
     notes: string;
-    startIso: string;
-    durationMin: number;
+    appointmentAt: string;
+    appointmentEndAt: string;
+    clientId?: number;
+    username: string;
+    firstName: string;
+    lastName: string;
+    phone: string;
+    email: string;
   }) => Promise<void>;
 };
 
-const EMPTY_FORM: EditFormState = {
+const EMPTY_FORM: AppointmentFormState = {
   specialistId: '',
+  clientId: '',
   startDate: '',
   startTime: '',
   endTime: '',
   status: 'new',
   meetingLink: '',
   notes: '',
+  username: '',
+  firstName: '',
+  lastName: '',
+  phone: '',
+  email: '',
 };
 
 export function AppointmentFormDialog({
@@ -73,6 +95,7 @@ export function AppointmentFormDialog({
   open,
   editingItem,
   specialists,
+  clients,
   selectedSpecialistId,
   selectedSlotStepMin,
   initialScheduledAtIso,
@@ -101,13 +124,19 @@ export function AppointmentFormDialog({
 
       return {
         specialistId: String(editingItem.specialistId),
+        clientId: String(editingItem.client?.id ?? ''),
         startDate: times.startDate,
         startTime: times.startTime,
         endTime: times.endTime,
         status: editingItem.status,
         meetingLink: editingItem.meetingLink,
         notes: editingItem.notes,
-      } satisfies EditFormState;
+        username: editingItem.client?.username ?? '',
+        firstName: editingItem.client?.firstName ?? '',
+        lastName: editingItem.client?.lastName ?? '',
+        phone: editingItem.client?.phone ?? '',
+        email: editingItem.client?.email ?? '',
+      } satisfies AppointmentFormState;
     }
 
     const times = createFormValuesFromAppointmentAt(
@@ -118,16 +147,22 @@ export function AppointmentFormDialog({
 
     return {
       specialistId: defaultSpecialistId ? String(defaultSpecialistId) : '',
+      clientId: '',
       startDate: times.startDate,
       startTime: times.startTime,
       endTime: times.endTime,
       status: 'new',
       meetingLink: '',
       notes: '',
-    } satisfies EditFormState;
+      username: '',
+      firstName: '',
+      lastName: '',
+      phone: '',
+      email: '',
+    } satisfies AppointmentFormState;
   }, [editingItem, initialScheduledAtIso, selectedSlotStepMin, selectedSpecialistId, specialists]);
 
-  const { control, handleSubmit, reset, watch, setValue } = useForm<EditFormState>({
+  const { control, handleSubmit, reset, watch, setValue } = useForm<AppointmentFormState>({
     defaultValues: EMPTY_FORM,
   });
 
@@ -140,6 +175,21 @@ export function AppointmentFormDialog({
     setFormTimeZone(BROWSER_TIMEZONE);
     setShowTimezoneSelect(false);
   }, [initialValues, open, reset]);
+
+  const selectedClientId = watch('clientId');
+
+  useEffect(() => {
+    const selectedClient = clients.find((item) => String(item.id) === selectedClientId);
+    if (!selectedClient) {
+      return;
+    }
+
+    setValue('username', selectedClient.username, { shouldDirty: true });
+    setValue('firstName', selectedClient.firstName, { shouldDirty: true });
+    setValue('lastName', selectedClient.lastName, { shouldDirty: true });
+    setValue('phone', selectedClient.phone, { shouldDirty: true });
+    setValue('email', selectedClient.email, { shouldDirty: true });
+  }, [clients, selectedClientId, setValue]);
 
   const startDateValue = watch('startDate');
   const startTimeValue = watch('startTime');
@@ -162,15 +212,20 @@ export function AppointmentFormDialog({
     }
 
     const { startIso, endIso } = buildStartEndIso(form, formTimeZone);
-    const durationMin = Math.max(selectedSlotStepMin, Math.round((new Date(endIso).getTime() - new Date(startIso).getTime()) / 60_000));
 
     await onSubmit({
       specialistId,
       status: form.status,
       meetingLink: form.meetingLink,
       notes: form.notes,
-      startIso,
-      durationMin,
+      appointmentAt: startIso,
+      appointmentEndAt: endIso,
+      clientId: form.clientId ? Number(form.clientId) : undefined,
+      username: form.username,
+      firstName: form.firstName,
+      lastName: form.lastName,
+      phone: form.phone,
+      email: form.email,
     });
   });
 
@@ -228,39 +283,42 @@ export function AppointmentFormDialog({
             )}
           />
           <Controller
-            name="startDate"
+            name="clientId"
             control={control}
             render={({ field }: any) => (
-              <AppRhfTextField
-                field={field}
-                label="Start date"
-                type="date"
-              />
+              <FormControl>
+                <InputLabel id="client-label">Client</InputLabel>
+                <Select
+                  labelId="client-label"
+                  label="Client"
+                  value={field.value}
+                  onChange={(event) => field.onChange(String(event.target.value))}
+                >
+                  <MenuItem value="">New client</MenuItem>
+                  {clients.map((client) => (
+                    <MenuItem key={client.id} value={String(client.id)}>{`${client.firstName} ${client.lastName}`.trim()}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
             )}
           />
+
+          <Controller name="firstName" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="First name" />} />
+          <Controller name="lastName" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="Last name" />} />
+          <Controller name="username" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="Telegram username" />} />
+          <Controller name="phone" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="Phone" />} />
+          <Controller name="email" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="Email" />} />
+
+          <Controller name="startDate" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="Start date" type="date" />} />
           <Controller
             name="startTime"
             control={control}
-            render={({ field }: any) => (
-              <AppRhfTextField
-                field={field}
-                label="Start time"
-                type="time"
-                minutesStep={selectedSlotStepMin}
-              />
-            )}
+            render={({ field }: any) => <AppRhfTextField field={field} label="Start time" type="time" minutesStep={selectedSlotStepMin} />}
           />
           <Controller
             name="endTime"
             control={control}
-            render={({ field }: any) => (
-              <AppRhfTextField
-                field={field}
-                label="End time"
-                type="time"
-                minutesStep={selectedSlotStepMin}
-              />
-            )}
+            render={({ field }: any) => <AppRhfTextField field={field} label="End time" type="time" minutesStep={selectedSlotStepMin} />}
           />
           <Controller
             name="status"
@@ -281,19 +339,11 @@ export function AppointmentFormDialog({
               </FormControl>
             )}
           />
-          <Controller
-            name="meetingLink"
-            control={control}
-            render={({ field }: any) => (
-              <AppRhfTextField field={field} label={t('appointments.fields.meetingLink')} />
-            )}
-          />
+          <Controller name="meetingLink" control={control} render={({ field }: any) => <AppRhfTextField field={field} label={t('appointments.fields.meetingLink')} />} />
           <Controller
             name="notes"
             control={control}
-            render={({ field }: any) => (
-              <AppRhfTextField field={field} label={t('appointments.fields.notes')} multiline minRows={3} />
-            )}
+            render={({ field }: any) => <AppRhfTextField field={field} label={t('appointments.fields.notes')} multiline minRows={3} />}
           />
           {editingItem && (
             <Stack spacing={1}>

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -38,7 +38,7 @@ import {
 import { apiClient, authHeaders } from '../shared/api/client';
 import { useAuth } from '../shared/auth/AuthContext';
 import { useI18n } from '../shared/i18n/I18nContext';
-import type { AppointmentItem, AppointmentListResponse, SpecialistItem } from '../shared/types/api';
+import type { AppointmentItem, AppointmentListResponse, ClientItem, SpecialistItem } from '../shared/types/api';
 import { WebUserRole } from '../shared/types/roles';
 import { AppPage } from '../shared/ui/AppPage';
 
@@ -49,6 +49,7 @@ export function AppointmentsContainer() {
 
   const [appointments, setAppointments] = useState<AppointmentItem[]>([]);
   const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
+  const [clients, setClients] = useState<ClientItem[]>([]);
   const [busySlots, setBusySlots] = useState<AppointmentListResponse['busySlots']>([]);
   const [selectedSpecialistId, setSelectedSpecialistId] = useState<number | 'all'>('all');
   const displayTimeZone = BROWSER_TIMEZONE;
@@ -185,6 +186,7 @@ export function AppointmentsContainer() {
 
       setAppointments(response.data.appointments);
       setSpecialists(response.data.specialists);
+      setClients(response.data.clients ?? []);
       setBusySlots(response.data.busySlots ?? []);
       setError('');
     } catch {
@@ -232,11 +234,17 @@ export function AppointmentsContainer() {
 
   const submitForm = async (payload: {
     specialistId: number;
-    startIso: string;
-    durationMin: number;
+    appointmentAt: string;
+    appointmentEndAt: string;
     status: AppointmentItem['status'];
     meetingLink: string;
     notes: string;
+    clientId?: number;
+    username: string;
+    firstName: string;
+    lastName: string;
+    phone: string;
+    email: string;
   }) => {
     if (!accessToken) {
       return;
@@ -245,29 +253,41 @@ export function AppointmentsContainer() {
     setIsSubmittingForm(true);
 
     try {
-      if (!editingItem && new Date(payload.startIso).getTime() < Date.now()) {
+      if (!editingItem && new Date(payload.appointmentAt).getTime() < Date.now()) {
         showPastSlotError();
         return;
       }
 
       if (editingItem) {
         await apiClient.patch(`/api/appointments/${editingItem.id}`, {
-          scheduledAt: payload.startIso,
-          durationMin: payload.durationMin,
+          appointmentAt: payload.appointmentAt,
+          appointmentEndAt: payload.appointmentEndAt,
           status: payload.status,
           meetingLink: payload.meetingLink,
           notes: payload.notes,
+          clientId: payload.clientId,
+          username: payload.username,
+          firstName: payload.firstName,
+          lastName: payload.lastName,
+          phone: payload.phone,
+          email: payload.email,
         }, {
           headers: authHeaders(accessToken),
         });
       } else {
         await apiClient.post('/api/appointments', {
           specialistId: payload.specialistId,
-          scheduledAt: payload.startIso,
-          durationMin: payload.durationMin,
+          appointmentAt: payload.appointmentAt,
+          appointmentEndAt: payload.appointmentEndAt,
           status: payload.status,
           meetingLink: payload.meetingLink,
           notes: payload.notes,
+          clientId: payload.clientId,
+          username: payload.username,
+          firstName: payload.firstName,
+          lastName: payload.lastName,
+          phone: payload.phone,
+          email: payload.email,
         }, {
           headers: authHeaders(accessToken),
         });
@@ -497,6 +517,7 @@ export function AppointmentsContainer() {
         open={isCreateOpen}
         editingItem={editingItem}
         specialists={specialists}
+        clients={clients}
         selectedSpecialistId={selectedSpecialistId}
         selectedSlotStepMin={selectedSlotStepMin}
         initialScheduledAtIso={createInitialScheduledAtIso}
@@ -513,11 +534,17 @@ export function AppointmentsContainer() {
         onNotifyClient={notifyClient}
         onSubmit={(payload) => submitForm({
           specialistId: payload.specialistId,
-          startIso: payload.startIso,
-          durationMin: payload.durationMin,
+          appointmentAt: payload.appointmentAt,
+          appointmentEndAt: payload.appointmentEndAt,
           status: payload.status,
           meetingLink: payload.meetingLink,
           notes: payload.notes,
+          clientId: payload.clientId,
+          username: payload.username,
+          firstName: payload.firstName,
+          lastName: payload.lastName,
+          phone: payload.phone,
+          email: payload.email,
         })}
       />
     </AppPage>

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -56,15 +56,26 @@ export type AppointmentItem = {
   paymentStatus: 'paid' | 'unpaid';
   meetingLink: string;
   notes: string;
+  client: ClientItem;
   events: Array<{
     action: 'cancel' | 'reschedule' | 'mark-paid' | 'notify';
     createdAt: string;
   }>;
 };
 
+export type ClientItem = {
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  email: string;
+};
+
 export type AppointmentListResponse = {
   appointments: AppointmentItem[];
   specialists: SpecialistItem[];
+  clients: ClientItem[];
   busySlots: Array<{
     specialistId: number;
     scheduledAt: string;


### PR DESCRIPTION
### Motivation

- Ensure appointment creation/editing can attach an existing client (filtered by `account_id`) or capture a new client when none is selected. 
- Pre-fill contact fields when an existing client is chosen to improve UX and reduce input errors. 
- Enforce server-side validation for appointment time range and required client contact data to avoid invalid records. 

### Description

- Added a new repository `server/src/repositories/clientRepository.ts` to list/find/create/update clients and a migration `20260424130000_add_last_name_to_clients.ts` to ensure `clients.last_name` exists. 
- Extended appointment persistence: `server/src/repositories/appointmentRepository.ts` now left-joins `clients` and returns client fields, and supports updating `user_id` on appointment update. 
- Implemented client-aware business logic in `server/src/services/appointmentService.ts` including `resolveClientId` which finds/updates/creates clients, computes appointment duration from `appointmentAt`/`appointmentEndAt`, and hydrates appointment responses with client data. 
- Updated API validation schemas in `server/src/config/schemas.ts` to require `appointmentAt`, `appointmentEndAt`, `firstName`, `lastName`, and at least one contact (`username` or `phone` or `email`) for creation, plus corresponding update refinements. 
- Routes now surface client-related errors (404 on missing client) in `server/src/routes/appointmentRoutes.ts`. 
- Frontend changes: `web/src/components/appointments/AppointmentFormDialog.tsx` and `web/src/containers/AppointmentsContainer.tsx` add client selection (prefill fields when selecting a client), send client fields and `appointmentAt`/`appointmentEndAt` to the API, and load `clients` from `GET /api/appointments`. Type definitions were updated (`web/src/shared/types/api.ts`). 
- Updated smoke tests to the new payload shape and added minimal payload data for client creation (`server/tests/*.test.ts`). 
- Documentation updated to reflect the behavior and validation: `README.md`, `TODO.md`, `PROJECT_MAP.md`, and `PRODUCTION_READINESS_CHECKLIST.md`.

### Testing

- Ran TypeScript checks for server and web with `npm run -w @scheduletm/server typecheck` and `npm run -w @scheduletm/web typecheck`, both succeeded. 
- Executed route smoke tests with Vitest (server) using a real connection string in the environment: `cd server && DATABASE_PUBLIC_URL=... npx vitest run --config vitest.config.ts tests/appointments.routes.smoke.test.ts`, and the test suite passed (5/5 tests). 
- No UI end-to-end browser tests were run in this environment (form behavior was exercised via updated smoke tests and typechecks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4ec5c96083338e19a07b783e38c0)