### PR TITLE
Specialists: create from filtered web_users and restrict management to owner/admin

### DIFF
--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -32,7 +32,8 @@
   - `web/src/components/layout/UserMenu.tsx` — профиль в header (avatar/инициалы, меню settings/logout).
   - `web/src/shared/ui/*` — базовые MUI-wrapper компоненты (`AppButton`, `AppTabs`, `AppForm`, `AppTextField`, `AppPage`, `AppIcons`).
   - Формы страниц `login/register/settings` управляются через `react-hook-form` (`Controller` + `useForm`).
-  - Управление специалистами вынесено в отдельную страницу `web/src/pages/SpecialistsPage.tsx` и контейнер `web/src/containers/SpecialistsContainer.tsx` (раздел `/specialists` в левом меню для `owner/admin`).
+  - Управление специалистами вынесено в отдельную страницу `web/src/pages/SpecialistsPage.tsx` и контейнер `web/src/containers/SpecialistsContainer.tsx` (раздел `/specialists` в левом меню только для `owner/admin`).
+  - Добавление специалиста выполняется через dropdown пользователей из `web_users` текущего `account_id` с фильтрацией `role = specialist` и `is_active = true`.
   - `web/src/shared/theme/*` — константы дизайна + фабрика темы + light/dark + palette variants.
   - `web/src/shared/*` — API client, типы, auth context и переиспользуемая инфраструктура.
   - `web/src/shared/api/client.ts` — глобальный `401` handler: при `Unauthorized` очищает auth-state и переводит пользователя на `/login`.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ scheduletm/
 - `access_token` Google сохраняется в `web_users.google_api_key` для текущего web-пользователя (под будущую ролевую модель, где специалист логинится сам).
 - После успешного callback пользователь возвращается на `/settings`, а в настройках отмечается `googleConnected: true`.
 - Управление специалистами вынесено из `Settings` в отдельный раздел `/specialists` в левом меню (для `owner/admin`).
+- На странице `/specialists` создание специалиста теперь выполняется через выбор из `web_users` текущего `account_id` (только `role = specialist` и `is_active = true`, исключая уже привязанные профили специалистов).
 - Переменные окружения добавлены в `server/.env.example`: `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URI`, `GOOGLE_OAUTH_SCOPES`.
 
 Текущее состояние модели данных для Google:

--- a/TODO.md
+++ b/TODO.md
@@ -111,3 +111,5 @@
 - [x] Добавить кнопки-иконки edit/delete в таблице специалистов.
 - [x] Добавить unit/smoke тесты для нового specialists-модуля.
 - [x] Вынести управление specialists из `Settings` в отдельный пункт меню `/specialists`.
+- [x] Добавить создание специалиста через dropdown `web_users` (`account_id` + `role=specialist` + `is_active=true`) вместо ручного ввода.
+- [x] Ограничить видимость меню `/specialists` и операции добавления ролями `owner/admin`.

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -75,7 +75,7 @@ export const specialistUserCreationSchema = z.object({
 
 
 export const specialistCreateSchema = z.object({
-  name: z.string().trim().min(2, 'Имя специалиста должно содержать минимум 2 символа').max(120, 'Имя специалиста слишком длинное'),
+  userId: z.coerce.number().int().positive('Выберите пользователя специалиста'),
 });
 
 export const specialistUpdateSchema = z.object({

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -62,6 +62,7 @@ type CreateSpecialistInput = {
   accountId: number;
   name: string;
   code: string;
+  userId: number;
 };
 
 export async function createSpecialist(input: CreateSpecialistInput): Promise<number> {
@@ -72,7 +73,7 @@ export async function createSpecialist(input: CreateSpecialistInput): Promise<nu
       name: input.name,
       is_active: true,
       is_default: false,
-      user_id: null,
+      user_id: input.userId,
     })
     .returning<{ id: number }[]>('id');
 

--- a/server/src/repositories/webUserRepository.ts
+++ b/server/src/repositories/webUserRepository.ts
@@ -32,6 +32,11 @@ type CreateWebUserInput = {
   timezone?: string;
 };
 
+export type SpecialistWebUserOption = {
+  id: number;
+  email: string;
+};
+
 export async function findWebUserByEmail(accountId: number, email: string): Promise<WebUserRecord | null> {
   const row = await db('web_users')
     .where({ account_id: accountId, email })
@@ -46,6 +51,19 @@ export async function findWebUserById(accountId: number, id: number): Promise<We
     .first<WebUserRecord>();
 
   return row ?? null;
+}
+
+export async function listActiveSpecialistWebUsersWithoutProfile(accountId: number): Promise<SpecialistWebUserOption[]> {
+  return db('web_users as wu')
+    .leftJoin('specialists as s', function joinSpecialists() {
+      this.on('s.user_id', '=', 'wu.id').andOn('s.account_id', '=', 'wu.account_id');
+    })
+    .where('wu.account_id', accountId)
+    .where('wu.role', 'specialist')
+    .where('wu.is_active', true)
+    .whereNull('s.id')
+    .orderBy('wu.email', 'asc')
+    .select('wu.id', 'wu.email');
 }
 
 export async function createWebUser(input: CreateWebUserInput): Promise<WebUserRecord> {

--- a/server/src/routes/specialistRoutes.ts
+++ b/server/src/routes/specialistRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { specialistCreateSchema, specialistUpdateSchema } from '../config/schemas.js';
 import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
 import {
+  getAvailableSpecialistWebUsersForActor,
   createSpecialistForActor,
   deleteSpecialistForActor,
   getSpecialistsForActor,
@@ -17,7 +18,11 @@ specialistRoutes.get('/', async (req, res) => {
   const actor = (req as unknown as AuthedRequest).user;
 
   try {
-    return res.json({ specialists: await getSpecialistsForActor(actor) });
+    const [specialists, availableWebUsers] = await Promise.all([
+      getSpecialistsForActor(actor),
+      getAvailableSpecialistWebUsersForActor(actor),
+    ]);
+    return res.json({ specialists, availableWebUsers });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ message: 'Не удалось загрузить специалистов' });
@@ -39,6 +44,9 @@ specialistRoutes.post('/', async (req, res) => {
     const message = error instanceof Error ? error.message : 'UNKNOWN';
     if (message === 'FORBIDDEN') {
       return res.status(403).json({ message: 'Недостаточно прав для создания специалиста' });
+    }
+    if (message === 'WEB_USER_NOT_AVAILABLE') {
+      return res.status(400).json({ message: 'Пользователь специалиста недоступен для добавления' });
     }
 
     console.error(error);

--- a/server/src/services/specialistService.ts
+++ b/server/src/services/specialistService.ts
@@ -7,6 +7,7 @@ import {
   updateSpecialistById,
 } from '../repositories/specialistRepository.js';
 import { countAppointmentsBySpecialistId } from '../repositories/appointmentRepository.js';
+import { findWebUserById, listActiveSpecialistWebUsersWithoutProfile } from '../repositories/webUserRepository.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 
@@ -20,12 +21,17 @@ type SpecialistDto = {
 };
 
 type SpecialistCreatePayload = {
-  name: string;
+  userId: number;
 };
 
 type SpecialistUpdatePayload = {
   name?: string;
   isActive?: boolean;
+};
+
+export type SpecialistWebUserOptionDto = {
+  id: number;
+  email: string;
 };
 
 const canManageSpecialists = (role: WebUserRole): boolean => {
@@ -72,16 +78,31 @@ export async function getSpecialistsForActor(actor: User): Promise<SpecialistDto
     .map(mapSpecialist);
 }
 
+export async function getAvailableSpecialistWebUsersForActor(actor: User): Promise<SpecialistWebUserOptionDto[]> {
+  if (!canManageSpecialists(actor.role)) {
+    return [];
+  }
+
+  const accountId = await resolveAccountId(actor);
+  return listActiveSpecialistWebUsersWithoutProfile(accountId);
+}
+
 export async function createSpecialistForActor(actor: User, payload: SpecialistCreatePayload): Promise<SpecialistDto> {
   if (!canManageSpecialists(actor.role)) {
     throw new Error('FORBIDDEN');
   }
 
   const accountId = await resolveAccountId(actor);
+  const webUser = await findWebUserById(accountId, payload.userId);
+  if (!webUser || webUser.role !== WebUserRole.Specialist || !webUser.is_active) {
+    throw new Error('WEB_USER_NOT_AVAILABLE');
+  }
+
   const id = await createSpecialist({
     accountId,
-    name: payload.name.trim(),
-    code: buildSpecialistCode(payload.name),
+    name: webUser.email,
+    code: buildSpecialistCode(webUser.email),
+    userId: payload.userId,
   });
 
   const created = await findSpecialistById(accountId, id);

--- a/server/tests/specialists.routes.smoke.test.ts
+++ b/server/tests/specialists.routes.smoke.test.ts
@@ -5,6 +5,7 @@ import { WebUserRole } from '../src/types/webUserRole.js';
 
 const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
 const getSpecialistsForActorMock = vi.hoisted(() => vi.fn());
+const getAvailableSpecialistWebUsersForActorMock = vi.hoisted(() => vi.fn());
 const createSpecialistForActorMock = vi.hoisted(() => vi.fn());
 const updateSpecialistForActorMock = vi.hoisted(() => vi.fn());
 const deleteSpecialistForActorMock = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ vi.mock('../src/services/authService.js', () => ({
 
 vi.mock('../src/services/specialistService.js', () => ({
   getSpecialistsForActor: getSpecialistsForActorMock,
+  getAvailableSpecialistWebUsersForActor: getAvailableSpecialistWebUsersForActorMock,
   createSpecialistForActor: createSpecialistForActorMock,
   updateSpecialistForActor: updateSpecialistForActorMock,
   deleteSpecialistForActor: deleteSpecialistForActorMock,
@@ -54,6 +56,7 @@ describe('specialists API route-smoke scenarios (mocked service layer)', () => {
     resolveUserByAccessTokenMock.mockReset();
     getSpecialistsForActorMock.mockReset();
     createSpecialistForActorMock.mockReset();
+    getAvailableSpecialistWebUsersForActorMock.mockReset();
     updateSpecialistForActorMock.mockReset();
     deleteSpecialistForActorMock.mockReset();
 
@@ -62,6 +65,7 @@ describe('specialists API route-smoke scenarios (mocked service layer)', () => {
 
   it('list: GET /api/specialists returns specialists', async () => {
     getSpecialistsForActorMock.mockResolvedValue([{ id: 1, name: 'Anna', code: 'anna-1', timezone: 'UTC', isActive: true, slotStepMin: 30 }]);
+    getAvailableSpecialistWebUsersForActorMock.mockResolvedValue([{ id: 8, email: 'spec@example.com' }]);
 
     const response = await fetch(`${baseUrl}/api/specialists`, {
       method: 'GET',
@@ -71,6 +75,7 @@ describe('specialists API route-smoke scenarios (mocked service layer)', () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       specialists: [{ id: 1, name: 'Anna' }],
+      availableWebUsers: [{ id: 8, email: 'spec@example.com' }],
     });
   });
 
@@ -83,7 +88,7 @@ describe('specialists API route-smoke scenarios (mocked service layer)', () => {
         'content-type': 'application/json',
         authorization: 'Bearer smoke-token',
       },
-      body: JSON.stringify({ name: 'New Spec' }),
+      body: JSON.stringify({ userId: 8 }),
     });
 
     expect(response.status).toBe(201);

--- a/web/src/components/specialists/SpecialistFormDialog.tsx
+++ b/web/src/components/specialists/SpecialistFormDialog.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import { Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, Switch, TextField } from '@mui/material';
+import { Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, InputLabel, MenuItem, Select, Switch, TextField } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { SpecialistManagementItem } from '../../shared/types/api';
 import { AppButton } from '../../shared/ui/AppButton';
@@ -13,8 +13,9 @@ type SpecialistFormDialogProps = {
   closeLabel: string;
   nameLabel: string;
   activeLabel: string;
+  availableWebUsers: Array<{ id: number; email: string }>;
   onClose: () => void;
-  onSubmit: (payload: { name: string; isActive: boolean }) => Promise<void> | void;
+  onSubmit: (payload: { userId?: number; name?: string; isActive: boolean }) => Promise<void> | void;
 };
 
 export function SpecialistFormDialog({
@@ -26,11 +27,13 @@ export function SpecialistFormDialog({
   closeLabel,
   nameLabel,
   activeLabel,
+  availableWebUsers,
   onClose,
   onSubmit,
 }: SpecialistFormDialogProps) {
   const [name, setName] = useState('');
   const [isActive, setIsActive] = useState(true);
+  const [selectedUserId, setSelectedUserId] = useState<number>(0);
 
   useEffect(() => {
     if (!open) {
@@ -39,36 +42,65 @@ export function SpecialistFormDialog({
 
     setName(editingSpecialist?.name ?? '');
     setIsActive(editingSpecialist?.isActive ?? true);
+    setSelectedUserId(0);
   }, [editingSpecialist, open]);
 
   const handleSubmit = async () => {
-    if (!name.trim()) {
+    if (editingSpecialist && !name.trim()) {
       return;
     }
 
-    await onSubmit({ name: name.trim(), isActive });
+    if (!editingSpecialist && !selectedUserId) {
+      return;
+    }
+
+    await onSubmit(editingSpecialist ? { name: name.trim(), isActive } : { userId: selectedUserId, isActive: true });
   };
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
-        <TextField
-          margin="dense"
-          fullWidth
-          label={nameLabel}
-          value={name}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => setName(event.target.value)}
-        />
+        {editingSpecialist ? (
+          <TextField
+            margin="dense"
+            fullWidth
+            label={nameLabel}
+            value={name}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => setName(event.target.value)}
+          />
+        ) : (
+          <FormControl margin="dense" fullWidth>
+            <InputLabel id="specialist-user-select-label">{nameLabel}</InputLabel>
+            <Select
+              labelId="specialist-user-select-label"
+              label={nameLabel}
+              value={selectedUserId}
+              onChange={(event) => setSelectedUserId(Number(event.target.value))}
+            >
+              {availableWebUsers.map((item) => (
+                <MenuItem key={item.id} value={item.id}>
+                  {item.email}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
         <FormControlLabel
           sx={{ mt: 1 }}
-          control={<Switch checked={isActive} onChange={(event) => setIsActive(event.target.checked)} />}
+          control={<Switch checked={isActive} disabled={!editingSpecialist} onChange={(event) => setIsActive(event.target.checked)} />}
           label={activeLabel}
         />
       </DialogContent>
       <DialogActions>
         <AppButton variant="text" onClick={onClose}>{closeLabel}</AppButton>
-        <AppButton onClick={() => void handleSubmit()} isLoading={isSaving} disabled={!name.trim()}>{saveLabel}</AppButton>
+        <AppButton
+          onClick={() => void handleSubmit()}
+          isLoading={isSaving}
+          disabled={editingSpecialist ? !name.trim() : !selectedUserId}
+        >
+          {saveLabel}
+        </AppButton>
       </DialogActions>
     </Dialog>
   );

--- a/web/src/containers/SpecialistsContainer.tsx
+++ b/web/src/containers/SpecialistsContainer.tsx
@@ -17,6 +17,7 @@ export function SpecialistsContainer() {
   const [success, setSuccess] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [specialists, setSpecialists] = useState<SpecialistManagementItem[]>([]);
+  const [availableWebUsers, setAvailableWebUsers] = useState<Array<{ id: number; email: string }>>([]);
   const [isSpecialistDialogOpen, setIsSpecialistDialogOpen] = useState(false);
   const [editingSpecialist, setEditingSpecialist] = useState<SpecialistManagementItem | null>(null);
   const [isSavingSpecialist, setIsSavingSpecialist] = useState(false);
@@ -41,6 +42,7 @@ export function SpecialistsContainer() {
           headers: authHeaders(accessToken),
         });
         setSpecialists(response.data.specialists);
+        setAvailableWebUsers(response.data.availableWebUsers ?? []);
       } catch {
         setError(t('settings.errors.load'));
       } finally {
@@ -70,7 +72,7 @@ export function SpecialistsContainer() {
     setEditingSpecialist(null);
   };
 
-  const saveSpecialist = async (payload: { name: string; isActive: boolean }) => {
+  const saveSpecialist = async (payload: { userId?: number; name?: string; isActive: boolean }) => {
     if (!accessToken) {
       return;
     }
@@ -79,17 +81,25 @@ export function SpecialistsContainer() {
 
     try {
       if (editingSpecialist) {
-        const response = await apiClient.patch<SpecialistManagementItem>(`/api/specialists/${editingSpecialist.id}`, payload, {
+        const response = await apiClient.patch<SpecialistManagementItem>(`/api/specialists/${editingSpecialist.id}`, {
+          name: payload.name,
+          isActive: payload.isActive,
+        }, {
           headers: authHeaders(accessToken),
         });
 
         setSpecialists((prev) => prev.map((item) => (item.id === response.data.id ? response.data : item)));
       } else {
-        const response = await apiClient.post<SpecialistManagementItem>('/api/specialists', { name: payload.name }, {
+        if (!payload.userId) {
+          return;
+        }
+
+        const response = await apiClient.post<SpecialistManagementItem>('/api/specialists', { userId: payload.userId }, {
           headers: authHeaders(accessToken),
         });
 
         setSpecialists((prev) => [...prev, response.data].sort((left, right) => left.name.localeCompare(right.name)));
+        setAvailableWebUsers((prev) => prev.filter((item) => item.id !== payload.userId));
       }
 
       setError('');
@@ -178,6 +188,7 @@ export function SpecialistsContainer() {
         closeLabel={t('appointments.close')}
         nameLabel={t('settings.specialists.columns.name')}
         activeLabel={t('settings.specialists.columns.active')}
+        availableWebUsers={availableWebUsers}
         onClose={closeSpecialistDialog}
         onSubmit={saveSpecialist}
       />

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -99,4 +99,8 @@ export type SpecialistManagementItem = {
 
 export type SpecialistsListResponse = {
   specialists: SpecialistManagementItem[];
+  availableWebUsers: Array<{
+    id: number;
+    email: string;
+  }>;
 };


### PR DESCRIPTION
### Motivation
- Replace free-text specialist creation with a dropdown backed by `web_users` so new specialists are linked to real web accounts (`account_id`, `role = specialist`, `is_active = true`) and avoid duplicate/unlinked profiles.  
- Ensure only `owner` or `admin` actors see the `/specialists` menu and can create specialists to enforce role-based access to management flows.

### Description
- Backend: changed `POST /api/specialists` contract to accept `userId` and added `specialistCreateSchema` validation for `userId`, plus a service check that the selected `web_user` exists, is active and has `role = specialist`; creation now stores `specialists.user_id`. (files: `server/src/config/schemas.ts`, `server/src/services/specialistService.ts`, `server/src/repositories/specialistRepository.ts`).
- Backend: added repository helper `listActiveSpecialistWebUsersWithoutProfile` which returns available `web_users` for the dropdown, and extended `GET /api/specialists` to return `availableWebUsers` alongside `specialists`. (files: `server/src/repositories/webUserRepository.ts`, `server/src/routes/specialistRoutes.ts`).
- Frontend: the Specialists dialog now shows a select dropdown of available `web_users` when creating a specialist and keeps name/isActive editing for existing specialists; the container consumes `availableWebUsers` and removes the chosen user after creation. (files: `web/src/containers/SpecialistsContainer.tsx`, `web/src/components/specialists/SpecialistFormDialog.tsx`, `web/src/shared/types/api.ts`).
- Tests & docs: updated API route-smoke tests to the new contract and refreshed README/PROJECT_MAP/TODO to document the new dropdown flow and role restriction. (files: `server/tests/specialists.routes.smoke.test.ts`, `README.md`, `PROJECT_MAP.md`, `TODO.md`).

### Testing
- Ran backend typecheck with `npm --workspace server run typecheck` which succeeded.  
- Ran frontend typecheck with `npm --workspace web run typecheck` which succeeded.  
- Executed specialists route-smoke tests `npm --workspace server test -- specialists.routes.smoke.test.ts` and all tests passed.  
- Executed web smoke e2e `npm --workspace web test -- smoke.e2e.test.mjs` and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6c5607188333a1ce96df88b18ebd)