### PR TITLE
Add client web users and scoped self-service appointments

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ scheduletm/
 ### Web + Server
 
 - Auth: register/login/refresh/logout.
-- Роли: `owner` / `admin` / `specialist`.
+- Роли: `owner` / `admin` / `specialist` / `client`.
 - Settings: system + user settings.
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
 - Specialists и Users CRUD (с role-gates).
+- Client web users:
+  - owner/admin/specialist могут создавать пользователей с ролью `client`;
+  - `client` может входить в web-приложение, редактировать собственный профиль и управлять только своими записями (редактирование/перенос/отмена);
+  - Google OAuth доступен для подключения календаря и синхронизации занятости.
 - Базовая i18n поддержка (`ru/en`) в web + локализованные server messages.
 
 ### Bot

--- a/server/README.md
+++ b/server/README.md
@@ -5,9 +5,14 @@ Node.js/Express API для web-клиента и интеграций.
 ## Что умеет
 
 - Auth: register/login/refresh/logout.
+- Web roles: owner/admin/specialist/client.
 - Settings API: user/system.
 - CRUD: users, specialists.
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
+- Client self-service:
+  - owner/admin/specialist могут создавать web users с ролью `client`;
+  - `client` видит и управляет только собственными записями (edit/reschedule/cancel);
+  - `client` не может создавать новые записи, отмечать оплату и отправлять уведомления.
 - Google OAuth (`start` + `callback`).
 - Локализованные API-сообщения (`ru/en`).
 

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -72,7 +72,7 @@ export const specialistUserCreationSchema = z.object({
     .max(120, v.specialistNameMax)
 });
 
-const managedUserRoleSchema = z.enum(['admin', 'specialist']);
+const managedUserRoleSchema = z.enum(['admin', 'specialist', 'client']);
 
 export const managedUserCreateSchema = z.object({
   email: z.string().trim().email(v.emailInvalid).max(254, v.emailTooLong),

--- a/server/src/db/migrations/20260424193000_add_client_role_and_link_to_web_users.ts
+++ b/server/src/db/migrations/20260424193000_add_client_role_and_link_to_web_users.ts
@@ -1,0 +1,56 @@
+import type { Knex } from 'knex';
+import { WEB_USER_ROLES } from '../../types/webUserRole.js';
+
+const WEB_USERS_TABLE = 'web_users';
+const CLIENTS_TABLE = 'clients';
+const ROLE_CHECK = `role IN (${WEB_USER_ROLES.map((role) => `'${role}'`).join(', ')})`;
+
+export async function up(knex: Knex): Promise<void> {
+  const hasWebUsers = await knex.schema.hasTable(WEB_USERS_TABLE);
+  if (!hasWebUsers) {
+    return;
+  }
+
+  const hasClientId = await knex.schema.hasColumn(WEB_USERS_TABLE, 'client_id');
+  if (!hasClientId) {
+    await knex.schema.alterTable(WEB_USERS_TABLE, (table) => {
+      table
+        .integer('client_id')
+        .references('id')
+        .inTable(CLIENTS_TABLE)
+        .onDelete('SET NULL');
+    });
+  }
+
+  await knex.raw(
+    `CREATE UNIQUE INDEX IF NOT EXISTS "web_users_account_id_client_id_unique" ON "${WEB_USERS_TABLE}" ("account_id", "client_id") WHERE "client_id" IS NOT NULL`,
+  );
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS "web_users_client_id_index" ON "${WEB_USERS_TABLE}" ("client_id")`,
+  );
+
+  await knex.raw(`ALTER TABLE "${WEB_USERS_TABLE}" DROP CONSTRAINT IF EXISTS "web_users_role_check"`);
+  await knex.raw(`ALTER TABLE "${WEB_USERS_TABLE}" ADD CONSTRAINT "web_users_role_check" CHECK (${ROLE_CHECK})`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasWebUsers = await knex.schema.hasTable(WEB_USERS_TABLE);
+  if (!hasWebUsers) {
+    return;
+  }
+
+  await knex.raw('DROP INDEX IF EXISTS "web_users_client_id_index"');
+  await knex.raw('DROP INDEX IF EXISTS "web_users_account_id_client_id_unique"');
+
+  const hasClientId = await knex.schema.hasColumn(WEB_USERS_TABLE, 'client_id');
+  if (hasClientId) {
+    await knex.schema.alterTable(WEB_USERS_TABLE, (table) => {
+      table.dropColumn('client_id');
+    });
+  }
+
+  await knex.raw(`ALTER TABLE "${WEB_USERS_TABLE}" DROP CONSTRAINT IF EXISTS "web_users_role_check"`);
+  await knex.raw(
+    `ALTER TABLE "${WEB_USERS_TABLE}" ADD CONSTRAINT "web_users_role_check" CHECK (role IN ('owner', 'admin', 'specialist'))`,
+  );
+}

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -38,6 +38,7 @@ type AppointmentListFilters = {
   from?: Date;
   to?: Date;
   specialistId?: number;
+  clientId?: number;
 };
 
 type CreateAppointmentInput = {
@@ -70,6 +71,10 @@ export async function listAppointments(filters: AppointmentListFilters): Promise
 
   if (filters.specialistId) {
     query.andWhere('appointments.specialist_id', filters.specialistId);
+  }
+
+  if (filters.clientId) {
+    query.andWhere('appointments.user_id', filters.clientId);
   }
 
   if (filters.from) {

--- a/server/src/repositories/webUserRepository.ts
+++ b/server/src/repositories/webUserRepository.ts
@@ -10,6 +10,7 @@ export type WebUserRecord = {
   last_name: string | null;
   phone: string | null;
   telegram_username: string | null;
+  client_id: number | null;
   password_hash: string;
   password_salt: string;
   is_active: boolean;
@@ -149,6 +150,7 @@ type UpdateWebUserProfileInput = {
   telegramUsername?: string;
   email?: string;
   isActive?: boolean;
+  clientId?: number | null;
 };
 
 export async function updateWebUserProfile(input: UpdateWebUserProfileInput): Promise<void> {
@@ -182,6 +184,10 @@ export async function updateWebUserProfile(input: UpdateWebUserProfileInput): Pr
 
   if (input.isActive !== undefined) {
     patch.is_active = input.isActive;
+  }
+
+  if (input.clientId !== undefined) {
+    patch.client_id = input.clientId;
   }
 
   await db('web_users')

--- a/server/src/routes/appointmentRoutes.ts
+++ b/server/src/routes/appointmentRoutes.ts
@@ -37,6 +37,10 @@ appointmentRoutes.get('/', async (req, res) => {
 
     return res.json(data);
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+    if (message === 'CLIENT_PROFILE_NOT_FOUND') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
+    }
     console.error(error);
     return res.status(500).json({ message: t(req, 'appointmentsLoadFailed') });
   }
@@ -58,6 +62,9 @@ appointmentRoutes.post('/', async (req, res) => {
 
     if (message === 'FORBIDDEN_SPECIALIST') {
       return res.status(403).json({ message: t(req, 'forbiddenSpecialistScope') });
+    }
+    if (message === 'FORBIDDEN_CLIENT') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
     }
 
     if (message === 'SPECIALIST_NOT_FOUND') {
@@ -98,6 +105,9 @@ appointmentRoutes.patch('/:id', async (req, res) => {
     if (message === 'FORBIDDEN_SPECIALIST') {
       return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
     }
+    if (message === 'FORBIDDEN_CLIENT') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
+    }
     if (message === 'CLIENT_NOT_FOUND') {
       return res.status(404).json({ message: t(req, 'clientNotFound') });
     }
@@ -125,6 +135,9 @@ appointmentRoutes.post('/:id/cancel', async (req, res) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'UNKNOWN';
     if (message === 'FORBIDDEN_SPECIALIST') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
+    }
+    if (message === 'FORBIDDEN_CLIENT') {
       return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
     }
 
@@ -158,6 +171,9 @@ appointmentRoutes.post('/:id/reschedule', async (req, res) => {
     if (message === 'FORBIDDEN_SPECIALIST') {
       return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
     }
+    if (message === 'FORBIDDEN_CLIENT') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
+    }
 
     console.error(error);
     return res.status(500).json({ message: t(req, 'appointmentRescheduleFailed') });
@@ -184,6 +200,9 @@ appointmentRoutes.post('/:id/mark-paid', async (req, res) => {
     if (message === 'FORBIDDEN_SPECIALIST') {
       return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
     }
+    if (message === 'FORBIDDEN_CLIENT') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
+    }
 
     console.error(error);
     return res.status(500).json({ message: t(req, 'appointmentMarkPaidFailed') });
@@ -208,6 +227,9 @@ appointmentRoutes.post('/:id/notify', async (req, res) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'UNKNOWN';
     if (message === 'FORBIDDEN_SPECIALIST') {
+      return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
+    }
+    if (message === 'FORBIDDEN_CLIENT') {
       return res.status(403).json({ message: t(req, 'forbiddenAppointmentScope') });
     }
 

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -25,6 +25,7 @@ import {
   listSpecialistsByAccount,
   type SpecialistRecord,
 } from '../repositories/specialistRepository.js';
+import { findWebUserById } from '../repositories/webUserRepository.js';
 import { listExternalBusySlots, type ExternalBusySlot } from './calendarAvailabilityService.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
@@ -92,6 +93,10 @@ type UpdateAppointmentPayload = {
 
 function canManageAllAppointments(role: WebUserRole): boolean {
   return role === WebUserRole.Owner || role === WebUserRole.Admin;
+}
+
+function isClientRole(role: WebUserRole): boolean {
+  return role === WebUserRole.Client;
 }
 
 function parseMeetingLinkFromNotes(notes: string | null): { notes: string; meetingLink: string } {
@@ -191,6 +196,9 @@ async function resolveAllowedSpecialistId(actor: User, accountId: number): Promi
   if (canManageAllAppointments(actor.role)) {
     return null;
   }
+  if (isClientRole(actor.role)) {
+    return null;
+  }
 
   const specialist = await findSpecialistByWebUserId(accountId, Number(actor.id));
   if (!specialist) {
@@ -198,6 +206,19 @@ async function resolveAllowedSpecialistId(actor: User, accountId: number): Promi
   }
 
   return specialist.id;
+}
+
+async function resolveClientScope(actor: User, accountId: number): Promise<number | null> {
+  if (!isClientRole(actor.role)) {
+    return null;
+  }
+
+  const webUser = await findWebUserById(accountId, Number(actor.id));
+  if (!webUser?.client_id) {
+    throw new Error('CLIENT_PROFILE_NOT_FOUND');
+  }
+
+  return webUser.client_id;
 }
 
 function mapSpecialistsForUi(rows: SpecialistRecord[]) {
@@ -313,19 +334,27 @@ export async function getAppointments(
 ): Promise<AppointmentListResult> {
   const accountId = await resolveAccountId(actor);
   const allowedSpecialistId = await resolveAllowedSpecialistId(actor, accountId);
+  const allowedClientId = await resolveClientScope(actor, accountId);
 
   const specialistId = allowedSpecialistId ?? filters.specialistId;
 
   const items = await listAppointments({
     accountId,
     specialistId,
+    clientId: allowedClientId ?? undefined,
     from: filters.from ? new Date(filters.from) : undefined,
     to: filters.to ? new Date(filters.to) : undefined,
   });
 
   const specialists = canManageAllAppointments(actor.role)
     ? mapSpecialistsForUi(await listSpecialistsByAccount(accountId))
-    : mapSpecialistsForUi(
+    : isClientRole(actor.role)
+      ? mapSpecialistsForUi(
+        (await listSpecialistsByAccount(accountId)).filter((item) =>
+          items.some((appointment) => appointment.specialist_id === item.id),
+        ),
+      )
+      : mapSpecialistsForUi(
         (await listSpecialistsByAccount(accountId)).filter((item) => item.user_id === Number(actor.id)),
       );
 
@@ -355,7 +384,11 @@ export async function getAppointments(
       events: eventsByAppointmentId.get(item.id) ?? [],
     })),
     specialists,
-    clients: (await listClientsByAccount(accountId)).map(mapClient),
+    clients: isClientRole(actor.role)
+      ? (await listClientsByAccount(accountId))
+        .filter((client) => client.id === allowedClientId)
+        .map(mapClient)
+      : (await listClientsByAccount(accountId)).map(mapClient),
     busySlots: filterBusySlotsOverlappingAppointments(appointmentsForUi, busySlots),
   };
 }
@@ -364,6 +397,10 @@ export async function createAppointmentForActor(
   actor: User,
   payload: CreateAppointmentPayload,
 ): Promise<AppointmentDto> {
+  if (isClientRole(actor.role)) {
+    throw new Error('FORBIDDEN_CLIENT');
+  }
+
   const accountId = await resolveAccountId(actor);
 
   if (!canManageAllAppointments(actor.role)) {
@@ -409,6 +446,15 @@ async function resolveManagedAppointment(actor: User, appointmentId: number) {
   }
 
   if (!canManageAllAppointments(actor.role)) {
+    if (isClientRole(actor.role)) {
+      const allowedClientId = await resolveClientScope(actor, accountId);
+      if (!allowedClientId || existing.user_id !== allowedClientId) {
+        throw new Error('FORBIDDEN_CLIENT');
+      }
+
+      return { accountId, existing };
+    }
+
     const selfSpecialist = await findSpecialistByWebUserId(accountId, Number(actor.id));
     if (!selfSpecialist || selfSpecialist.id !== existing.specialist_id) {
       throw new Error('FORBIDDEN_SPECIALIST');
@@ -516,6 +562,10 @@ export async function rescheduleAppointmentForActor(
 }
 
 export async function markPaidAppointmentForActor(actor: User, appointmentId: number): Promise<AppointmentDto | null> {
+  if (isClientRole(actor.role)) {
+    throw new Error('FORBIDDEN_CLIENT');
+  }
+
   const { accountId, existing } = await resolveManagedAppointment(actor, appointmentId);
 
   if (!existing) {
@@ -541,6 +591,10 @@ export async function markPaidAppointmentForActor(actor: User, appointmentId: nu
 }
 
 export async function notifyAppointmentForActor(actor: User, appointmentId: number): Promise<AppointmentDto | null> {
+  if (isClientRole(actor.role)) {
+    throw new Error('FORBIDDEN_CLIENT');
+  }
+
   const { accountId, existing } = await resolveManagedAppointment(actor, appointmentId);
 
   if (!existing) {

--- a/server/src/services/userManagementService.ts
+++ b/server/src/services/userManagementService.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import { getDefaultAccountId } from '../repositories/accountRepository.js';
+import { createClient } from '../repositories/clientRepository.js';
 import { deactivateSpecialistByWebUserId } from '../repositories/specialistRepository.js';
 import {
   createWebUser,
@@ -27,7 +28,7 @@ export type UserManagementItem = {
 
 type UserCreatePayload = {
   email: string;
-  role: "admin" | "specialist";
+  role: "admin" | "specialist" | "client";
   firstName: string;
   lastName: string;
   phone?: string;
@@ -36,14 +37,26 @@ type UserCreatePayload = {
 
 type UserUpdatePayload = {
   email: string;
-  role: "admin" | "specialist";
+  role: "admin" | "specialist" | "client";
   firstName: string;
   lastName: string;
   phone?: string;
   telegramUsername?: string;
 };
 
-const canManageUsers = (role: WebUserRole): boolean => role === WebUserRole.Owner || role === WebUserRole.Admin;
+const canManageFullUserDirectory = (role: WebUserRole): boolean =>
+  role === WebUserRole.Owner || role === WebUserRole.Admin;
+
+const canManageClients = (role: WebUserRole): boolean =>
+  canManageFullUserDirectory(role) || role === WebUserRole.Specialist;
+
+const canCreateRole = (actorRole: WebUserRole, targetRole: UserCreatePayload['role']): boolean => {
+  if (targetRole === WebUserRole.Client) {
+    return canManageClients(actorRole);
+  }
+
+  return canManageFullUserDirectory(actorRole);
+};
 
 const mapUser = (item: Awaited<ReturnType<typeof listWebUsersByAccount>>[number]): UserManagementItem => ({
   id: item.id,
@@ -62,17 +75,20 @@ async function resolveAccountId(actor: User): Promise<number> {
 }
 
 export async function listManagedUsers(actor: User): Promise<UserManagementItem[]> {
-  if (!canManageUsers(actor.role)) {
+  if (!canManageClients(actor.role)) {
     throw new Error('FORBIDDEN');
   }
 
   const accountId = await resolveAccountId(actor);
   const users = await listWebUsersByAccount(accountId);
-  return users.map(mapUser);
+  const filtered = canManageFullUserDirectory(actor.role)
+    ? users
+    : users.filter((item) => item.role === WebUserRole.Client);
+  return filtered.map(mapUser);
 }
 
 export async function createManagedUser(actor: User, payload: UserCreatePayload): Promise<UserManagementItem> {
-  if (!canManageUsers(actor.role)) {
+  if (!canCreateRole(actor.role, payload.role)) {
     throw new Error('FORBIDDEN');
   }
 
@@ -100,6 +116,23 @@ export async function createManagedUser(actor: User, payload: UserCreatePayload)
     passwordSalt: salt,
   });
 
+  if (payload.role === WebUserRole.Client) {
+    const client = await createClient({
+      accountId,
+      firstName: payload.firstName.trim(),
+      lastName: payload.lastName.trim(),
+      phone: payload.phone?.trim(),
+      email,
+      username: payload.telegramUsername?.trim(),
+    });
+
+    await updateWebUserProfile({
+      accountId,
+      id: created.id,
+      clientId: client.id,
+    });
+  }
+
   await sendWelcomePasswordEmail({
     to: email,
     firstName: payload.firstName.trim(),
@@ -110,7 +143,7 @@ export async function createManagedUser(actor: User, payload: UserCreatePayload)
 }
 
 export async function updateManagedUser(actor: User, userId: number, payload: UserUpdatePayload): Promise<UserManagementItem | null> {
-  if (!canManageUsers(actor.role)) {
+  if (!canManageClients(actor.role)) {
     throw new Error('FORBIDDEN');
   }
 
@@ -118,6 +151,11 @@ export async function updateManagedUser(actor: User, userId: number, payload: Us
   const existing = await findWebUserById(accountId, userId);
   if (!existing) {
     return null;
+  }
+  if (!canManageFullUserDirectory(actor.role)) {
+    if (existing.role !== WebUserRole.Client || payload.role !== WebUserRole.Client) {
+      throw new Error('FORBIDDEN');
+    }
   }
 
   const email = sanitizeEmail(payload.email);
@@ -144,7 +182,7 @@ export async function updateManagedUser(actor: User, userId: number, payload: Us
 }
 
 export async function deactivateManagedUser(actor: User, userId: number): Promise<UserManagementItem | null> {
-  if (!canManageUsers(actor.role)) {
+  if (!canManageClients(actor.role)) {
     throw new Error('FORBIDDEN');
   }
 
@@ -152,6 +190,9 @@ export async function deactivateManagedUser(actor: User, userId: number): Promis
   const existing = await findWebUserById(accountId, userId);
   if (!existing) {
     return null;
+  }
+  if (!canManageFullUserDirectory(actor.role) && existing.role !== WebUserRole.Client) {
+    throw new Error('FORBIDDEN');
   }
 
   await updateWebUserProfile({

--- a/server/src/types/webUserRole.ts
+++ b/server/src/types/webUserRole.ts
@@ -2,6 +2,7 @@ export enum WebUserRole {
   Owner = 'owner',
   Admin = 'admin',
   Specialist = 'specialist',
+  Client = 'client',
 }
 
-export const WEB_USER_ROLES = [WebUserRole.Owner, WebUserRole.Admin, WebUserRole.Specialist] as const;
+export const WEB_USER_ROLES = [WebUserRole.Owner, WebUserRole.Admin, WebUserRole.Specialist, WebUserRole.Client] as const;

--- a/web/README.md
+++ b/web/README.md
@@ -1,14 +1,15 @@
 # Web (`@scheduletm/web`)
 
-React SPA для owner/admin/specialist.
+React SPA для owner/admin/specialist/client.
 
 ## Что умеет
 
 - Auth: `/login`, `/register`.
 - Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`.
-- Role-aware UI (owner/admin/specialist).
+- Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
+- Client flow: клиент работает только со своим расписанием (без доступа к чужим записям).
 
 ## Команды
 

--- a/web/src/components/users/UserFormDialog.tsx
+++ b/web/src/components/users/UserFormDialog.tsx
@@ -22,7 +22,7 @@ type UserFormDialogProps = {
   onClose: () => void;
   onSubmit: (payload: {
     email: string;
-    role: 'admin' | 'specialist';
+    role: 'admin' | 'specialist' | 'client';
     firstName: string;
     lastName: string;
     phone?: string;
@@ -32,7 +32,7 @@ type UserFormDialogProps = {
 
 type UserFormState = {
   email: string;
-  role: 'admin' | 'specialist';
+  role: 'admin' | 'specialist' | 'client';
   firstName: string;
   lastName: string;
   phone: string;
@@ -75,7 +75,11 @@ export function UserFormDialog({
 
     reset({
       email: editingUser?.email ?? '',
-      role: editingUser?.role === 'admin' ? 'admin' : 'specialist',
+      role: editingUser?.role === 'admin'
+        ? 'admin'
+        : editingUser?.role === 'client'
+          ? 'client'
+          : 'specialist',
       firstName: editingUser?.firstName ?? '',
       lastName: editingUser?.lastName ?? '',
       phone: editingUser?.phone ?? '',
@@ -112,9 +116,10 @@ export function UserFormDialog({
           render={({ field }) => (
             <FormControl margin="dense" fullWidth>
               <InputLabel id="managed-user-role-label">{roleLabel}</InputLabel>
-              <Select labelId="managed-user-role-label" label={roleLabel} value={field.value} onChange={(event) => field.onChange(event.target.value as 'admin' | 'specialist')}>
+              <Select labelId="managed-user-role-label" label={roleLabel} value={field.value} onChange={(event) => field.onChange(event.target.value as 'admin' | 'specialist' | 'client')}>
                 <MenuItem value="admin">admin</MenuItem>
                 <MenuItem value="specialist">specialist</MenuItem>
+                <MenuItem value="client">client</MenuItem>
               </Select>
             </FormControl>
           )}

--- a/web/src/containers/UsersContainer.tsx
+++ b/web/src/containers/UsersContainer.tsx
@@ -21,7 +21,7 @@ export function UsersContainer() {
   const [editingUser, setEditingUser] = useState<ManagedUserItem | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const canManageUsers = user?.role === 'owner' || user?.role === 'admin';
+  const canManageUsers = user?.role === 'owner' || user?.role === 'admin' || user?.role === 'specialist';
 
   useEffect(() => {
     if (!accessToken) {
@@ -54,7 +54,7 @@ export function UsersContainer() {
     void load();
   }, [accessToken, canManageUsers, navigate, t]);
 
-  const saveUser = async (payload: { email: string; role: 'admin' | 'specialist'; firstName: string; lastName: string; phone?: string; telegramUsername?: string }) => {
+  const saveUser = async (payload: { email: string; role: 'admin' | 'specialist' | 'client'; firstName: string; lastName: string; phone?: string; telegramUsername?: string }) => {
     if (!accessToken) {
       return;
     }

--- a/web/src/shared/types/roles.ts
+++ b/web/src/shared/types/roles.ts
@@ -2,4 +2,5 @@ export enum WebUserRole {
   Owner = 'owner',
   Admin = 'admin',
   Specialist = 'specialist',
+  Client = 'client',
 }


### PR DESCRIPTION
### Motivation
- Provide a lightweight `client` web role so customers can sign in, edit their profile and manage only their own appointments. 
- Keep changes minimal and consistent with existing role/gateway patterns so owners/admins retain full control and specialists can manage client accounts.

### Description
- Added a new `client` role to server and web enums (`server/src/types/webUserRole.ts`, `web/src/shared/types/roles.ts`) and extended the managed user schema to accept `client` (`server/src/config/schemas.ts`).
- Linked `web_users` to `clients` via a new `client_id` column and migration (`server/src/db/migrations/20260424193000_add_client_role_and_link_to_web_users.ts`) and exposed the field in the web user repository (`server/src/repositories/webUserRepository.ts`).
- Extended user-management flows so `owner`/`admin` keep full directory control while `specialist` can create/manage only `client` web users, and creation of a `client` web user auto-creates a `clients` record and links it (`server/src/services/userManagementService.ts`).
- Scoped appointments for `client` users: repository filter by `clientId`, service-level scope resolution based on `web_users.client_id`, `client` users see/manage only their appointments and are blocked from creating/mark-paid/notify actions (`server/src/repositories/appointmentRepository.ts`, `server/src/services/appointmentService.ts`, `server/src/routes/appointmentRoutes.ts`).
- Updated web UI to allow creating/selecting `client` role (`web/src/components/users/UserFormDialog.tsx`, `web/src/containers/UsersContainer.tsx`) and refreshed README docs in root/server/web to describe the new role and behavior.

### Testing
- Built server with `npm run -w @scheduletm/server build` (success). 
- Built web with `npm run -w @scheduletm/web build` (success) and ran web smoke tests with `npm run -w @scheduletm/web test` (success). 
- Ran server unit tests with `npm run -w @scheduletm/server test`, which reported a pre-existing failing test (`tests/specialists.schemas.unit.test.ts`) that is unrelated to these changes; CI/build remains green for compilation and web tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9894fa448333850e2bfc59ff6b1b)