### PR TITLE
Move Google/Telegram credentials to dedicated web_user_integrations table

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -35,8 +35,8 @@
 
 - [x] Добавить endpoint запуска OAuth `/api/integrations/google/oauth/start`.
 - [x] Реализовать полноценный OAuth 2.0 Google flow (auth URL + callback + token exchange).
-- [x] Сохранять OAuth ключ web-пользователя в `web_users.google_api_key` после callback.
-- [x] Добавить пользовательский Telegram BOT_TOKEN в `web_users` + проверку через Telegram `getMe` при сохранении.
+- [x] Сохранять OAuth ключ web-пользователя в `web_user_integrations.google_api_key` после callback.
+- [x] Добавить пользовательский Telegram BOT_TOKEN в `web_user_integrations` + проверку через Telegram `getMe` при сохранении.
 - [ ] Добавить retry/backoff для внешних API.
 
 ## 5. Web delivery

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -18,9 +18,9 @@
 - `telegram_users` — Telegram users.
 - `web_users` — web auth users (email/password hash/salt).
 - `web_users.role` — роль web-пользователя (`owner`/`admin`/`specialist`).
-- `web_users.google_api_key` — Google OAuth `access_token`, сохраняемый после web-коннекта Google.
-- `web_users.telegram_bot_token` — персональный Telegram BOT_TOKEN из user settings.
-- `web_users.telegram_bot_username` / `web_users.telegram_bot_name` — метаданные бота из `getMe` для отображения статуса интеграции.
+- `web_user_integrations.google_api_key` — Google OAuth `access_token`, сохраняемый после web-коннекта Google.
+- `web_user_integrations.telegram_bot_token` — персональный Telegram BOT_TOKEN из user settings.
+- `web_user_integrations.telegram_bot_username` / `web_user_integrations.telegram_bot_name` — метаданные бота из `getMe` для отображения статуса интеграции.
 - `user_identity_links` — 1:1 bridge между `telegram_users` и `web_users` внутри `account_id`.
 - `specialists.user_id` — 1:1 bridge между `specialists` и `web_users` внутри `account_id`.
 - `web_user_sessions` — web auth-сессии (`access`/`refresh`) с `expires_at`/`revoked_at`, источник истины для проверки токенов и refresh-rotation.
@@ -142,13 +142,13 @@
 
 - `PUT /api/settings/user` принимает `telegramBotToken` (password-поле на фронте).
 - Server пытается провалидировать токен через Telegram `getMe`; если запрос неуспешен, токен сохраняется как fallback.
-- `bot` использует токен из `web_users.telegram_bot_token` для вызовов Telegram API.
+- `bot` использует токен из `web_user_integrations.telegram_bot_token` для вызовов Telegram API.
 
 ## Google credentials (текущее разделение)
 
-- `web_users.google_api_key` — ключ, полученный через OAuth в web (под будущие роли и self-service логин специалистов).
+- `web_user_integrations.google_api_key` — ключ, полученный через OAuth в web (под будущие роли и self-service логин специалистов).
 - `specialists.user_id` — связь владельца credentials с конкретным специалистом.
-- `specialists` не хранит Google credentials; bot/web должны использовать `web_users.google_api_key/google_calendar_id` через связь `specialists.user_id`.
+- `specialists` не хранит Google credentials; bot/web должны использовать `web_user_integrations.google_api_key/google_calendar_id` через связь `specialists.user_id`.
 
 ## Тестовая карта (smoke)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ scheduletm/
 - `POST /api/integrations/google/oauth/start`
 - `GET /api/integrations/google/oauth/callback`
 
-`PUT /api/settings/system` обновляет системные настройки (таблица `app_settings`), а `PUT /api/settings/user` сохраняет пользовательские настройки (`web_users`, включая `uiThemeMode` / `uiPaletteVariantId` и `telegram_bot_token`).
+`PUT /api/settings/system` обновляет системные настройки (таблица `app_settings`), а `PUT /api/settings/user` сохраняет пользовательские настройки (`web_users` для UI/locale/timezone + `web_user_integrations` для Google/Telegram интеграций).
 
 Слой данных серверной части теперь фиксирует разделение identity-моделей:
 
@@ -77,7 +77,7 @@ scheduletm/
 - `web_users` — web-учетки для email/password auth.
 - `user_identity_links` — связь между Telegram и Web учетками (1:1 в рамках `account_id`).
 - `web_users.role` — роль web-пользователя (`owner`/`admin`/`specialist`).
-- `web_users.telegram_bot_token` — персональный BOT_TOKEN для Telegram-интеграции пользователя в web settings.
+- `web_user_integrations.telegram_bot_token` — персональный BOT_TOKEN для Telegram-интеграции пользователя в web settings.
 - `specialists.user_id` — прямая 1:1 привязка специалиста к web-учетке (в рамках `account_id`).
 - `server` auth-сервис регистрирует/логинит через `web_users`, а `bot` user-сервис при наличии email делает auto-link через `user_identity_links`.
 
@@ -111,7 +111,7 @@ scheduletm/
 - Кнопка `Connect Google` в web теперь запускает backend endpoint `POST /api/integrations/google/oauth/start`.
 - Backend формирует `authorizeUrl` и redirect на Google Consent Screen.
 - Callback обрабатывается через `GET /api/integrations/google/oauth/callback` с обменом `code -> tokens`.
-- `access_token` Google сохраняется в `web_users.google_api_key` для текущего web-пользователя (под будущую ролевую модель, где специалист логинится сам).
+- `access_token` Google сохраняется в `web_user_integrations.google_api_key` для текущего web-пользователя (под будущую ролевую модель, где специалист логинится сам).
 - После успешного callback пользователь возвращается на `/settings`, а в настройках отмечается `googleConnected: true`.
 - Управление специалистами вынесено из `Settings` в отдельный раздел `/specialists` в левом меню (для `owner/admin`).
 - На странице `/specialists` создание специалиста теперь выполняется через выбор из `web_users` текущего `account_id` (только `role = specialist` и `is_active = true`, исключая уже привязанные профили специалистов).
@@ -119,16 +119,16 @@ scheduletm/
 
 Текущее состояние модели данных для Google:
 
-- `web_users.google_api_key` — ключ, полученный через web OAuth (источник истины для авторизованного web-пользователя).
+- `web_user_integrations.google_api_key` — ключ, полученный через web OAuth (источник истины для авторизованного web-пользователя).
 - `specialists.user_id` определяет, какому специалисту принадлежит `web_user`.
-- `specialists` больше не хранит Google credentials: источник истины только `web_users.google_api_key/google_calendar_id`.
+- `specialists` больше не хранит Google credentials: источник истины только `web_user_integrations.google_api_key/google_calendar_id`.
 
 ### Telegram BOT_TOKEN (добавлено)
 
 - В `User settings` добавлено password-поле для `BOT_TOKEN`.
 - Backend при сохранении токена вызывает Telegram API `getMe`; если API недоступен, токен всё равно сохраняется как рабочий fallback.
-- В `web_users` сохраняются `telegram_bot_token` и метаданные бота (`telegram_bot_username`, `telegram_bot_name`) для отображения статуса на фронте.
-- Bot backend использует токен из `web_users.telegram_bot_token` (а не из `.env BOT_TOKEN`) для Telegram API вызовов.
+- В `web_user_integrations` сохраняются `telegram_bot_token` и метаданные бота (`telegram_bot_username`, `telegram_bot_name`) для отображения статуса на фронте.
+- Bot backend использует токен из `web_user_integrations.telegram_bot_token` (а не из `.env BOT_TOKEN`) для Telegram API вызовов.
 
 ## Куда двигаться дальше (web/server)
 

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@
 - [x] Перенести web auth-сессии в БД (`web_user_sessions`, access + refresh токены).
 - [ ] Добавить миграции и seed для локальной разработки.
 - [x] Развести identity-модели: `users` (Telegram), `web_users` (web-auth), `user_identity_links` (1:1 связь в рамках account).
-- [x] Сохранять Google OAuth ключ web-пользователя в `web_users.google_api_key` после успешного callback.
+- [x] Сохранять Google OAuth ключ web-пользователя в `web_user_integrations.google_api_key` после успешного callback.
 - [x] Добавить связь `specialists <-> web_users` через `specialists.user_id` для персонального календаря специалиста.
 - [x] Добавить ролевую модель web-auth (`owner`/`admin`/`specialist`) и авто-создание default specialist для owner при регистрации.
 - [x] Добавить endpoint для owner/admin: создание пользователя роли `specialist` и связанного `specialists` профиля.

--- a/bot/README.md
+++ b/bot/README.md
@@ -116,8 +116,8 @@ npm test
 - `specialists` - специалисты (в т.ч. `is_default`, `is_active`, `base_session_price`, `base_hour_price`)
 - Для интеграции календаря у специалиста используется связка:
   - `specialists.user_id` (какой `web_user` владеет интеграцией специалиста)
-  - `web_users.google_api_key` / `web_users.google_calendar_id`
-  - `specialists` не хранит Google ключи; источник истины — `web_users`
+  - `web_user_integrations.google_api_key` / `web_user_integrations.google_calendar_id`
+  - `specialists` не хранит Google ключи; источник истины — `web_user_integrations`
 - `app_settings` - рабочие часы/дни и timezone (IANA), в которой показываются слоты/записи
 - `appointment_groups` - группы пакетных записей (общая стоимость/статус оплаты пакета), связанные с `appointments.group_id`
 

--- a/bot/src/repositories/specialist.repository.ts
+++ b/bot/src/repositories/specialist.repository.ts
@@ -44,10 +44,13 @@ export async function findSpecialistCalendarCredentials(accountId: number, speci
     .leftJoin('web_users as wu', function joinWebUsers() {
       this.on('wu.account_id', '=', 'sp.account_id').andOn('wu.id', '=', 'sp.user_id');
     })
+    .leftJoin('web_user_integrations as wui', function joinWebUserIntegrations() {
+      this.on('wui.account_id', '=', 'wu.account_id').andOn('wui.web_user_id', '=', 'wu.id');
+    })
     .where({ 'sp.account_id': accountId, 'sp.id': specialistId })
     .first<SpecialistCalendarCredentialsRow>(
-      'wu.google_api_key as google_api_key',
-      'wu.google_calendar_id as google_calendar_id',
+      'wui.google_api_key as google_api_key',
+      'wui.google_calendar_id as google_calendar_id',
     );
 
   return row ?? null;

--- a/bot/src/repositories/web-user.repository.ts
+++ b/bot/src/repositories/web-user.repository.ts
@@ -1,14 +1,17 @@
 import { db } from '../db/knex';
 
 export async function findActiveTelegramBotTokenByAccountId(accountId: number): Promise<string | null> {
-  const row = await db('web_users')
-    .where({ account_id: accountId, is_active: true })
-    .whereNotNull('telegram_bot_token')
+  const row = await db('web_users as wu')
+    .join('web_user_integrations as wui', function joinWebUserIntegrations() {
+      this.on('wui.web_user_id', '=', 'wu.id').andOn('wui.account_id', '=', 'wu.account_id');
+    })
+    .where({ 'wu.account_id': accountId, 'wu.is_active': true })
+    .whereNotNull('wui.telegram_bot_token')
     .orderByRaw(
-      "CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'specialist' THEN 2 ELSE 3 END",
+      "CASE wu.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'specialist' THEN 2 ELSE 3 END",
     )
-    .orderBy('updated_at', 'desc')
-    .first<{ telegram_bot_token: string | null }>('telegram_bot_token');
+    .orderBy('wui.updated_at', 'desc')
+    .first<{ telegram_bot_token: string | null }>('wui.telegram_bot_token as telegram_bot_token');
 
   return row?.telegram_bot_token ?? null;
 }

--- a/server/src/db/migrations/20260424170000_create_web_user_integrations.ts
+++ b/server/src/db/migrations/20260424170000_create_web_user_integrations.ts
@@ -1,0 +1,121 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'web_user_integrations';
+
+const INTEGRATION_COLUMNS = [
+  'google_api_key',
+  'google_refresh_token',
+  'google_token_expires_at',
+  'google_calendar_id',
+  'google_connected_at',
+  'telegram_bot_token',
+  'telegram_bot_username',
+  'telegram_bot_name',
+] as const;
+
+async function ensureTable(knex: Knex) {
+  const hasTable = await knex.schema.hasTable(TABLE_NAME);
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table
+      .integer('account_id')
+      .notNullable()
+      .references('id')
+      .inTable('accounts')
+      .onDelete('CASCADE');
+    table
+      .integer('web_user_id')
+      .notNullable()
+      .references('id')
+      .inTable('web_users')
+      .onDelete('CASCADE');
+
+    table.string('google_api_key');
+    table.string('google_refresh_token');
+    table.timestamp('google_token_expires_at', { useTz: true });
+    table.string('google_calendar_id');
+    table.timestamp('google_connected_at', { useTz: true });
+
+    table.text('telegram_bot_token');
+    table.string('telegram_bot_username', 255);
+    table.string('telegram_bot_name', 255);
+
+    table.timestamps(true, true);
+
+    table.unique(['account_id', 'web_user_id'], {
+      indexName: 'web_user_integrations_account_id_web_user_id_unique',
+    });
+    table.index(['account_id'], 'web_user_integrations_account_id_index');
+    table.index(['web_user_id'], 'web_user_integrations_web_user_id_index');
+  });
+}
+
+async function backfillFromWebUsers(knex: Knex) {
+  const hasWebUsersTable = await knex.schema.hasTable('web_users');
+  if (!hasWebUsersTable) {
+    return;
+  }
+
+  const hasAllColumns = await Promise.all(
+    INTEGRATION_COLUMNS.map((column) => knex.schema.hasColumn('web_users', column)),
+  );
+
+  if (hasAllColumns.some((hasColumn) => !hasColumn)) {
+    return;
+  }
+
+  await knex.raw(`
+    INSERT INTO ${TABLE_NAME} (
+      account_id,
+      web_user_id,
+      google_api_key,
+      google_refresh_token,
+      google_token_expires_at,
+      google_calendar_id,
+      google_connected_at,
+      telegram_bot_token,
+      telegram_bot_username,
+      telegram_bot_name,
+      created_at,
+      updated_at
+    )
+    SELECT
+      wu.account_id,
+      wu.id,
+      wu.google_api_key,
+      wu.google_refresh_token,
+      wu.google_token_expires_at,
+      wu.google_calendar_id,
+      wu.google_connected_at,
+      wu.telegram_bot_token,
+      wu.telegram_bot_username,
+      wu.telegram_bot_name,
+      wu.created_at,
+      wu.updated_at
+    FROM web_users wu
+    WHERE (
+      wu.google_api_key IS NOT NULL OR
+      wu.google_refresh_token IS NOT NULL OR
+      wu.google_token_expires_at IS NOT NULL OR
+      wu.google_calendar_id IS NOT NULL OR
+      wu.google_connected_at IS NOT NULL OR
+      wu.telegram_bot_token IS NOT NULL OR
+      wu.telegram_bot_username IS NOT NULL OR
+      wu.telegram_bot_name IS NOT NULL
+    )
+    ON CONFLICT (account_id, web_user_id) DO NOTHING
+  `);
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await ensureTable(knex);
+  await backfillFromWebUsers(knex);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists(TABLE_NAME);
+}

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -165,16 +165,19 @@ export async function findSpecialistsCalendarCredentials(
     .join('web_users as wu', function joinWebUsers() {
       this.on('wu.id', '=', 's.user_id').andOn('wu.account_id', '=', 's.account_id');
     })
+    .leftJoin('web_user_integrations as wui', function joinWebUserIntegrations() {
+      this.on('wui.web_user_id', '=', 'wu.id').andOn('wui.account_id', '=', 'wu.account_id');
+    })
     .where('s.account_id', accountId)
     .whereIn('s.id', specialistIds)
-    .whereNotNull('wu.google_api_key')
+    .whereNotNull('wui.google_api_key')
     .select(
       's.id as specialistId',
       'wu.id as webUserId',
-      'wu.google_api_key as googleApiKey',
-      'wu.google_refresh_token as googleRefreshToken',
-      'wu.google_token_expires_at as googleTokenExpiresAt',
-      'wu.google_calendar_id as googleCalendarId',
+      'wui.google_api_key as googleApiKey',
+      'wui.google_refresh_token as googleRefreshToken',
+      'wui.google_token_expires_at as googleTokenExpiresAt',
+      'wui.google_calendar_id as googleCalendarId',
     );
 
   return rows.filter((row) => Boolean(row.googleApiKey));

--- a/server/src/repositories/webUserIntegrationRepository.ts
+++ b/server/src/repositories/webUserIntegrationRepository.ts
@@ -1,0 +1,118 @@
+import { db } from '../db/knex.js';
+
+export type WebUserIntegrationRecord = {
+  id: number;
+  account_id: number;
+  web_user_id: number;
+  google_api_key: string | null;
+  google_refresh_token: string | null;
+  google_token_expires_at: Date | null;
+  google_calendar_id: string | null;
+  google_connected_at: Date | null;
+  telegram_bot_token: string | null;
+  telegram_bot_username: string | null;
+  telegram_bot_name: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type UpdateWebUserGoogleCredentialsInput = {
+  accountId: number;
+  webUserId: number;
+  googleApiKey: string;
+  googleRefreshToken?: string | null;
+  googleTokenExpiresAt?: Date | null;
+  googleCalendarId?: string | null;
+};
+
+type UpdateWebUserTelegramIntegrationInput = {
+  accountId: number;
+  webUserId: number;
+  telegramBotToken?: string | null;
+  telegramBotUsername?: string | null;
+  telegramBotName?: string | null;
+};
+
+async function upsertPatch(
+  accountId: number,
+  webUserId: number,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  await db('web_user_integrations')
+    .insert({
+      account_id: accountId,
+      web_user_id: webUserId,
+      ...patch,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    })
+    .onConflict(['account_id', 'web_user_id'])
+    .merge({
+      ...patch,
+      updated_at: db.fn.now(),
+    });
+}
+
+export async function findWebUserIntegrationByWebUserId(
+  accountId: number,
+  webUserId: number,
+): Promise<WebUserIntegrationRecord | null> {
+  const row = await db('web_user_integrations')
+    .where({ account_id: accountId, web_user_id: webUserId })
+    .first<WebUserIntegrationRecord>();
+
+  return row ?? null;
+}
+
+export async function updateWebUserGoogleCredentials(input: UpdateWebUserGoogleCredentialsInput): Promise<void> {
+  const patch: Record<string, unknown> = {
+    google_api_key: input.googleApiKey,
+    google_connected_at: db.fn.now(),
+  };
+
+  if (input.googleRefreshToken !== undefined) {
+    patch.google_refresh_token = input.googleRefreshToken;
+  }
+
+  if (input.googleTokenExpiresAt !== undefined) {
+    patch.google_token_expires_at = input.googleTokenExpiresAt;
+  }
+
+  if (input.googleCalendarId !== undefined) {
+    patch.google_calendar_id = input.googleCalendarId;
+  }
+
+  await upsertPatch(input.accountId, input.webUserId, patch);
+}
+
+export async function clearWebUserGoogleCredentials(accountId: number, webUserId: number): Promise<void> {
+  await upsertPatch(accountId, webUserId, {
+    google_api_key: null,
+    google_refresh_token: null,
+    google_token_expires_at: null,
+    google_calendar_id: null,
+    google_connected_at: null,
+  });
+}
+
+export async function updateWebUserTelegramIntegration(input: UpdateWebUserTelegramIntegrationInput): Promise<void> {
+  const patch: Record<string, unknown> = {};
+
+  if (input.telegramBotToken !== undefined) {
+    patch.telegram_bot_token = input.telegramBotToken;
+  }
+
+  if (input.telegramBotUsername !== undefined) {
+    patch.telegram_bot_username = input.telegramBotUsername;
+  }
+
+  if (input.telegramBotName !== undefined) {
+    patch.telegram_bot_name = input.telegramBotName;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return;
+  }
+
+  await upsertPatch(input.accountId, input.webUserId, patch);
+}

--- a/server/src/repositories/webUserRepository.ts
+++ b/server/src/repositories/webUserRepository.ts
@@ -9,14 +9,6 @@ export type WebUserRecord = {
   password_hash: string;
   password_salt: string;
   is_active: boolean;
-  google_api_key: string | null;
-  google_refresh_token: string | null;
-  google_token_expires_at: Date | null;
-  google_calendar_id: string | null;
-  google_connected_at: Date | null;
-  telegram_bot_token: string | null;
-  telegram_bot_username: string | null;
-  telegram_bot_name: string | null;
   timezone: string;
   locale: string;
   ui_theme_mode: 'light' | 'dark';
@@ -94,55 +86,6 @@ export async function touchWebUserLastLogin(accountId: number, id: number): Prom
     });
 }
 
-type UpdateWebUserGoogleCredentialsInput = {
-  accountId: number;
-  id: number;
-  googleApiKey: string;
-  googleRefreshToken?: string | null;
-  googleTokenExpiresAt?: Date | null;
-  googleCalendarId?: string | null;
-};
-
-export async function updateWebUserGoogleCredentials(
-  input: UpdateWebUserGoogleCredentialsInput,
-): Promise<void> {
-  const patch: Record<string, unknown> = {
-    google_api_key: input.googleApiKey,
-    google_connected_at: db.fn.now(),
-    updated_at: db.fn.now(),
-  };
-
-  if (input.googleRefreshToken !== undefined) {
-    patch.google_refresh_token = input.googleRefreshToken;
-  }
-
-  if (input.googleTokenExpiresAt !== undefined) {
-    patch.google_token_expires_at = input.googleTokenExpiresAt;
-  }
-
-  if (input.googleCalendarId !== undefined) {
-    patch.google_calendar_id = input.googleCalendarId;
-  }
-
-  await db('web_users')
-    .where({ account_id: input.accountId, id: input.id })
-    .update(patch);
-}
-
-export async function clearWebUserGoogleCredentials(accountId: number, id: number): Promise<void> {
-  await db('web_users')
-    .where({ account_id: accountId, id })
-    .update({
-      google_api_key: null,
-      google_refresh_token: null,
-      google_token_expires_at: null,
-      google_calendar_id: null,
-      google_connected_at: null,
-      updated_at: db.fn.now(),
-    });
-}
-
-
 type UpdateWebUserSettingsInput = {
   accountId: number;
   id: number;
@@ -150,9 +93,6 @@ type UpdateWebUserSettingsInput = {
   locale?: string;
   uiThemeMode?: 'light' | 'dark';
   uiPaletteVariantId?: string;
-  telegramBotToken?: string | null;
-  telegramBotUsername?: string | null;
-  telegramBotName?: string | null;
 };
 
 export async function updateWebUserSettings(input: UpdateWebUserSettingsInput): Promise<void> {
@@ -174,18 +114,6 @@ export async function updateWebUserSettings(input: UpdateWebUserSettingsInput): 
 
   if (input.uiPaletteVariantId !== undefined) {
     patch.ui_palette_variant_id = input.uiPaletteVariantId;
-  }
-
-  if (input.telegramBotToken !== undefined) {
-    patch.telegram_bot_token = input.telegramBotToken;
-  }
-
-  if (input.telegramBotUsername !== undefined) {
-    patch.telegram_bot_username = input.telegramBotUsername;
-  }
-
-  if (input.telegramBotName !== undefined) {
-    patch.telegram_bot_name = input.telegramBotName;
   }
 
   await db('web_users')

--- a/server/src/services/googleOAuthService.ts
+++ b/server/src/services/googleOAuthService.ts
@@ -4,7 +4,7 @@ import { URLSearchParams } from 'node:url';
 import { env } from '../config/env.js';
 import { getDefaultAccountId } from '../repositories/accountRepository.js';
 import { createGoogleOAuthState, consumeGoogleOAuthState } from '../repositories/googleOAuthStateRepository.js';
-import { clearWebUserGoogleCredentials, updateWebUserGoogleCredentials } from '../repositories/webUserRepository.js';
+import { clearWebUserGoogleCredentials, updateWebUserGoogleCredentials } from '../repositories/webUserIntegrationRepository.js';
 
 type GoogleTokenResponse = {
   access_token: string;
@@ -107,7 +107,7 @@ export const completeGoogleOAuth = async (state: string, code: string) => {
 
     await updateWebUserGoogleCredentials({
       accountId,
-      id: pending.web_user_id,
+      webUserId: pending.web_user_id,
       googleApiKey: tokenResponse.data.access_token,
       googleRefreshToken: tokenResponse.data.refresh_token,
       googleTokenExpiresAt: resolveTokenExpiresAt(tokenResponse.data.expires_in),
@@ -152,7 +152,7 @@ export const refreshGoogleAccessToken = async (input: RefreshGoogleAccessTokenIn
     const googleTokenExpiresAt = resolveTokenExpiresAt(tokenResponse.data.expires_in);
     await updateWebUserGoogleCredentials({
       accountId: input.accountId,
-      id: input.webUserId,
+      webUserId: input.webUserId,
       googleApiKey: tokenResponse.data.access_token,
       googleRefreshToken: tokenResponse.data.refresh_token,
       googleTokenExpiresAt,

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -1,6 +1,7 @@
 import { getDefaultAccountId } from '../repositories/accountRepository.js';
 import { findAppSettingsByAccountId, updateAppSettingsByAccountId } from '../repositories/appSettingsRepository.js';
 import { findWebUserById, updateWebUserSettings } from '../repositories/webUserRepository.js';
+import { findWebUserIntegrationByWebUserId, updateWebUserTelegramIntegration } from '../repositories/webUserIntegrationRepository.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 import { systemSettingsSchema, userSettingsSchema } from '../config/schemas.js';
@@ -97,15 +98,17 @@ export const getUserSettings = async (userId: string): Promise<UserSettings> => 
     };
   }
 
+  const integration = await findWebUserIntegrationByWebUserId(accountId, numericUserId);
+
   return {
     timezone: user.timezone,
     locale: user.locale,
     uiThemeMode: user.ui_theme_mode,
     uiPaletteVariantId: user.ui_palette_variant_id,
-    googleConnected: Boolean(user.google_api_key),
-    telegramBotConnected: Boolean(user.telegram_bot_token),
-    telegramBotName: user.telegram_bot_name,
-    telegramBotUsername: user.telegram_bot_username,
+    googleConnected: Boolean(integration?.google_api_key),
+    telegramBotConnected: Boolean(integration?.telegram_bot_token),
+    telegramBotName: integration?.telegram_bot_name ?? null,
+    telegramBotUsername: integration?.telegram_bot_username ?? null,
   };
 };
 
@@ -147,6 +150,11 @@ export const updateUserSettings = async (actor: User, payload: unknown): Promise
     locale: parsed.data.locale,
     uiThemeMode: parsed.data.uiThemeMode,
     uiPaletteVariantId: parsed.data.uiPaletteVariantId,
+  });
+
+  await updateWebUserTelegramIntegration({
+    accountId,
+    webUserId: numericUserId,
     telegramBotToken: telegramBotTokenPatch,
     telegramBotUsername: telegramBotUsernamePatch,
     telegramBotName: telegramBotNamePatch,


### PR DESCRIPTION
### Motivation
- Reduce coupling of `web_users` by moving Google and Telegram integration data to a single-purpose `web_user_integrations` table so integration fields are managed separately and mapped to `web_users` by id. 
- Make it easier for `specialists` and `bot` code to read per-user integration credentials without expanding core web-user profile shape. 

### Description
- Added migration `20260424170000_create_web_user_integrations.ts` to create `web_user_integrations`, backfill existing integration data from `web_users` and add indexes/unique constraint. 
- Introduced `server/src/repositories/webUserIntegrationRepository.ts` with upsert-style APIs `updateWebUserGoogleCredentials`, `clearWebUserGoogleCredentials`, `updateWebUserTelegramIntegration` and `findWebUserIntegrationByWebUserId`. 
- Switched server flows to use the new table by updating `server/src/services/googleOAuthService.ts` and `server/src/services/settingsService.ts`, and simplified `server/src/repositories/webUserRepository.ts` to keep only core web-user fields. 
- Updated specialist credential joins and bot token selection to join `web_user_integrations` (server and bot repo changes under `server/src/repositories/specialistRepository.ts`, `bot/src/repositories/specialist.repository.ts`, and `bot/src/repositories/web-user.repository.ts`). 
- Updated documentation (`README.md`, `PROJECT_MAP.md`, `TODO.md`, `PRODUCTION_READINESS_CHECKLIST.md`, `bot/README.md`) to reflect `web_user_integrations` as the source of truth for Google/Telegram credentials. 

### Testing
- Ran `npm run --workspace server typecheck` and `npm run --workspace bot typecheck`, both succeeded. 
- Ran `npm run --workspace bot test`, all bot tests passed. 
- Ran `npm run --workspace server test`, most server tests passed but the run failed due to an existing unit test `tests/specialists.schemas.unit.test.ts > validates create payload` (assertion failure) that appears unrelated to this refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb733f37d88333868a26a812a90d05)