### PR TITLE
Add AppRhfPasswordField and replace inline password fields across auth, settings, and invite flows

### DIFF
--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -4,6 +4,7 @@ import { Controller, useForm } from 'react-hook-form';
 import logoText from '../static/images/logo_text.svg';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
+import { AppRhfPasswordField } from '../shared/ui/AppRhfPasswordField';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type AuthFormValues = {
@@ -112,10 +113,9 @@ export function AuthCard({
             }
           }}
           render={({ field, fieldState }: any) => (
-            <AppRhfTextField
+            <AppRhfPasswordField
               field={field}
               label={passwordLabel}
-              type="password"
               slotProps={{ htmlInput: { minLength: 10 } }}
               onValueChange={() => clearErrors('password')}
               error={Boolean(fieldState.error)}

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -5,6 +5,7 @@ import type { SystemSettings, UserSettings } from '../shared/types/api';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
 import { AppIcons } from '../shared/ui/AppIcons';
+import { AppRhfPasswordField } from '../shared/ui/AppRhfPasswordField';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import { AppTab, AppTabs } from '../shared/ui/AppTabs';
 
@@ -158,7 +159,7 @@ export function SettingsCard({
             name="telegramBotToken"
             control={userControl}
             render={({ field }: any) => (
-              <AppRhfTextField field={field} label={copy.telegramBotToken} type="password" />
+              <AppRhfPasswordField field={field} label={copy.telegramBotToken} />
             )}
           />
 

--- a/web/src/containers/InviteAcceptContainer.tsx
+++ b/web/src/containers/InviteAcceptContainer.tsx
@@ -2,14 +2,10 @@ import {
   Alert,
   Box,
   CircularProgress,
-  IconButton,
-  InputAdornment,
   Link,
   Stack,
   Typography,
 } from '@mui/material';
-import VisibilityOffRoundedIcon from '@mui/icons-material/VisibilityOffRounded';
-import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
 import { useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
@@ -20,6 +16,7 @@ import { useI18n } from '../shared/i18n/I18nContext';
 import type { InviteVerifyResponse, VerifyEmailResponse } from '../shared/types/api';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
+import { AppRhfPasswordField } from '../shared/ui/AppRhfPasswordField';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import { AppTextField } from '../shared/ui/AppTextField';
 
@@ -55,8 +52,6 @@ export function InviteAcceptContainer() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isRequestingInvite, setIsRequestingInvite] = useState(false);
   const [inviteState, setInviteState] = useState<InviteState>({ status: 'loading' });
-  const [showPassword, setShowPassword] = useState(false);
-  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
 
   const token = useMemo(() => searchParams.get('token')?.trim() ?? '', [searchParams]);
   const fallbackEmail = useMemo(() => searchParams.get('email')?.trim() ?? '', [searchParams]);
@@ -285,32 +280,12 @@ export function InviteAcceptContainer() {
                   validate: (value) => isStrongPassword(value) || t('auth.inviteWeakPassword'),
                 }}
                 render={({ field }) => (
-                  <AppTextField
-                    name={field.name}
+                  <AppRhfPasswordField
+                    field={field}
                     label={t('common.password')}
-                    type={showPassword ? 'text' : 'password'}
                     autoFocus
-                    value={field.value}
-                    onBlur={field.onBlur}
-                    onChange={field.onChange}
-                    inputRef={field.ref}
                     error={Boolean(errors.password)}
                     helperText={errors.password?.message}
-                    slotProps={{
-                      input: {
-                        endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            edge="end"
-                            onClick={() => setShowPassword((prev) => !prev)}
-                            aria-label={t('auth.togglePasswordVisibility')}
-                          >
-                            {showPassword ? <VisibilityOffRoundedIcon /> : <VisibilityRoundedIcon />}
-                          </IconButton>
-                        </InputAdornment>
-                        ),
-                      },
-                    }}
                   />
                 )}
               />
@@ -323,31 +298,11 @@ export function InviteAcceptContainer() {
                   validate: (value) => value === passwordValue || t('auth.passwordMismatch'),
                 }}
                 render={({ field }) => (
-                  <AppTextField
-                    name={field.name}
+                  <AppRhfPasswordField
+                    field={field}
                     label={t('auth.passwordRepeatLabel')}
-                    type={showPasswordConfirm ? 'text' : 'password'}
-                    value={field.value}
-                    onBlur={field.onBlur}
-                    onChange={field.onChange}
-                    inputRef={field.ref}
                     error={Boolean(errors.passwordConfirm)}
                     helperText={errors.passwordConfirm?.message}
-                    slotProps={{
-                      input: {
-                        endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            edge="end"
-                            onClick={() => setShowPasswordConfirm((prev) => !prev)}
-                            aria-label={t('auth.togglePasswordVisibility')}
-                          >
-                            {showPasswordConfirm ? <VisibilityOffRoundedIcon /> : <VisibilityRoundedIcon />}
-                          </IconButton>
-                        </InputAdornment>
-                        ),
-                      },
-                    }}
                   />
                 )}
               />

--- a/web/src/shared/ui/AppRhfPasswordField.tsx
+++ b/web/src/shared/ui/AppRhfPasswordField.tsx
@@ -1,0 +1,54 @@
+import VisibilityOffRoundedIcon from '@mui/icons-material/VisibilityOffRounded';
+import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
+import { IconButton, InputAdornment, type TextFieldProps } from '@mui/material';
+import { useState } from 'react';
+import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
+import { useI18n } from '../i18n/I18nContext';
+import { AppRhfTextField } from './AppRhfTextField';
+
+type AppRhfPasswordFieldProps<TFieldValues extends FieldValues> = Omit<
+  TextFieldProps,
+  'name' | 'value' | 'onBlur' | 'onChange' | 'inputRef' | 'type'
+> & {
+  field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>;
+  onValueChange?: (value: string) => void;
+};
+
+export function AppRhfPasswordField<TFieldValues extends FieldValues>({
+  field,
+  onValueChange,
+  ...props
+}: AppRhfPasswordFieldProps<TFieldValues>) {
+  const { t } = useI18n();
+  const [showPassword, setShowPassword] = useState(false);
+  const inputSlotProps = (props.slotProps?.input ?? {}) as Record<string, unknown>;
+
+  return (
+    <AppRhfTextField
+      {...props}
+      field={field}
+      onValueChange={onValueChange}
+      type={showPassword ? 'text' : 'password'}
+      slotProps={{
+        ...props.slotProps,
+        input: {
+          ...inputSlotProps,
+          endAdornment: (
+            <>
+              {inputSlotProps.endAdornment}
+              <InputAdornment position="end">
+                <IconButton
+                  edge="end"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  aria-label={t('auth.togglePasswordVisibility')}
+                >
+                  {showPassword ? <VisibilityOffRoundedIcon /> : <VisibilityRoundedIcon />}
+                </IconButton>
+              </InputAdornment>
+            </>
+          ),
+        },
+      }}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation
- Consolidate password visibility toggle and input adornment logic into a single reusable RHF-compatible component to avoid duplication and inconsistent behavior.
- Make password fields consistent across authentication, settings, and invite flows and ensure integration with `react-hook-form` helpers.

### Description
- Add a new reusable component `shared/ui/AppRhfPasswordField.tsx` that wraps `AppRhfTextField` and provides a show/hide password toggle with localized aria label and preserved `slotProps` behavior.
- Replace inline password `AppTextField` and `AppRhfTextField` usages with `AppRhfPasswordField` in `AuthCard.tsx`, `SettingsCard.tsx`, and `InviteAcceptContainer.tsx` to remove duplicated visibility-state and adornment code.
- Remove local `showPassword`/`showPasswordConfirm` state and manual `InputAdornment`/`IconButton` logic from `InviteAcceptContainer.tsx` and simplify imports accordingly.

### Testing
- Ran the app build with `yarn build` and the build completed successfully.
- Executed the test suite with `yarn test` and all tests passed.
- Ran lint checks with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb1371ef8833384205607754d914a)