### PR TITLE
Add per-specialist settings (repo, service, API, UI) and permission to manage them

### DIFF
--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -155,6 +155,13 @@ export const specialistCreateSchema = z.object({
 export const specialistUpdateSchema = z.object({
   name: z.string().trim().min(2, v.specialistNameMin).max(120, v.specialistNameMax).optional(),
   isActive: z.boolean().optional(),
+  baseSessionPrice: z.coerce.number().int().min(0).max(10_000_000).optional(),
+  baseHourPrice: z.coerce.number().int().min(0).max(10_000_000).optional(),
+  workStartHour: z.coerce.number().int().min(0).max(23).optional(),
+  workEndHour: z.coerce.number().int().min(1).max(24).optional(),
+  slotDurationMin: z.coerce.number().int().min(15).max(480).optional(),
+  slotStepMin: z.coerce.number().int().min(5).max(240).optional(),
+  defaultSessionContinuationMin: z.coerce.number().int().min(15).max(480).optional(),
 }).refine((value) => Object.keys(value).length > 0, {
   message: v.atLeastOneFieldToUpdate,
 });

--- a/server/src/policies/rolePermissions.ts
+++ b/server/src/policies/rolePermissions.ts
@@ -11,6 +11,9 @@ export const canManageAccountSettings = (role: WebUserRole): boolean =>
 export const canManageSpecialists = (role: WebUserRole): boolean =>
   role === WebUserRole.Owner || role === WebUserRole.Admin;
 
+export const canManageSpecialistSettings = (role: WebUserRole): boolean =>
+  role === WebUserRole.Owner || role === WebUserRole.Admin || role === WebUserRole.Specialist;
+
 export const canManageAllAppointments = (role: WebUserRole): boolean =>
   role === WebUserRole.Owner || role === WebUserRole.Admin;
 

--- a/server/src/repositories/specialistRepository.ts
+++ b/server/src/repositories/specialistRepository.ts
@@ -56,6 +56,12 @@ export type SpecialistRecord = {
   user_id: number | null;
   timezone: string;
   slot_step_min: number | null;
+  base_session_price?: number;
+  base_hour_price?: number;
+  work_start_hour?: number;
+  work_end_hour?: number;
+  slot_duration_min?: number;
+  default_session_continuation_min?: number;
 };
 
 type CreateSpecialistInput = {
@@ -131,16 +137,54 @@ export type SpecialistCalendarCredentials = {
 };
 
 export async function findSpecialistById(accountId: number, specialistId: number): Promise<SpecialistRecord | null> {
-  const row = await db('specialists')
-    .where({ account_id: accountId, id: specialistId })
+  const row = await db('specialists as s')
+    .leftJoin('specialist_settings as ss', function joinSpecialistSettings() {
+      this.on('ss.specialist_id', '=', 's.id').andOn('ss.account_id', '=', 's.account_id');
+    })
+    .where({ 's.account_id': accountId, 's.id': specialistId })
+    .select(
+      's.id',
+      's.account_id',
+      's.code',
+      's.name',
+      's.is_active',
+      's.user_id',
+      db.raw("'UTC' as timezone"),
+      db.raw('COALESCE(ss.slot_step_min, s.slot_step_min, 30) as slot_step_min'),
+      db.raw('COALESCE(ss.base_session_price, s.base_session_price, 0) as base_session_price'),
+      db.raw('COALESCE(ss.base_hour_price, s.base_hour_price, 0) as base_hour_price'),
+      db.raw('COALESCE(ss.work_start_hour, s.work_start_hour, 9) as work_start_hour'),
+      db.raw('COALESCE(ss.work_end_hour, s.work_end_hour, 20) as work_end_hour'),
+      db.raw('COALESCE(ss.slot_duration_min, s.slot_duration_min, 90) as slot_duration_min'),
+      db.raw('COALESCE(ss.default_session_continuation_min, s.slot_duration_min, 90) as default_session_continuation_min'),
+    )
     .first<SpecialistRecord>();
 
   return row ?? null;
 }
 
 export async function findSpecialistByIdAnyAccount(specialistId: number): Promise<SpecialistRecord | null> {
-  const row = await db('specialists')
-    .where({ id: specialistId })
+  const row = await db('specialists as s')
+    .leftJoin('specialist_settings as ss', function joinSpecialistSettings() {
+      this.on('ss.specialist_id', '=', 's.id').andOn('ss.account_id', '=', 's.account_id');
+    })
+    .where({ 's.id': specialistId })
+    .select(
+      's.id',
+      's.account_id',
+      's.code',
+      's.name',
+      's.is_active',
+      's.user_id',
+      db.raw("'UTC' as timezone"),
+      db.raw('COALESCE(ss.slot_step_min, s.slot_step_min, 30) as slot_step_min'),
+      db.raw('COALESCE(ss.base_session_price, s.base_session_price, 0) as base_session_price'),
+      db.raw('COALESCE(ss.base_hour_price, s.base_hour_price, 0) as base_hour_price'),
+      db.raw('COALESCE(ss.work_start_hour, s.work_start_hour, 9) as work_start_hour'),
+      db.raw('COALESCE(ss.work_end_hour, s.work_end_hour, 20) as work_end_hour'),
+      db.raw('COALESCE(ss.slot_duration_min, s.slot_duration_min, 90) as slot_duration_min'),
+      db.raw('COALESCE(ss.default_session_continuation_min, s.slot_duration_min, 90) as default_session_continuation_min'),
+    )
     .first<SpecialistRecord>();
 
   return row ?? null;
@@ -148,6 +192,9 @@ export async function findSpecialistByIdAnyAccount(specialistId: number): Promis
 
 export async function listSpecialistsByAccount(accountId: number): Promise<SpecialistRecord[]> {
   return db('specialists as s')
+    .leftJoin('specialist_settings as ss', function joinSpecialistSettings() {
+      this.on('ss.specialist_id', '=', 's.id').andOn('ss.account_id', '=', 's.account_id');
+    })
     .leftJoin('web_users as wu', function joinWebUsers() {
       this.on('wu.id', '=', 's.user_id').andOn('wu.account_id', '=', 's.account_id');
     })
@@ -160,13 +207,22 @@ export async function listSpecialistsByAccount(accountId: number): Promise<Speci
       's.name',
       's.is_active',
       's.user_id',
-      's.slot_step_min',
+      db.raw('COALESCE(ss.slot_step_min, s.slot_step_min, 30) as slot_step_min'),
+      db.raw('COALESCE(ss.base_session_price, s.base_session_price, 0) as base_session_price'),
+      db.raw('COALESCE(ss.base_hour_price, s.base_hour_price, 0) as base_hour_price'),
+      db.raw('COALESCE(ss.work_start_hour, s.work_start_hour, 9) as work_start_hour'),
+      db.raw('COALESCE(ss.work_end_hour, s.work_end_hour, 20) as work_end_hour'),
+      db.raw('COALESCE(ss.slot_duration_min, s.slot_duration_min, 90) as slot_duration_min'),
+      db.raw('COALESCE(ss.default_session_continuation_min, s.slot_duration_min, 90) as default_session_continuation_min'),
       db.raw("COALESCE(wu.timezone, 'UTC') as timezone"),
     );
 }
 
 export async function listSpecialistsAllAccounts(): Promise<SpecialistRecord[]> {
   return db('specialists as s')
+    .leftJoin('specialist_settings as ss', function joinSpecialistSettings() {
+      this.on('ss.specialist_id', '=', 's.id').andOn('ss.account_id', '=', 's.account_id');
+    })
     .leftJoin('web_users as wu', function joinWebUsers() {
       this.on('wu.id', '=', 's.user_id').andOn('wu.account_id', '=', 's.account_id');
     })
@@ -178,7 +234,13 @@ export async function listSpecialistsAllAccounts(): Promise<SpecialistRecord[]> 
       's.name',
       's.is_active',
       's.user_id',
-      's.slot_step_min',
+      db.raw('COALESCE(ss.slot_step_min, s.slot_step_min, 30) as slot_step_min'),
+      db.raw('COALESCE(ss.base_session_price, s.base_session_price, 0) as base_session_price'),
+      db.raw('COALESCE(ss.base_hour_price, s.base_hour_price, 0) as base_hour_price'),
+      db.raw('COALESCE(ss.work_start_hour, s.work_start_hour, 9) as work_start_hour'),
+      db.raw('COALESCE(ss.work_end_hour, s.work_end_hour, 20) as work_end_hour'),
+      db.raw('COALESCE(ss.slot_duration_min, s.slot_duration_min, 90) as slot_duration_min'),
+      db.raw('COALESCE(ss.default_session_continuation_min, s.slot_duration_min, 90) as default_session_continuation_min'),
       db.raw("COALESCE(wu.timezone, 'UTC') as timezone"),
     );
 }

--- a/server/src/repositories/specialistSettingsRepository.ts
+++ b/server/src/repositories/specialistSettingsRepository.ts
@@ -1,0 +1,81 @@
+import { db } from '../db/knex.js';
+
+export type SpecialistSettingsRecord = {
+  id: number;
+  account_id: number;
+  specialist_id: number;
+  base_session_price: number;
+  base_hour_price: number;
+  work_start_hour: number;
+  work_end_hour: number;
+  slot_duration_min: number;
+  slot_step_min: number;
+  default_session_continuation_min: number;
+};
+
+type UpsertSpecialistSettingsInput = {
+  accountId: number;
+  specialistId: number;
+  baseSessionPrice?: number;
+  baseHourPrice?: number;
+  workStartHour?: number;
+  workEndHour?: number;
+  slotDurationMin?: number;
+  slotStepMin?: number;
+  defaultSessionContinuationMin?: number;
+};
+
+export async function findSpecialistSettingsBySpecialistId(
+  accountId: number,
+  specialistId: number,
+): Promise<SpecialistSettingsRecord | null> {
+  const row = await db('specialist_settings')
+    .where({ account_id: accountId, specialist_id: specialistId })
+    .first<SpecialistSettingsRecord>();
+
+  return row ?? null;
+}
+
+export async function upsertSpecialistSettingsBySpecialistId(input: UpsertSpecialistSettingsInput): Promise<void> {
+  const payload: Record<string, unknown> = {
+    account_id: input.accountId,
+    specialist_id: input.specialistId,
+    updated_at: db.fn.now(),
+  };
+
+  if (input.baseSessionPrice !== undefined) {
+    payload.base_session_price = input.baseSessionPrice;
+  }
+
+  if (input.baseHourPrice !== undefined) {
+    payload.base_hour_price = input.baseHourPrice;
+  }
+
+  if (input.workStartHour !== undefined) {
+    payload.work_start_hour = input.workStartHour;
+  }
+
+  if (input.workEndHour !== undefined) {
+    payload.work_end_hour = input.workEndHour;
+  }
+
+  if (input.slotDurationMin !== undefined) {
+    payload.slot_duration_min = input.slotDurationMin;
+  }
+
+  if (input.slotStepMin !== undefined) {
+    payload.slot_step_min = input.slotStepMin;
+  }
+
+  if (input.defaultSessionContinuationMin !== undefined) {
+    payload.default_session_continuation_min = input.defaultSessionContinuationMin;
+  }
+
+  await db('specialist_settings')
+    .insert({
+      ...payload,
+      created_at: db.fn.now(),
+    })
+    .onConflict(['specialist_id'])
+    .merge(payload);
+}

--- a/server/src/services/specialistService.ts
+++ b/server/src/services/specialistService.ts
@@ -9,7 +9,8 @@ import {
 import { findWebUserById, listActiveSpecialistWebUsersWithoutProfile } from '../repositories/webUserRepository.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
-import { canManageSpecialists } from '../policies/rolePermissions.js';
+import { canManageSpecialistSettings, canManageSpecialists } from '../policies/rolePermissions.js';
+import { upsertSpecialistSettingsBySpecialistId } from '../repositories/specialistSettingsRepository.js';
 
 type SpecialistDto = {
   id: number;
@@ -18,6 +19,12 @@ type SpecialistDto = {
   timezone: string;
   isActive: boolean;
   slotStepMin: number;
+  baseSessionPrice: number;
+  baseHourPrice: number;
+  workStartHour: number;
+  workEndHour: number;
+  slotDurationMin: number;
+  defaultSessionContinuationMin: number;
 };
 
 type SpecialistCreatePayload = {
@@ -27,6 +34,13 @@ type SpecialistCreatePayload = {
 type SpecialistUpdatePayload = {
   name?: string;
   isActive?: boolean;
+  baseSessionPrice?: number;
+  baseHourPrice?: number;
+  workStartHour?: number;
+  workEndHour?: number;
+  slotDurationMin?: number;
+  slotStepMin?: number;
+  defaultSessionContinuationMin?: number;
 };
 
 export type SpecialistWebUserOptionDto = {
@@ -40,6 +54,12 @@ const mapSpecialist = (item: Awaited<ReturnType<typeof listSpecialistsByAccount>
   timezone: item.timezone || 'UTC',
   isActive: item.is_active,
   slotStepMin: item.slot_step_min ?? 30,
+  baseSessionPrice: item.base_session_price ?? 0,
+  baseHourPrice: item.base_hour_price ?? 0,
+  workStartHour: item.work_start_hour ?? 9,
+  workEndHour: item.work_end_hour ?? 20,
+  slotDurationMin: item.slot_duration_min ?? 90,
+  defaultSessionContinuationMin: item.default_session_continuation_min ?? item.slot_duration_min ?? 90,
 });
 
 const buildSpecialistCode = (name: string): string => {
@@ -100,6 +120,11 @@ export async function createSpecialistForActor(actor: User, payload: SpecialistC
     userId: payload.userId,
   });
 
+  await upsertSpecialistSettingsBySpecialistId({
+    accountId,
+    specialistId: id,
+  });
+
   const created = await findSpecialistById(accountId, id);
   if (!created) {
     throw new Error('CREATE_FAILED');
@@ -113,7 +138,7 @@ export async function updateSpecialistForActor(
   specialistId: number,
   payload: SpecialistUpdatePayload,
 ): Promise<SpecialistDto | null> {
-  if (!canManageSpecialists(actor.role)) {
+  if (!canManageSpecialistSettings(actor.role)) {
     throw new Error('FORBIDDEN');
   }
 
@@ -123,9 +148,30 @@ export async function updateSpecialistForActor(
     return null;
   }
 
-  await updateSpecialistById(accountId, specialistId, {
-    name: payload.name,
-    isActive: payload.isActive,
+  const isManager = canManageSpecialists(actor.role);
+  const isOwnSpecialist = existing.user_id === Number(actor.id);
+
+  if (!isManager && !isOwnSpecialist) {
+    throw new Error('FORBIDDEN');
+  }
+
+  if (isManager) {
+    await updateSpecialistById(accountId, specialistId, {
+      name: payload.name,
+      isActive: payload.isActive,
+    });
+  }
+
+  await upsertSpecialistSettingsBySpecialistId({
+    accountId,
+    specialistId,
+    baseSessionPrice: payload.baseSessionPrice,
+    baseHourPrice: payload.baseHourPrice,
+    workStartHour: payload.workStartHour,
+    workEndHour: payload.workEndHour,
+    slotDurationMin: payload.slotDurationMin,
+    slotStepMin: payload.slotStepMin,
+    defaultSessionContinuationMin: payload.defaultSessionContinuationMin,
   });
 
   const updated = await findSpecialistById(accountId, specialistId);

--- a/server/tests/role-permissions.unit.test.ts
+++ b/server/tests/role-permissions.unit.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { canManageSpecialistSettings } from '../src/policies/rolePermissions.js';
+import { WebUserRole } from '../src/types/webUserRole.js';
+
+describe('role permissions', () => {
+  it('allows owner/admin/specialist to manage specialist settings', () => {
+    expect(canManageSpecialistSettings(WebUserRole.Owner)).toBe(true);
+    expect(canManageSpecialistSettings(WebUserRole.Admin)).toBe(true);
+    expect(canManageSpecialistSettings(WebUserRole.Specialist)).toBe(true);
+    expect(canManageSpecialistSettings(WebUserRole.Client)).toBe(false);
+  });
+});

--- a/server/tests/specialists.routes.smoke.test.ts
+++ b/server/tests/specialists.routes.smoke.test.ts
@@ -96,7 +96,20 @@ describe('specialists API route-smoke scenarios (mocked service layer)', () => {
   });
 
   it('update: PATCH /api/specialists/:id returns 200', async () => {
-    updateSpecialistForActorMock.mockResolvedValue({ id: 2, name: 'Updated', code: 'updated', timezone: 'UTC', isActive: true, slotStepMin: 30 });
+    updateSpecialistForActorMock.mockResolvedValue({
+      id: 2,
+      name: 'Updated',
+      code: 'updated',
+      timezone: 'UTC',
+      isActive: true,
+      slotStepMin: 30,
+      baseSessionPrice: 100,
+      baseHourPrice: 2500,
+      workStartHour: 9,
+      workEndHour: 20,
+      slotDurationMin: 90,
+      defaultSessionContinuationMin: 60,
+    });
 
     const response = await fetch(`${baseUrl}/api/specialists/2`, {
       method: 'PATCH',
@@ -104,7 +117,17 @@ describe('specialists API route-smoke scenarios (mocked service layer)', () => {
         'content-type': 'application/json',
         authorization: 'Bearer smoke-token',
       },
-      body: JSON.stringify({ name: 'Updated', isActive: true }),
+      body: JSON.stringify({
+        name: 'Updated',
+        isActive: true,
+        baseSessionPrice: 100,
+        baseHourPrice: 2500,
+        workStartHour: 9,
+        workEndHour: 20,
+        slotDurationMin: 90,
+        slotStepMin: 30,
+        defaultSessionContinuationMin: 60,
+      }),
     });
 
     expect(response.status).toBe(200);

--- a/web/src/components/specialists/SpecialistFormDialog.tsx
+++ b/web/src/components/specialists/SpecialistFormDialog.tsx
@@ -13,9 +13,27 @@ type SpecialistFormDialogProps = {
   closeLabel: string;
   nameLabel: string;
   activeLabel: string;
+  baseSessionPriceLabel: string;
+  baseHourPriceLabel: string;
+  workStartHourLabel: string;
+  workEndHourLabel: string;
+  slotDurationMinLabel: string;
+  slotStepMinLabel: string;
+  defaultSessionContinuationMinLabel: string;
   availableWebUsers: Array<{ id: number; email: string }>;
   onClose: () => void;
-  onSubmit: (payload: { userId?: number; name?: string; isActive: boolean }) => Promise<void> | void;
+  onSubmit: (payload: {
+    userId?: number;
+    name?: string;
+    isActive: boolean;
+    baseSessionPrice: number;
+    baseHourPrice: number;
+    workStartHour: number;
+    workEndHour: number;
+    slotDurationMin: number;
+    slotStepMin: number;
+    defaultSessionContinuationMin: number;
+  }) => Promise<void> | void;
 };
 
 export function SpecialistFormDialog({
@@ -27,6 +45,13 @@ export function SpecialistFormDialog({
   closeLabel,
   nameLabel,
   activeLabel,
+  baseSessionPriceLabel,
+  baseHourPriceLabel,
+  workStartHourLabel,
+  workEndHourLabel,
+  slotDurationMinLabel,
+  slotStepMinLabel,
+  defaultSessionContinuationMinLabel,
   availableWebUsers,
   onClose,
   onSubmit,
@@ -34,6 +59,13 @@ export function SpecialistFormDialog({
   const [name, setName] = useState('');
   const [isActive, setIsActive] = useState(true);
   const [selectedUserId, setSelectedUserId] = useState<number>(0);
+  const [baseSessionPrice, setBaseSessionPrice] = useState(0);
+  const [baseHourPrice, setBaseHourPrice] = useState(0);
+  const [workStartHour, setWorkStartHour] = useState(9);
+  const [workEndHour, setWorkEndHour] = useState(20);
+  const [slotDurationMin, setSlotDurationMin] = useState(90);
+  const [slotStepMin, setSlotStepMin] = useState(30);
+  const [defaultSessionContinuationMin, setDefaultSessionContinuationMin] = useState(60);
 
   useEffect(() => {
     if (!open) {
@@ -43,6 +75,13 @@ export function SpecialistFormDialog({
     setName(editingSpecialist?.name ?? '');
     setIsActive(editingSpecialist?.isActive ?? true);
     setSelectedUserId(0);
+    setBaseSessionPrice(editingSpecialist?.baseSessionPrice ?? 0);
+    setBaseHourPrice(editingSpecialist?.baseHourPrice ?? 0);
+    setWorkStartHour(editingSpecialist?.workStartHour ?? 9);
+    setWorkEndHour(editingSpecialist?.workEndHour ?? 20);
+    setSlotDurationMin(editingSpecialist?.slotDurationMin ?? 90);
+    setSlotStepMin(editingSpecialist?.slotStepMin ?? 30);
+    setDefaultSessionContinuationMin(editingSpecialist?.defaultSessionContinuationMin ?? 60);
   }, [editingSpecialist, open]);
 
   const handleSubmit = async () => {
@@ -54,7 +93,9 @@ export function SpecialistFormDialog({
       return;
     }
 
-    await onSubmit(editingSpecialist ? { name: name.trim(), isActive } : { userId: selectedUserId, isActive: true });
+    await onSubmit(editingSpecialist
+      ? { name: name.trim(), isActive, baseSessionPrice, baseHourPrice, workStartHour, workEndHour, slotDurationMin, slotStepMin, defaultSessionContinuationMin }
+      : { userId: selectedUserId, isActive: true, baseSessionPrice, baseHourPrice, workStartHour, workEndHour, slotDurationMin, slotStepMin, defaultSessionContinuationMin });
   };
 
   return (
@@ -91,6 +132,13 @@ export function SpecialistFormDialog({
           control={<Switch checked={isActive} disabled={!editingSpecialist} onChange={(event) => setIsActive(event.target.checked)} />}
           label={activeLabel}
         />
+        <TextField margin="dense" fullWidth label={baseSessionPriceLabel} type="number" value={baseSessionPrice} onChange={(e) => setBaseSessionPrice(Number(e.target.value))} />
+        <TextField margin="dense" fullWidth label={baseHourPriceLabel} type="number" value={baseHourPrice} onChange={(e) => setBaseHourPrice(Number(e.target.value))} />
+        <TextField margin="dense" fullWidth label={workStartHourLabel} type="number" value={workStartHour} onChange={(e) => setWorkStartHour(Number(e.target.value))} />
+        <TextField margin="dense" fullWidth label={workEndHourLabel} type="number" value={workEndHour} onChange={(e) => setWorkEndHour(Number(e.target.value))} />
+        <TextField margin="dense" fullWidth label={slotDurationMinLabel} type="number" value={slotDurationMin} onChange={(e) => setSlotDurationMin(Number(e.target.value))} />
+        <TextField margin="dense" fullWidth label={slotStepMinLabel} type="number" value={slotStepMin} onChange={(e) => setSlotStepMin(Number(e.target.value))} />
+        <TextField margin="dense" fullWidth label={defaultSessionContinuationMinLabel} type="number" value={defaultSessionContinuationMin} onChange={(e) => setDefaultSessionContinuationMin(Number(e.target.value))} />
       </DialogContent>
       <DialogActions>
         <AppButton variant="text" onClick={onClose}>{closeLabel}</AppButton>

--- a/web/src/components/specialists/SpecialistsTable.tsx
+++ b/web/src/components/specialists/SpecialistsTable.tsx
@@ -30,6 +30,8 @@ type SpecialistsTableProps = {
   onAdd: () => void;
   onEdit: (item: SpecialistManagementItem) => void;
   onDelete: (item: SpecialistManagementItem) => void;
+  canAdd: boolean;
+  canDelete: boolean;
 };
 
 export function SpecialistsTable({
@@ -43,12 +45,14 @@ export function SpecialistsTable({
   onAdd,
   onEdit,
   onDelete,
+  canAdd,
+  canDelete,
 }: SpecialistsTableProps) {
   return (
     <Stack spacing={1.5}>
       <Stack direction="row" sx={{ justifyContent: "space-between", alignItems: "center" }}>
         <Typography variant="h5">{title}</Typography>
-        <AppButton size="small" onClick={onAdd} startIcon={<AppIcons.add />}>{addLabel}</AppButton>
+        {canAdd ? <AppButton size="small" onClick={onAdd} startIcon={<AppIcons.add />}>{addLabel}</AppButton> : <span />}
       </Stack>
 
       <TableContainer component={Paper} variant="outlined">
@@ -77,9 +81,11 @@ export function SpecialistsTable({
                   <IconButton size="small" aria-label={editLabel} onClick={() => onEdit(item)}>
                     <AppIcons.edit fontSize="small" />
                   </IconButton>
-                  <IconButton size="small" aria-label={deleteLabel} color="error" onClick={() => onDelete(item)}>
-                    <AppIcons.delete fontSize="small" />
-                  </IconButton>
+                  {canDelete && (
+                    <IconButton size="small" aria-label={deleteLabel} color="error" onClick={() => onDelete(item)}>
+                      <AppIcons.delete fontSize="small" />
+                    </IconButton>
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/web/src/containers/SpecialistsContainer.tsx
+++ b/web/src/containers/SpecialistsContainer.tsx
@@ -24,6 +24,7 @@ export function SpecialistsContainer() {
   const [isSavingSpecialist, setIsSavingSpecialist] = useState(false);
 
   const canManageSpecialists = user?.role === 'owner' || user?.role === 'admin';
+  const canManageSpecialistSettings = canManageSpecialists || user?.role === 'specialist';
 
   useEffect(() => {
     if (!accessToken) {
@@ -31,7 +32,7 @@ export function SpecialistsContainer() {
       return;
     }
 
-    if (!canManageSpecialists) {
+    if (!canManageSpecialistSettings) {
       setIsLoading(false);
       return;
     }
@@ -55,7 +56,7 @@ export function SpecialistsContainer() {
     };
 
     void load();
-  }, [accessToken, canManageSpecialists, navigate, t]);
+  }, [accessToken, canManageSpecialistSettings, navigate, t]);
 
   const openCreateSpecialistDialog = () => {
     setEditingSpecialist(null);
@@ -76,7 +77,18 @@ export function SpecialistsContainer() {
     setEditingSpecialist(null);
   };
 
-  const saveSpecialist = async (payload: { userId?: number; name?: string; isActive: boolean }) => {
+  const saveSpecialist = async (payload: {
+    userId?: number;
+    name?: string;
+    isActive: boolean;
+    baseSessionPrice: number;
+    baseHourPrice: number;
+    workStartHour: number;
+    workEndHour: number;
+    slotDurationMin: number;
+    slotStepMin: number;
+    defaultSessionContinuationMin: number;
+  }) => {
     if (!accessToken) {
       return;
     }
@@ -88,6 +100,13 @@ export function SpecialistsContainer() {
         const response = await apiClient.patch<SpecialistManagementItem>(`/api/specialists/${editingSpecialist.id}`, {
           name: payload.name,
           isActive: payload.isActive,
+          baseSessionPrice: payload.baseSessionPrice,
+          baseHourPrice: payload.baseHourPrice,
+          workStartHour: payload.workStartHour,
+          workEndHour: payload.workEndHour,
+          slotDurationMin: payload.slotDurationMin,
+          slotStepMin: payload.slotStepMin,
+          defaultSessionContinuationMin: payload.defaultSessionContinuationMin,
         }, {
           headers: authHeaders(accessToken),
         });
@@ -156,7 +175,7 @@ export function SpecialistsContainer() {
         </Box>
       )}
 
-      {!canManageSpecialists ? (
+      {!canManageSpecialistSettings ? (
         <Box sx={{ maxWidth: 900 }}>
           <Alert severity="info">{t('specialists.accessDenied')}</Alert>
         </Box>
@@ -184,6 +203,8 @@ export function SpecialistsContainer() {
               onAdd={openCreateSpecialistDialog}
               onEdit={openEditSpecialistDialog}
               onDelete={(item) => void deleteSpecialist(item)}
+              canAdd={canManageSpecialists}
+              canDelete={canManageSpecialists}
             />
           )}
         </Box>
@@ -198,6 +219,13 @@ export function SpecialistsContainer() {
         closeLabel={t('appointments.close')}
         nameLabel={t('settings.specialists.columns.name')}
         activeLabel={t('settings.specialists.columns.active')}
+        baseSessionPriceLabel={t('settings.specialistSettings.baseSessionPrice')}
+        baseHourPriceLabel={t('settings.specialistSettings.baseHourPrice')}
+        workStartHourLabel={t('settings.specialistSettings.workStartHour')}
+        workEndHourLabel={t('settings.specialistSettings.workEndHour')}
+        slotDurationMinLabel={t('settings.specialistSettings.slotDurationMin')}
+        slotStepMinLabel={t('settings.specialistSettings.slotStepMin')}
+        defaultSessionContinuationMinLabel={t('settings.specialistSettings.defaultSessionContinuationMin')}
         availableWebUsers={availableWebUsers}
         onClose={closeSpecialistDialog}
         onSubmit={saveSpecialist}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -116,6 +116,15 @@ export const dictionaries = {
           actions: 'Actions'
         }
       },
+      specialistSettings: {
+        baseSessionPrice: 'Base session price',
+        baseHourPrice: 'Base hour price',
+        workStartHour: 'Work start hour',
+        workEndHour: 'Work end hour',
+        slotDurationMin: 'Slot duration (min)',
+        slotStepMin: 'Slot step (min)',
+        defaultSessionContinuationMin: 'Default session continuation (min)'
+      },
       errors: {
         load: 'Unable to load settings.',
         save: 'Unable to save settings.',
@@ -340,6 +349,15 @@ export const dictionaries = {
           actions: 'Действия'
         }
       },
+      specialistSettings: {
+        baseSessionPrice: 'Базовая цена сессии',
+        baseHourPrice: 'Базовая цена часа',
+        workStartHour: 'Час начала работы',
+        workEndHour: 'Час окончания работы',
+        slotDurationMin: 'Длительность слота (мин)',
+        slotStepMin: 'Шаг слота (мин)',
+        defaultSessionContinuationMin: 'Продление сессии по умолчанию (мин)'
+      },
       errors: {
         load: 'Не удалось загрузить настройки.',
         save: 'Не удалось сохранить настройки.',
@@ -556,6 +574,13 @@ export type TranslationKey =
   | 'settings.specialists.columns.actions'
   | 'settings.errors.saveSpecialist'
   | 'settings.errors.deleteSpecialist'
+  | 'settings.specialistSettings.baseSessionPrice'
+  | 'settings.specialistSettings.baseHourPrice'
+  | 'settings.specialistSettings.workStartHour'
+  | 'settings.specialistSettings.workEndHour'
+  | 'settings.specialistSettings.slotDurationMin'
+  | 'settings.specialistSettings.slotStepMin'
+  | 'settings.specialistSettings.defaultSessionContinuationMin'
   | 'settings.errors.load'
   | 'settings.errors.save'
   | 'settings.errors.connectGoogle'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -132,6 +132,12 @@ export type SpecialistManagementItem = {
   timezone: string;
   isActive: boolean;
   slotStepMin: number;
+  baseSessionPrice: number;
+  baseHourPrice: number;
+  workStartHour: number;
+  workEndHour: number;
+  slotDurationMin: number;
+  defaultSessionContinuationMin: number;
 };
 
 export type SpecialistsListResponse = {

--- a/web/tests/e2e/smoke.e2e.test.mjs
+++ b/web/tests/e2e/smoke.e2e.test.mjs
@@ -34,6 +34,8 @@ describe('web smoke (auth/settings/specialists/appointments contracts)', () => {
     assert.match(settingsContainer, /'\/api\/settings\/user'/);
     assert.match(settingsContainer, /'\/api\/settings\/system'/);
     assert.match(specialistsContainer, /'\/api\/specialists'/);
+    assert.match(specialistsContainer, /baseSessionPrice/);
+    assert.match(specialistsContainer, /defaultSessionContinuationMin/);
     assert.match(appointmentsContainer, /'\/api\/appointments'/);
     assert.match(appointmentsContainer, /\/cancel/);
     assert.match(appointmentsContainer, /\/reschedule/);


### PR DESCRIPTION
### Motivation
- Introduce per-specialist configurable settings (pricing, working hours, slot durations) so specialists and admins can customize profile-specific defaults.
- Allow specialists (in addition to owner/admin) to manage their own specialist settings while preserving manager-only controls for core specialist records.

### Description
- Add `specialist_settings` repository with `findSpecialistSettingsBySpecialistId` and `upsertSpecialistSettingsBySpecialistId`, and persist/merge settings via `ON CONFLICT` in `upsertSpecialistSettingsBySpecialistId`.
- Extend `specialists` repository queries to left-join `specialist_settings` and `COALESCE` fields (`base_session_price`, `base_hour_price`, `work_start_hour`, `work_end_hour`, `slot_duration_min`, `slot_step_min`, `default_session_continuation_min`) with sensible defaults.
- Update service logic in `specialistService` to create default settings on specialist creation, to `upsert` settings on update, and to allow owners/admins to update core specialist record while enabling specialists to update only their settings; add `canManageSpecialistSettings` permission and enforce it.
- Extend backend schemas and DTOs to include new numeric fields and add a `role-permissions` unit test for the new permission.
- Update frontend: `SpecialistFormDialog` to display and submit new settings fields, `SpecialistsTable` to conditionally show add/delete actions via `canAdd`/`canDelete` props, `SpecialistsContainer` to fetch/save the new fields and allow specialists to access the settings UI, and add i18n keys for the new labels and types in `shared/types/api` and smoke tests to assert presence of the new fields.

### Testing
- Ran server unit tests including the new `role-permissions.unit.test.ts` which asserts `canManageSpecialistSettings` for `Owner`/`Admin`/`Specialist`, and the tests passed.
- Ran server route-smoke tests and updated mocked specialists route-smoke test to include the new fields, and they passed.
- Ran web smoke/e2e checks which were updated to look for `baseSessionPrice` and `defaultSessionContinuationMin` in the UI container code, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed134a7b888333a306212799f5822f)