### PR TITLE
Move Google OAuth secrets to env, remove OAuth fields from system settings, and add specialist_settings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ scheduletm/
 Нужно сделать system_settings следующим образом
  - Будут доступны только для Owner
  - Будут ссылаться на таблицу system_settings
- - Будет возможность настроек системы на уровне Owner (REFRESH_TOKEN_TTL_DAYS, ACCESS_TOKEN_TTL_SECONDS, SESSION_COOKIE_NAME, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET, GOOGLE_OAUTH_REDIRECT_URI) и другие системные настройки(можешь что то посоветовать если есть идеи)
+ - Будет возможность настроек системы на уровне Owner (REFRESH_TOKEN_TTL_DAYS, ACCESS_TOKEN_TTL_SECONDS, SESSION_COOKIE_NAME) и другие runtime-настройки без секретов (можешь что-то посоветовать, если есть идеи)
+ - GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET, GOOGLE_OAUTH_REDIRECT_URI храним только в `.env`
 
 app_settings наверное лучше переименовать в user_settings (нужен совет как это лучше сделать, возможно надо часть настроек перенести в user_settings и сделать еще одну таблицу account_settings - могут редактировать Owner с сортировкой по account_id, админы аккаунта)
  - перенести всю логику из app_settings в user_settings

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -101,9 +101,6 @@ export const systemSettingsSchema = z.object({
   refreshTokenTtlDays: z.coerce.number().int().min(1).max(365),
   accessTokenTtlSeconds: z.coerce.number().int().min(60).max(86400),
   sessionCookieName: z.string().trim().min(1).max(128),
-  googleOauthClientId: z.string().trim().max(255).optional().or(z.literal('')),
-  googleOauthClientSecret: z.string().trim().max(255).optional().or(z.literal('')),
-  googleOauthRedirectUri: z.string().trim().url(v.appointmentLinkInvalid).max(1024).optional().or(z.literal('')),
 }).partial();
 
 export const accountSettingsSchema = z.object({

--- a/server/src/db/migrations/20260425143000_align_settings_with_env_and_add_specialist_settings.ts
+++ b/server/src/db/migrations/20260425143000_align_settings_with_env_and_add_specialist_settings.ts
@@ -1,0 +1,144 @@
+import type { Knex } from 'knex';
+
+const SYSTEM_SETTINGS_TABLE = 'system_settings';
+const SPECIALISTS_TABLE = 'specialists';
+const SPECIALIST_SETTINGS_TABLE = 'specialist_settings';
+
+async function dropOAuthColumnsFromSystemSettings(knex: Knex) {
+  const hasSystemSettings = await knex.schema.hasTable(SYSTEM_SETTINGS_TABLE);
+  if (!hasSystemSettings) {
+    return;
+  }
+
+  const hasClientId = await knex.schema.hasColumn(SYSTEM_SETTINGS_TABLE, 'google_oauth_client_id');
+  const hasClientSecret = await knex.schema.hasColumn(SYSTEM_SETTINGS_TABLE, 'google_oauth_client_secret');
+  const hasRedirectUri = await knex.schema.hasColumn(SYSTEM_SETTINGS_TABLE, 'google_oauth_redirect_uri');
+
+  if (!hasClientId && !hasClientSecret && !hasRedirectUri) {
+    return;
+  }
+
+  await knex.schema.alterTable(SYSTEM_SETTINGS_TABLE, (table) => {
+    if (hasClientId) {
+      table.dropColumn('google_oauth_client_id');
+    }
+
+    if (hasClientSecret) {
+      table.dropColumn('google_oauth_client_secret');
+    }
+
+    if (hasRedirectUri) {
+      table.dropColumn('google_oauth_redirect_uri');
+    }
+  });
+}
+
+async function createSpecialistSettingsTable(knex: Knex) {
+  const hasTable = await knex.schema.hasTable(SPECIALIST_SETTINGS_TABLE);
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable(SPECIALIST_SETTINGS_TABLE, (table) => {
+    table.increments('id').primary();
+    table
+      .integer('account_id')
+      .notNullable()
+      .references('id')
+      .inTable('accounts')
+      .onDelete('CASCADE');
+    table
+      .integer('specialist_id')
+      .notNullable()
+      .references('id')
+      .inTable(SPECIALISTS_TABLE)
+      .onDelete('CASCADE');
+    table.integer('base_session_price').notNullable().defaultTo(0);
+    table.integer('base_hour_price').notNullable().defaultTo(0);
+    table.integer('work_start_hour').notNullable().defaultTo(9);
+    table.integer('work_end_hour').notNullable().defaultTo(20);
+    table.integer('slot_duration_min').notNullable().defaultTo(90);
+    table.integer('slot_step_min').notNullable().defaultTo(30);
+    table.integer('default_session_continuation_min').notNullable().defaultTo(60);
+    table.timestamps(true, true);
+
+    table.unique(['specialist_id'], { indexName: 'specialist_settings_specialist_id_unique' });
+    table.index(['account_id'], 'specialist_settings_account_id_index');
+  });
+}
+
+async function backfillSpecialistSettings(knex: Knex) {
+  const hasSpecialists = await knex.schema.hasTable(SPECIALISTS_TABLE);
+  const hasSpecialistSettings = await knex.schema.hasTable(SPECIALIST_SETTINGS_TABLE);
+
+  if (!hasSpecialists || !hasSpecialistSettings) {
+    return;
+  }
+
+  await knex.raw(`
+    INSERT INTO specialist_settings (
+      account_id,
+      specialist_id,
+      base_session_price,
+      base_hour_price,
+      work_start_hour,
+      work_end_hour,
+      slot_duration_min,
+      slot_step_min,
+      default_session_continuation_min,
+      created_at,
+      updated_at
+    )
+    SELECT
+      s.account_id,
+      s.id,
+      COALESCE(s.base_session_price, 0),
+      COALESCE(s.base_hour_price, 0),
+      COALESCE(s.work_start_hour, 9),
+      COALESCE(s.work_end_hour, 20),
+      COALESCE(s.slot_duration_min, 90),
+      COALESCE(s.slot_step_min, 30),
+      COALESCE(s.slot_duration_min, 90),
+      s.created_at,
+      s.updated_at
+    FROM specialists s
+    ON CONFLICT (specialist_id) DO NOTHING
+  `);
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await dropOAuthColumnsFromSystemSettings(knex);
+  await createSpecialistSettingsTable(knex);
+  await backfillSpecialistSettings(knex);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists(SPECIALIST_SETTINGS_TABLE);
+
+  const hasSystemSettings = await knex.schema.hasTable(SYSTEM_SETTINGS_TABLE);
+  if (!hasSystemSettings) {
+    return;
+  }
+
+  const hasClientId = await knex.schema.hasColumn(SYSTEM_SETTINGS_TABLE, 'google_oauth_client_id');
+  const hasClientSecret = await knex.schema.hasColumn(SYSTEM_SETTINGS_TABLE, 'google_oauth_client_secret');
+  const hasRedirectUri = await knex.schema.hasColumn(SYSTEM_SETTINGS_TABLE, 'google_oauth_redirect_uri');
+
+  if (hasClientId && hasClientSecret && hasRedirectUri) {
+    return;
+  }
+
+  await knex.schema.alterTable(SYSTEM_SETTINGS_TABLE, (table) => {
+    if (!hasClientId) {
+      table.string('google_oauth_client_id', 255);
+    }
+
+    if (!hasClientSecret) {
+      table.string('google_oauth_client_secret', 255);
+    }
+
+    if (!hasRedirectUri) {
+      table.string('google_oauth_redirect_uri', 1024);
+    }
+  });
+}

--- a/server/src/repositories/systemSettingsRepository.ts
+++ b/server/src/repositories/systemSettingsRepository.ts
@@ -8,9 +8,6 @@ export type SystemSettingsRecord = {
   refresh_token_ttl_days: number;
   access_token_ttl_seconds: number;
   session_cookie_name: string;
-  google_oauth_client_id: string | null;
-  google_oauth_client_secret: string | null;
-  google_oauth_redirect_uri: string | null;
 };
 
 export type UpdateSystemSettingsInput = {
@@ -20,9 +17,6 @@ export type UpdateSystemSettingsInput = {
   refreshTokenTtlDays?: number;
   accessTokenTtlSeconds?: number;
   sessionCookieName?: string;
-  googleOauthClientId?: string;
-  googleOauthClientSecret?: string;
-  googleOauthRedirectUri?: string;
 };
 
 export async function getSystemSettingsRecord(): Promise<SystemSettingsRecord | null> {
@@ -59,17 +53,6 @@ export async function updateSystemSettingsRecord(input: UpdateSystemSettingsInpu
     patch.session_cookie_name = input.sessionCookieName;
   }
 
-  if (input.googleOauthClientId !== undefined) {
-    patch.google_oauth_client_id = input.googleOauthClientId;
-  }
-
-  if (input.googleOauthClientSecret !== undefined) {
-    patch.google_oauth_client_secret = input.googleOauthClientSecret;
-  }
-
-  if (input.googleOauthRedirectUri !== undefined) {
-    patch.google_oauth_redirect_uri = input.googleOauthRedirectUri;
-  }
 
   await db('system_settings').whereIn('id', db('system_settings').select('id').orderBy('id', 'asc').limit(1)).update(patch);
 }

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -21,9 +21,6 @@ export type SystemSettings = {
   refreshTokenTtlDays: number;
   accessTokenTtlSeconds: number;
   sessionCookieName: string;
-  googleOauthClientId: string;
-  googleOauthClientSecret: string;
-  googleOauthRedirectUri: string;
 };
 
 export type AccountSettings = {
@@ -52,9 +49,6 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   refreshTokenTtlDays: 30,
   accessTokenTtlSeconds: 900,
   sessionCookieName: 'meetli_refresh_token',
-  googleOauthClientId: '',
-  googleOauthClientSecret: '',
-  googleOauthRedirectUri: '',
 };
 
 const mapSystemSettings = async (): Promise<SystemSettings> => {
@@ -70,9 +64,6 @@ const mapSystemSettings = async (): Promise<SystemSettings> => {
     refreshTokenTtlDays: row.refresh_token_ttl_days,
     accessTokenTtlSeconds: row.access_token_ttl_seconds,
     sessionCookieName: row.session_cookie_name,
-    googleOauthClientId: row.google_oauth_client_id ?? '',
-    googleOauthClientSecret: row.google_oauth_client_secret ?? '',
-    googleOauthRedirectUri: row.google_oauth_redirect_uri ?? '',
   };
 };
 
@@ -124,9 +115,6 @@ export const updateSystemSettings = async (payload: unknown): Promise<SystemSett
     refreshTokenTtlDays: parsed.data.refreshTokenTtlDays,
     accessTokenTtlSeconds: parsed.data.accessTokenTtlSeconds,
     sessionCookieName: parsed.data.sessionCookieName,
-    googleOauthClientId: parsed.data.googleOauthClientId,
-    googleOauthClientSecret: parsed.data.googleOauthClientSecret,
-    googleOauthRedirectUri: parsed.data.googleOauthRedirectUri,
   });
 
   return mapSystemSettings();

--- a/settings-rework-plan.md
+++ b/settings-rework-plan.md
@@ -14,7 +14,7 @@
 
 Дополнительно:
 
-* `specialist_settings` — настройки специалиста (прайс, расписание)
+* `specialist_settings` — настройки специалиста (прайс, расписание, дефолтное продолжение сессии)
 * `specialist_booking_policies` — правила бронирования
 * `account_notification_defaults` — дефолты нотификаций
 * `specialist_notification_settings` — логика отправки
@@ -59,6 +59,7 @@
 * `work_end_hour`
 * `slot_duration_min`
 * `slot_step_min`
+* `default_session_continuation_min`
 
 Структура:
 
@@ -189,7 +190,6 @@ cancelled
 * `specialist_notification_settings`
 * `specialist_booking_policies`
 * `user_integrations`
-* 
 
 ---
 
@@ -208,14 +208,19 @@ cancelled
 
 ## 9) Что хранить в `system_settings`
 
-Только runtime настройки:
+Только runtime-настройки без секретов:
 
 * auth TTL
-* OAuth
 * email sender
 * security limits
 
-(секреты — шифровать)
+Google OAuth параметры и секреты храним только на уровне `.env` (не в таблицах настроек):
+
+```env
+GOOGLE_OAUTH_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
+GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3003/api/integrations/google/oauth/callback
+```
 
 ---
 

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -24,9 +24,6 @@ type SettingsCardCopy = {
   refreshTokenTtlDays: string;
   accessTokenTtlSeconds: string;
   sessionCookieName: string;
-  googleOauthClientId: string;
-  googleOauthClientSecret: string;
-  googleOauthRedirectUri: string;
   saveSettings: string;
   integrationsTitle: string;
   integrationsSubtitle: string;
@@ -165,23 +162,6 @@ export function SettingsCard({
             render={({ field }: any) => <AppRhfTextField field={field} label={copy.sessionCookieName} />}
           />
 
-          <Controller
-            name="googleOauthClientId"
-            control={systemControl}
-            render={({ field }: any) => <AppRhfTextField field={field} label={copy.googleOauthClientId} />}
-          />
-
-          <Controller
-            name="googleOauthClientSecret"
-            control={systemControl}
-            render={({ field }: any) => <AppRhfPasswordField field={field} label={copy.googleOauthClientSecret} />}
-          />
-
-          <Controller
-            name="googleOauthRedirectUri"
-            control={systemControl}
-            render={({ field }: any) => <AppRhfTextField field={field} label={copy.googleOauthRedirectUri} />}
-          />
 
           <Controller
             name="dailyDigestEnabled"

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -22,9 +22,6 @@ const defaultSystemSettings: SystemSettings = {
   refreshTokenTtlDays: 30,
   accessTokenTtlSeconds: 900,
   sessionCookieName: 'meetli_refresh_token',
-  googleOauthClientId: '',
-  googleOauthClientSecret: '',
-  googleOauthRedirectUri: '',
 };
 
 const defaultAccountSettings: AccountSettings = {
@@ -336,9 +333,6 @@ export function SettingsContainer() {
               refreshTokenTtlDays: t('settings.refreshTokenTtlDays'),
               accessTokenTtlSeconds: t('settings.accessTokenTtlSeconds'),
               sessionCookieName: t('settings.sessionCookieName'),
-              googleOauthClientId: t('settings.googleOauthClientId'),
-              googleOauthClientSecret: t('settings.googleOauthClientSecret'),
-              googleOauthRedirectUri: t('settings.googleOauthRedirectUri'),
               saveSettings: t('common.saveSettings'),
               integrationsTitle: t('settings.integrationsTitle'),
               integrationsSubtitle: t('settings.integrationsSubtitle'),

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -89,9 +89,6 @@ export const dictionaries = {
       refreshTokenTtlDays: 'Refresh token TTL (days)',
       accessTokenTtlSeconds: 'Access token TTL (seconds)',
       sessionCookieName: 'Session cookie name',
-      googleOauthClientId: 'Google OAuth client id',
-      googleOauthClientSecret: 'Google OAuth client secret',
-      googleOauthRedirectUri: 'Google OAuth redirect URI',
       integrationsTitle: 'Integrations',
       integrationsSubtitle: 'Connect external services to automate bookings and reminders.',
       connectGoogle: 'Connect Google',
@@ -316,9 +313,6 @@ export const dictionaries = {
       refreshTokenTtlDays: 'TTL refresh token (дни)',
       accessTokenTtlSeconds: 'TTL access token (сек)',
       sessionCookieName: 'Имя session cookie',
-      googleOauthClientId: 'Google OAuth client id',
-      googleOauthClientSecret: 'Google OAuth client secret',
-      googleOauthRedirectUri: 'Google OAuth redirect URI',
       integrationsTitle: 'Интеграции',
       integrationsSubtitle: 'Подключите внешние сервисы, чтобы автоматизировать бронирования и напоминания.',
       connectGoogle: 'Подключить Google',
@@ -537,9 +531,6 @@ export type TranslationKey =
   | 'settings.refreshTokenTtlDays'
   | 'settings.accessTokenTtlSeconds'
   | 'settings.sessionCookieName'
-  | 'settings.googleOauthClientId'
-  | 'settings.googleOauthClientSecret'
-  | 'settings.googleOauthRedirectUri'
   | 'settings.integrationsTitle'
   | 'settings.integrationsSubtitle'
   | 'settings.connectGoogle'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -42,9 +42,6 @@ export type SystemSettings = {
   refreshTokenTtlDays: number;
   accessTokenTtlSeconds: number;
   sessionCookieName: string;
-  googleOauthClientId: string;
-  googleOauthClientSecret: string;
-  googleOauthRedirectUri: string;
 };
 
 export type AccountSettings = {


### PR DESCRIPTION
### Motivation
- Avoid storing OAuth secrets in the database and keep only runtime, non-secret system settings in `system_settings`. 
- Introduce a dedicated `specialist_settings` table to extract pricing and scheduling fields from `specialists` and support default session continuation. 
- Align backend schemas, repositories and frontend settings UI/types with the new model and migration plan.

### Description
- Remove Google OAuth fields (`google_oauth_client_id`, `google_oauth_client_secret`, `google_oauth_redirect_uri`) from system schemas, repository types, service mappings and frontend settings UI and i18n, and document that these values are stored in `.env` instead. 
- Add a new migration `20260425143000_align_settings_with_env_and_add_specialist_settings.ts` that drops OAuth columns from `system_settings`, creates the `specialist_settings` table with pricing/schedule/default continuation fields, and backfills data from `specialists`; the migration also provides a `down` that restores the removed columns and drops the new table. 
- Update server code: `config/schemas.ts`, `repositories/systemSettingsRepository.ts`, and `services/settingsService.ts` to remove OAuth fields and associated defaults and update operations. 
- Update web app: remove OAuth inputs and copy keys from `SettingsCard.tsx`, `SettingsContainer.tsx`, `dictionaries.ts`, and `types/api.ts` to reflect the new system settings shape. 
- Update documentation and the settings rework plan (`settings-rework-plan.md`) to clarify storing OAuth credentials in `.env` and to add `default_session_continuation_min` to `specialist_settings`.

### Testing
- Ran TypeScript typecheck with `tsc` and the project build, and there were no type or build errors. 
- Executed the automated test suite with `npm test` and all tests passed. 
- Ran the new migration locally against a development database to verify columns are removed, `specialist_settings` is created and backfilled, and the `down` migration restores columns; migration executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0fae61988333b160e241fff83601)