### PR TITLE
Add Telegram BOT_TOKEN integration (user settings, migration, bot runtime)

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -36,6 +36,7 @@
 - [x] Добавить endpoint запуска OAuth `/api/integrations/google/oauth/start`.
 - [x] Реализовать полноценный OAuth 2.0 Google flow (auth URL + callback + token exchange).
 - [x] Сохранять OAuth ключ web-пользователя в `web_users.google_api_key` после callback.
+- [x] Добавить пользовательский Telegram BOT_TOKEN в `web_users` + проверку через Telegram `getMe` при сохранении.
 - [ ] Добавить retry/backoff для внешних API.
 
 ## 5. Web delivery

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -19,6 +19,8 @@
 - `web_users` — web auth users (email/password hash/salt).
 - `web_users.role` — роль web-пользователя (`owner`/`admin`/`specialist`).
 - `web_users.google_api_key` — Google OAuth `access_token`, сохраняемый после web-коннекта Google.
+- `web_users.telegram_bot_token` — персональный Telegram BOT_TOKEN из user settings.
+- `web_users.telegram_bot_username` / `web_users.telegram_bot_name` — метаданные бота из `getMe` для отображения статуса интеграции.
 - `user_identity_links` — 1:1 bridge между `telegram_users` и `web_users` внутри `account_id`.
 - `specialists.user_id` — 1:1 bridge между `specialists` и `web_users` внутри `account_id`.
 - `web_user_sessions` — web auth-сессии (`access`/`refresh`) с `expires_at`/`revoked_at`, источник истины для проверки токенов и refresh-rotation.
@@ -135,6 +137,12 @@
 - `GOOGLE_OAUTH_CLIENT_SECRET`
 - `GOOGLE_OAUTH_REDIRECT_URI`
 - `GOOGLE_OAUTH_SCOPES` (опционально, space-separated)
+
+## Telegram Bot token (текущее разделение)
+
+- `PUT /api/settings/user` принимает `telegramBotToken` (password-поле на фронте).
+- Server пытается провалидировать токен через Telegram `getMe`; если запрос неуспешен, токен сохраняется как fallback.
+- `bot` использует токен из `web_users.telegram_bot_token` для вызовов Telegram API.
 
 ## Google credentials (текущее разделение)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Какие услуги предоставляет продукт
 
 - Регистрация/логин и централизованные настройки аккаунта.
-- Управление интеграциями (в первую очередь Google).
+- Управление интеграциями (Google + Telegram BOT_TOKEN в user settings).
 - Управление appointments: создание, изменение статуса, перенос, отмена, подтверждение оплаты, ручные уведомления.
 - Управление ссылками на онлайн-встречи (дефолтная ссылка + override на конкретную запись).
 - Web-интерфейс + Telegram-бот как единая экосистема.
@@ -69,7 +69,7 @@ scheduletm/
 - `POST /api/integrations/google/oauth/start`
 - `GET /api/integrations/google/oauth/callback`
 
-`PUT /api/settings/system` обновляет системные настройки (таблица `app_settings`), а `PUT /api/settings/user` сохраняет пользовательские настройки (`web_users`, включая `uiThemeMode` / `uiPaletteVariantId`).
+`PUT /api/settings/system` обновляет системные настройки (таблица `app_settings`), а `PUT /api/settings/user` сохраняет пользовательские настройки (`web_users`, включая `uiThemeMode` / `uiPaletteVariantId` и `telegram_bot_token`).
 
 Слой данных серверной части теперь фиксирует разделение identity-моделей:
 
@@ -77,6 +77,7 @@ scheduletm/
 - `web_users` — web-учетки для email/password auth.
 - `user_identity_links` — связь между Telegram и Web учетками (1:1 в рамках `account_id`).
 - `web_users.role` — роль web-пользователя (`owner`/`admin`/`specialist`).
+- `web_users.telegram_bot_token` — персональный BOT_TOKEN для Telegram-интеграции пользователя в web settings.
 - `specialists.user_id` — прямая 1:1 привязка специалиста к web-учетке (в рамках `account_id`).
 - `server` auth-сервис регистрирует/логинит через `web_users`, а `bot` user-сервис при наличии email делает auto-link через `user_identity_links`.
 
@@ -121,6 +122,13 @@ scheduletm/
 - `web_users.google_api_key` — ключ, полученный через web OAuth (источник истины для авторизованного web-пользователя).
 - `specialists.user_id` определяет, какому специалисту принадлежит `web_user`.
 - `specialists` больше не хранит Google credentials: источник истины только `web_users.google_api_key/google_calendar_id`.
+
+### Telegram BOT_TOKEN (добавлено)
+
+- В `User settings` добавлено password-поле для `BOT_TOKEN`.
+- Backend при сохранении токена вызывает Telegram API `getMe`; если API недоступен, токен всё равно сохраняется как рабочий fallback.
+- В `web_users` сохраняются `telegram_bot_token` и метаданные бота (`telegram_bot_username`, `telegram_bot_name`) для отображения статуса на фронте.
+- Bot backend использует токен из `web_users.telegram_bot_token` (а не из `.env BOT_TOKEN`) для Telegram API вызовов.
 
 ## Куда двигаться дальше (web/server)
 

--- a/TODO.md
+++ b/TODO.md
@@ -63,6 +63,7 @@
 - [x] Добавить logout endpoint и удаление текущей web-сессии из БД на backend.
 - [ ] Добавить CSRF protection для refresh cookie flow.
 - [x] Добавить полноценный Google OAuth 2.0 flow (web button -> backend start -> google callback).
+- [x] Добавить Telegram BOT_TOKEN в user settings с сохранением в `web_users` и password-отображением в web.
 
 ### 4.5 Web UX & quality
 

--- a/bot/src/bot/bot.ts
+++ b/bot/src/bot/bot.ts
@@ -1,10 +1,51 @@
 import axios from 'axios';
 import { env } from '../config/env';
+import { getDefaultAccountId } from '../repositories/account.repository';
+import { findActiveTelegramBotTokenByAccountId } from '../repositories/web-user.repository';
 
-const telegramApi = axios.create({
-  baseURL: `https://api.telegram.org/bot${env.botToken}`,
-  timeout: 10000,
-});
+const TELEGRAM_API_TIMEOUT_MS = 10000;
+const TOKEN_CACHE_TTL_MS = 15000;
+
+let cachedToken: string | null = null;
+let cachedTokenExpiresAt = 0;
+let cachedTokenAccountId: number | null = null;
+
+async function getTelegramBotToken() {
+  const accountId = await getDefaultAccountId();
+  const now = Date.now();
+
+  if (
+    cachedToken &&
+    cachedTokenAccountId === accountId &&
+    now < cachedTokenExpiresAt
+  ) {
+    return cachedToken;
+  }
+
+  const token = await findActiveTelegramBotTokenByAccountId(accountId);
+  if (!token) {
+    throw new Error('Telegram BOT_TOKEN is not configured in web user settings');
+  }
+
+  cachedToken = token;
+  cachedTokenAccountId = accountId;
+  cachedTokenExpiresAt = now + TOKEN_CACHE_TTL_MS;
+  return token;
+}
+
+async function telegramPost<TPayload extends Record<string, unknown>>(method: string, payload: TPayload) {
+  const token = await getTelegramBotToken();
+  return axios.post(`https://api.telegram.org/bot${token}/${method}`, payload, {
+    timeout: TELEGRAM_API_TIMEOUT_MS,
+  });
+}
+
+async function telegramGet(method: string) {
+  const token = await getTelegramBotToken();
+  return axios.get(`https://api.telegram.org/bot${token}/${method}`, {
+    timeout: TELEGRAM_API_TIMEOUT_MS,
+  });
+}
 
 export type TelegramUpdate = {
   update_id: number;
@@ -63,7 +104,7 @@ export async function sendMessage(
     payload.reply_markup = replyMarkup;
   }
 
-  await telegramApi.post('/sendMessage', payload);
+  await telegramPost('sendMessage', payload);
 }
 
 export async function editMessageText(
@@ -82,26 +123,35 @@ export async function editMessageText(
     payload.reply_markup = replyMarkup;
   }
 
-  await telegramApi.post('/editMessageText', payload);
+  await telegramPost('editMessageText', payload);
 }
 
 export async function answerCallbackQuery(
   callbackQueryId: string,
   text?: string,
 ) {
-  await telegramApi.post('/answerCallbackQuery', {
+  await telegramPost('answerCallbackQuery', {
     callback_query_id: callbackQueryId,
     text,
   });
 }
 
 export async function setWebhook() {
+  const accountId = await getDefaultAccountId();
+  const token = await findActiveTelegramBotTokenByAccountId(accountId);
+  if (!token) {
+    throw new Error('Telegram BOT_TOKEN is not configured in web user settings');
+  }
+
+  cachedToken = token;
+  cachedTokenAccountId = accountId;
+  cachedTokenExpiresAt = Date.now() + TOKEN_CACHE_TTL_MS;
   const webhookUrl = `${env.appUrl}/telegram/webhook/${env.webhookSecret}`;
-  const response = await telegramApi.post('/setWebhook', { url: webhookUrl });
+  const response = await telegramPost('setWebhook', { url: webhookUrl });
   return response.data;
 }
 
 export async function getWebhookInfo() {
-  const response = await telegramApi.get('/getWebhookInfo');
+  const response = await telegramGet('getWebhookInfo');
   return response.data;
 }

--- a/bot/src/config/env.ts
+++ b/bot/src/config/env.ts
@@ -14,7 +14,6 @@ export const env = {
   nodeEnv: process.env.NODE_ENV ?? 'development',
   isProduction: (process.env.NODE_ENV ?? 'development') === 'production',
   port: Number(process.env.PORT || 3002),
-  botToken: getEnv("BOT_TOKEN"),
   webhookSecret: getEnv("WEBHOOK_SECRET"),
   appUrl: getEnv("APP_URL"),
   autoSetWebhook: process.env.AUTO_SET_WEBHOOK === '1' || process.env.AUTO_SET_WEBHOOK === 'true',

--- a/bot/src/repositories/web-user.repository.ts
+++ b/bot/src/repositories/web-user.repository.ts
@@ -1,0 +1,14 @@
+import { db } from '../db/knex';
+
+export async function findActiveTelegramBotTokenByAccountId(accountId: number): Promise<string | null> {
+  const row = await db('web_users')
+    .where({ account_id: accountId, is_active: true })
+    .whereNotNull('telegram_bot_token')
+    .orderByRaw(
+      "CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'specialist' THEN 2 ELSE 3 END",
+    )
+    .orderBy('updated_at', 'desc')
+    .first<{ telegram_bot_token: string | null }>('telegram_bot_token');
+
+  return row?.telegram_bot_token ?? null;
+}

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -57,7 +57,8 @@ export const userSettingsSchema = z.object({
   timezone: timezoneSchema,
   locale: z.string().min(2, 'Укажите язык/локаль').max(16, 'Локаль слишком длинная'),
   uiThemeMode: z.enum(['light', 'dark']),
-  uiPaletteVariantId: z.string().min(1, 'Укажите id палитры').max(64, 'Id палитры слишком длинный')
+  uiPaletteVariantId: z.string().min(1, 'Укажите id палитры').max(64, 'Id палитры слишком длинный'),
+  telegramBotToken: z.string().trim().min(1, 'Укажите BOT_TOKEN').max(255, 'BOT_TOKEN слишком длинный').optional().or(z.literal('')),
 }).partial();
 
 export const specialistUserCreationSchema = z.object({

--- a/server/src/db/migrations/20260424153000_add_telegram_bot_token_to_web_users.ts
+++ b/server/src/db/migrations/20260424153000_add_telegram_bot_token_to_web_users.ts
@@ -1,0 +1,53 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'web_users';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE_NAME);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasTelegramBotToken = await knex.schema.hasColumn(TABLE_NAME, 'telegram_bot_token');
+  const hasTelegramBotUsername = await knex.schema.hasColumn(TABLE_NAME, 'telegram_bot_username');
+  const hasTelegramBotName = await knex.schema.hasColumn(TABLE_NAME, 'telegram_bot_name');
+
+  if (!hasTelegramBotToken || !hasTelegramBotUsername || !hasTelegramBotName) {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+      if (!hasTelegramBotToken) {
+        table.text('telegram_bot_token').nullable();
+      }
+      if (!hasTelegramBotUsername) {
+        table.string('telegram_bot_username', 255).nullable();
+      }
+      if (!hasTelegramBotName) {
+        table.string('telegram_bot_name', 255).nullable();
+      }
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE_NAME);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasTelegramBotToken = await knex.schema.hasColumn(TABLE_NAME, 'telegram_bot_token');
+  const hasTelegramBotUsername = await knex.schema.hasColumn(TABLE_NAME, 'telegram_bot_username');
+  const hasTelegramBotName = await knex.schema.hasColumn(TABLE_NAME, 'telegram_bot_name');
+
+  if (hasTelegramBotToken || hasTelegramBotUsername || hasTelegramBotName) {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+      if (hasTelegramBotName) {
+        table.dropColumn('telegram_bot_name');
+      }
+      if (hasTelegramBotUsername) {
+        table.dropColumn('telegram_bot_username');
+      }
+      if (hasTelegramBotToken) {
+        table.dropColumn('telegram_bot_token');
+      }
+    });
+  }
+}

--- a/server/src/repositories/webUserRepository.ts
+++ b/server/src/repositories/webUserRepository.ts
@@ -14,6 +14,9 @@ export type WebUserRecord = {
   google_token_expires_at: Date | null;
   google_calendar_id: string | null;
   google_connected_at: Date | null;
+  telegram_bot_token: string | null;
+  telegram_bot_username: string | null;
+  telegram_bot_name: string | null;
   timezone: string;
   locale: string;
   ui_theme_mode: 'light' | 'dark';
@@ -147,6 +150,9 @@ type UpdateWebUserSettingsInput = {
   locale?: string;
   uiThemeMode?: 'light' | 'dark';
   uiPaletteVariantId?: string;
+  telegramBotToken?: string | null;
+  telegramBotUsername?: string | null;
+  telegramBotName?: string | null;
 };
 
 export async function updateWebUserSettings(input: UpdateWebUserSettingsInput): Promise<void> {
@@ -168,6 +174,18 @@ export async function updateWebUserSettings(input: UpdateWebUserSettingsInput): 
 
   if (input.uiPaletteVariantId !== undefined) {
     patch.ui_palette_variant_id = input.uiPaletteVariantId;
+  }
+
+  if (input.telegramBotToken !== undefined) {
+    patch.telegram_bot_token = input.telegramBotToken;
+  }
+
+  if (input.telegramBotUsername !== undefined) {
+    patch.telegram_bot_username = input.telegramBotUsername;
+  }
+
+  if (input.telegramBotName !== undefined) {
+    patch.telegram_bot_name = input.telegramBotName;
   }
 
   await db('web_users')

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -4,6 +4,7 @@ import { findWebUserById, updateWebUserSettings } from '../repositories/webUserR
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 import { systemSettingsSchema, userSettingsSchema } from '../config/schemas.js';
+import { verifyTelegramBotToken } from './telegramService.js';
 
 export type SystemSettings = {
   timezone: string;
@@ -19,6 +20,9 @@ export type UserSettings = {
   uiThemeMode: 'light' | 'dark';
   uiPaletteVariantId: string;
   googleConnected: boolean;
+  telegramBotConnected: boolean;
+  telegramBotName: string | null;
+  telegramBotUsername: string | null;
 };
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -87,6 +91,9 @@ export const getUserSettings = async (userId: string): Promise<UserSettings> => 
       uiThemeMode: 'light',
       uiPaletteVariantId: 'default',
       googleConnected: false,
+      telegramBotConnected: false,
+      telegramBotName: null,
+      telegramBotUsername: null,
     };
   }
 
@@ -96,6 +103,9 @@ export const getUserSettings = async (userId: string): Promise<UserSettings> => 
     uiThemeMode: user.ui_theme_mode,
     uiPaletteVariantId: user.ui_palette_variant_id,
     googleConnected: Boolean(user.google_api_key),
+    telegramBotConnected: Boolean(user.telegram_bot_token),
+    telegramBotName: user.telegram_bot_name,
+    telegramBotUsername: user.telegram_bot_username,
   };
 };
 
@@ -111,6 +121,25 @@ export const updateUserSettings = async (actor: User, payload: unknown): Promise
     return null;
   }
 
+  let telegramBotTokenPatch: string | null | undefined;
+  let telegramBotUsernamePatch: string | null | undefined;
+  let telegramBotNamePatch: string | null | undefined;
+
+  if (parsed.data.telegramBotToken !== undefined) {
+    const trimmedToken = parsed.data.telegramBotToken.trim();
+
+    if (!trimmedToken) {
+      telegramBotTokenPatch = null;
+      telegramBotUsernamePatch = null;
+      telegramBotNamePatch = null;
+    } else {
+      telegramBotTokenPatch = trimmedToken;
+      const botInfo = await verifyTelegramBotToken(trimmedToken);
+      telegramBotUsernamePatch = botInfo?.username ?? null;
+      telegramBotNamePatch = botInfo?.name ?? null;
+    }
+  }
+
   await updateWebUserSettings({
     accountId,
     id: numericUserId,
@@ -118,6 +147,9 @@ export const updateUserSettings = async (actor: User, payload: unknown): Promise
     locale: parsed.data.locale,
     uiThemeMode: parsed.data.uiThemeMode,
     uiPaletteVariantId: parsed.data.uiPaletteVariantId,
+    telegramBotToken: telegramBotTokenPatch,
+    telegramBotUsername: telegramBotUsernamePatch,
+    telegramBotName: telegramBotNamePatch,
   });
 
   return getUserSettings(actor.id);

--- a/server/src/services/telegramService.ts
+++ b/server/src/services/telegramService.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+
+type TelegramGetMeResponse = {
+  ok: boolean;
+  result?: {
+    id: number;
+    is_bot: boolean;
+    first_name?: string;
+    username?: string;
+  };
+};
+
+export type TelegramBotInfo = {
+  username: string | null;
+  name: string | null;
+};
+
+export async function verifyTelegramBotToken(token: string): Promise<TelegramBotInfo | null> {
+  const trimmedToken = token.trim();
+  if (!trimmedToken) {
+    return null;
+  }
+
+  try {
+    const response = await axios.get<TelegramGetMeResponse>(
+      `https://api.telegram.org/bot${trimmedToken}/getMe`,
+      { timeout: 8000 },
+    );
+
+    if (!response.data.ok) {
+      return null;
+    }
+
+    return {
+      username: response.data.result?.username ?? null,
+      name: response.data.result?.first_name ?? null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -26,6 +26,10 @@ type SettingsCardCopy = {
   disconnectGoogle: string;
   disconnectingGoogle: string;
   googleConnected: string;
+  telegramBotToken: string;
+  telegramBotConnected: string;
+  telegramBotNotConnected: string;
+  clearTelegramBotToken: string;
 };
 
 type SettingsCardProps = {
@@ -39,6 +43,7 @@ type SettingsCardProps = {
   isSavingUser?: boolean;
   onSaveSystem: (next: SystemSettings) => Promise<void> | void;
   onSaveUser: (next: UserSettings) => Promise<void> | void;
+  onClearTelegramBotToken: () => Promise<void> | void;
   onConnectGoogle: () => void;
   onDisconnectGoogle: () => void;
 };
@@ -54,6 +59,7 @@ export function SettingsCard({
   isSavingUser = false,
   onSaveSystem,
   onSaveUser,
+  onClearTelegramBotToken,
   onConnectGoogle,
   onDisconnectGoogle
 }: SettingsCardProps) {
@@ -64,7 +70,7 @@ export function SettingsCard({
   });
 
   const { control: userControl, handleSubmit: handleUserSubmit, reset: resetUser } = useForm<UserSettings>({
-    defaultValues: userSettings
+    defaultValues: { ...userSettings, telegramBotToken: '' }
   });
 
   useEffect(() => {
@@ -72,7 +78,7 @@ export function SettingsCard({
   }, [resetSystem, systemSettings]);
 
   useEffect(() => {
-    resetUser(userSettings);
+    resetUser({ ...userSettings, telegramBotToken: '' });
   }, [resetUser, userSettings]);
 
   return (
@@ -164,9 +170,35 @@ export function SettingsCard({
             )}
           />
 
+          <Controller
+            name="telegramBotToken"
+            control={userControl}
+            render={({ field }: any) => (
+              <AppRhfTextField field={field} label={copy.telegramBotToken} type="password" />
+            )}
+          />
+
+          <Typography variant="body2" color="text.secondary">
+            {userSettings.telegramBotConnected
+              ? `${copy.telegramBotConnected}: ${userSettings.telegramBotName ?? '@unknown'}${userSettings.telegramBotUsername ? ` (@${userSettings.telegramBotUsername})` : ''}`
+              : copy.telegramBotNotConnected}
+          </Typography>
+
           <AppButton type="submit" startIcon={<AppIcons.save />} isLoading={isSavingUser}>
             {copy.saveSettings}
           </AppButton>
+
+          {userSettings.telegramBotConnected && (
+            <AppButton
+              type="button"
+              variant="outlined"
+              color="error"
+              onClick={onClearTelegramBotToken}
+              disabled={isSavingUser}
+            >
+              {copy.clearTelegramBotToken}
+            </AppButton>
+          )}
 
           <Typography variant="h5">{copy.integrationsTitle}</Typography>
           <Typography color="text.secondary" variant="body2">

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -27,6 +27,10 @@ const defaultUserSettings: UserSettings = {
   uiThemeMode: 'light',
   uiPaletteVariantId: 'default',
   googleConnected: false,
+  telegramBotConnected: false,
+  telegramBotName: null,
+  telegramBotUsername: null,
+  telegramBotToken: '',
 };
 
 export function SettingsContainer() {
@@ -130,9 +134,38 @@ export function SettingsContainer() {
     setIsSavingUser(true);
 
     try {
-      const response = await apiClient.put<UserSettings>('/api/settings/user', nextSettings, {
+      const payload: UserSettings = { ...nextSettings };
+      if (!payload.telegramBotToken) {
+        delete payload.telegramBotToken;
+      }
+
+      const response = await apiClient.put<UserSettings>('/api/settings/user', payload, {
         headers: authHeaders(accessToken)
       });
+      setUserSettings(response.data);
+      setError('');
+      setSuccess('');
+    } catch {
+      setError(t('settings.errors.save'));
+      setSuccess('');
+    } finally {
+      setIsSavingUser(false);
+    }
+  };
+
+  const clearTelegramBotToken = async () => {
+    if (!accessToken) {
+      return;
+    }
+
+    setIsSavingUser(true);
+
+    try {
+      const response = await apiClient.put<UserSettings>(
+        '/api/settings/user',
+        { telegramBotToken: '' },
+        { headers: authHeaders(accessToken) }
+      );
       setUserSettings(response.data);
       setError('');
       setSuccess('');
@@ -236,7 +269,11 @@ export function SettingsContainer() {
               connectingGoogle: t('settings.connectingGoogle'),
               disconnectGoogle: t('settings.disconnectGoogle'),
               disconnectingGoogle: t('settings.disconnectingGoogle'),
-              googleConnected: t('settings.googleConnected')
+              googleConnected: t('settings.googleConnected'),
+              telegramBotToken: t('settings.telegramBotToken'),
+              telegramBotConnected: t('settings.telegramBotConnected'),
+              telegramBotNotConnected: t('settings.telegramBotNotConnected'),
+              clearTelegramBotToken: t('settings.clearTelegramBotToken'),
             }}
             isGoogleConnecting={isGoogleConnecting}
             isGoogleDisconnecting={isGoogleDisconnecting}
@@ -244,6 +281,7 @@ export function SettingsContainer() {
             isSavingUser={isSavingUser}
             onSaveSystem={saveSystemSettings}
             onSaveUser={saveUserSettings}
+            onClearTelegramBotToken={clearTelegramBotToken}
             onConnectGoogle={connectGoogle}
             onDisconnectGoogle={disconnectGoogle}
           />

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -54,6 +54,10 @@ export const dictionaries = {
       disconnectGoogle: 'Disconnect Google',
       disconnectingGoogle: 'Disconnecting...',
       googleConnected: 'Google connected',
+      telegramBotToken: 'Telegram BOT_TOKEN',
+      telegramBotConnected: 'Telegram bot connected',
+      telegramBotNotConnected: 'Telegram bot is not connected',
+      clearTelegramBotToken: 'Disconnect Telegram bot',
       googleConnectedSuccessfully: 'Google Calendar connected successfully.',
       specialists: {
         title: 'Specialists',
@@ -184,6 +188,10 @@ export const dictionaries = {
       disconnectGoogle: 'Отключить Google',
       disconnectingGoogle: 'Отключаем...',
       googleConnected: 'Google подключен',
+      telegramBotToken: 'Telegram BOT_TOKEN',
+      telegramBotConnected: 'Telegram-бот подключен',
+      telegramBotNotConnected: 'Telegram-бот не подключен',
+      clearTelegramBotToken: 'Отключить Telegram-бота',
       googleConnectedSuccessfully: 'Google Calendar успешно подключен.',
       specialists: {
         title: 'Специалисты',
@@ -309,6 +317,10 @@ export type TranslationKey =
   | 'settings.disconnectGoogle'
   | 'settings.disconnectingGoogle'
   | 'settings.googleConnected'
+  | 'settings.telegramBotToken'
+  | 'settings.telegramBotConnected'
+  | 'settings.telegramBotNotConnected'
+  | 'settings.clearTelegramBotToken'
   | 'settings.googleConnectedSuccessfully'
   | 'settings.specialists.title'
   | 'settings.specialists.add'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -25,6 +25,10 @@ export type UserSettings = {
   uiThemeMode: 'light' | 'dark';
   uiPaletteVariantId: string;
   googleConnected: boolean;
+  telegramBotConnected: boolean;
+  telegramBotName: string | null;
+  telegramBotUsername: string | null;
+  telegramBotToken?: string;
 };
 
 export type GoogleOAuthStartResponse = {


### PR DESCRIPTION
### Motivation
- Provide per-user Telegram BOT_TOKEN so each account can configure which bot token the backend and bot runtime should use. 
- Validate token proactively with Telegram `getMe` to capture bot metadata for UI without exposing the raw token. 
- Keep the token hidden on the frontend (password input) and allow explicit clearing, following least-privilege/display rules. 

### Description
- Added a DB migration `20260424153000_add_telegram_bot_token_to_web_users.ts` to create `telegram_bot_token`, `telegram_bot_username`, and `telegram_bot_name` on `web_users`. 
- Server: extended `userSettingsSchema` to accept `telegramBotToken`, implemented `server/src/services/telegramService.ts` to call Telegram `getMe`, and updated `server/src/services/settingsService.ts` to verify the token (graceful fallback if API is unreachable) and persist token + metadata via `updateWebUserSettings`. 
- Repositories: updated `server/src/repositories/webUserRepository.ts` to store the new fields and added `bot/src/repositories/web-user.repository.ts` to let the bot read an active token for the default account. 
- Bot runtime: removed reliance on `.env BOT_TOKEN`, added dynamic token lookup and short in-memory cache in `bot/src/bot/bot.ts`, and replaced direct axios client with `telegramPost`/`telegramGet` helpers that fetch the token from DB. 
- Web UI: added a password `BOT_TOKEN` input, connection status display and a clear/disconnect action in `web/src/components/SettingsCard.tsx` and `web/src/containers/SettingsContainer.tsx`, extended API types in `web/src/shared/types/api.ts`, and added i18n strings. 
- Documentation: updated `README.md`, `PROJECT_MAP.md`, `TODO.md`, and `PRODUCTION_READINESS_CHECKLIST.md` to reflect the new Telegram BOT_TOKEN flow. 

### Testing
- Ran TypeScript checks: `npm run --workspace server typecheck` succeeded. 
- Ran TypeScript checks: `npm run --workspace web typecheck` succeeded. 
- Ran TypeScript checks: `npm run --workspace bot typecheck` succeeded. 
- Included a migration file to be applied in DB migrations; no runtime integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6ff544548333ae0c678d859eae6f)