### PR TITLE
Add specialist booking policy frontend and backend test coverage

### DIFF
--- a/server/tests/settings.specialist-booking-policy.routes.smoke.test.ts
+++ b/server/tests/settings.specialist-booking-policy.routes.smoke.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import { createApp } from '../src/app.js';
+import { WebUserRole } from '../src/types/webUserRole.js';
+
+const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
+const getSpecialistBookingPolicyMock = vi.hoisted(() => vi.fn());
+const updateSpecialistBookingPolicyMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/authService.js', () => ({
+  resolveUserByAccessToken: resolveUserByAccessTokenMock,
+}));
+
+vi.mock('../src/services/settingsService.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/services/settingsService.js')>('../src/services/settingsService.js');
+  return {
+    ...actual,
+    getSpecialistBookingPolicy: getSpecialistBookingPolicyMock,
+    updateSpecialistBookingPolicy: updateSpecialistBookingPolicyMock,
+  };
+});
+
+const authedUser = {
+  id: '101',
+  accountId: 1,
+  email: 'specialist@example.com',
+  role: WebUserRole.Specialist,
+  passwordSalt: 'salt',
+  passwordHash: 'hash',
+  createdAt: '2026-04-22T09:00:00.000Z',
+};
+
+describe('settings specialist booking policy route-smoke scenarios (mocked service layer)', () => {
+  const app = createApp();
+  let baseUrl = '';
+  let server: Awaited<ReturnType<typeof app.listen>>;
+
+  beforeAll(async () => {
+    server = await new Promise((resolve) => {
+      const started = app.listen(0, () => resolve(started));
+    });
+
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    resolveUserByAccessTokenMock.mockReset();
+    getSpecialistBookingPolicyMock.mockReset();
+    updateSpecialistBookingPolicyMock.mockReset();
+
+    resolveUserByAccessTokenMock.mockResolvedValue(authedUser);
+  });
+
+  it('GET /api/settings/specialist-booking-policy returns booking policy', async () => {
+    getSpecialistBookingPolicyMock.mockResolvedValue({
+      specialistId: 7,
+      cancelGracePeriodHours: 24,
+      refundOnLateCancel: false,
+      autoCancelUnpaidEnabled: true,
+      unpaidAutoCancelAfterHours: 72,
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings/specialist-booking-policy`, {
+      method: 'GET',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      specialistId: 7,
+      autoCancelUnpaidEnabled: true,
+    });
+  });
+
+  it('PUT /api/settings/specialist-booking-policy returns updated booking policy', async () => {
+    updateSpecialistBookingPolicyMock.mockResolvedValue({
+      specialistId: 7,
+      cancelGracePeriodHours: 12,
+      refundOnLateCancel: true,
+      autoCancelUnpaidEnabled: true,
+      unpaidAutoCancelAfterHours: 48,
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings/specialist-booking-policy`, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer smoke-token',
+      },
+      body: JSON.stringify({
+        cancelGracePeriodHours: 12,
+        refundOnLateCancel: true,
+        autoCancelUnpaidEnabled: true,
+        unpaidAutoCancelAfterHours: 48,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      cancelGracePeriodHours: 12,
+      refundOnLateCancel: true,
+      unpaidAutoCancelAfterHours: 48,
+    });
+  });
+});

--- a/server/tests/settings.specialist-booking-policy.unit.test.ts
+++ b/server/tests/settings.specialist-booking-policy.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { specialistBookingPolicySchema } from '../src/config/schemas.js';
+import { canManageSpecialistBookingPolicies } from '../src/services/settingsService.js';
+import { WebUserRole } from '../src/types/webUserRole.js';
+
+describe('specialist booking policy unit', () => {
+  it('allows valid specialist booking policy payload', () => {
+    const parsed = specialistBookingPolicySchema.safeParse({
+      cancelGracePeriodHours: 24,
+      refundOnLateCancel: false,
+      autoCancelUnpaidEnabled: true,
+      unpaidAutoCancelAfterHours: 72,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects out-of-range specialist booking policy values', () => {
+    const parsed = specialistBookingPolicySchema.safeParse({
+      cancelGracePeriodHours: 999,
+      refundOnLateCancel: false,
+      autoCancelUnpaidEnabled: true,
+      unpaidAutoCancelAfterHours: 0,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('grants specialist booking policy access only to owner/admin/specialist', () => {
+    expect(canManageSpecialistBookingPolicies(WebUserRole.Owner)).toBe(true);
+    expect(canManageSpecialistBookingPolicies(WebUserRole.Admin)).toBe(true);
+    expect(canManageSpecialistBookingPolicies(WebUserRole.Specialist)).toBe(true);
+    expect(canManageSpecialistBookingPolicies(WebUserRole.Client)).toBe(false);
+  });
+});

--- a/settings-rework-plan.md
+++ b/settings-rework-plan.md
@@ -12,6 +12,9 @@
    - отдельная таблица и repository для правил.
 2. На фронте добавлена отдельная вкладка настроек правил бронирования специалиста.
 3. В bot логика редактирования/отмены начала учитывать `cancel_grace_period_hours`.
+4. Тестовое покрытие для `specialist_booking_policies`:
+   - frontend: интеграционный smoke-контракт для загрузки/сохранения и UI-полей;
+   - backend: unit-тесты схемы/доступов и route-smoke для `GET/PUT /api/settings/specialist-booking-policy`.
 
 ### ⏭️ Следующая итерация
 

--- a/web/tests/e2e/smoke.e2e.test.mjs
+++ b/web/tests/e2e/smoke.e2e.test.mjs
@@ -6,7 +6,7 @@ async function read(relativePath) {
   return readFile(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
 }
 
-describe('web smoke (auth/settings/specialists/appointments contracts)', () => {
+describe('web smoke (auth/settings/specialists/appointments/specialist booking policy contracts)', () => {
   it('router exposes auth/settings/specialists/appointments routes', async () => {
     const router = await read('src/app/router.tsx');
 
@@ -30,9 +30,14 @@ describe('web smoke (auth/settings/specialists/appointments contracts)', () => {
     const appointmentsContainer = await read('src/containers/AppointmentsContainer.tsx');
     const appointmentDialog = await read('src/components/appointments/AppointmentFormDialog.tsx');
     const specialistsTable = await read('src/components/specialists/SpecialistsTable.tsx');
+    const settingsCard = await read('src/components/SettingsCard.tsx');
 
     assert.match(settingsContainer, /'\/api\/settings\/user'/);
     assert.match(settingsContainer, /'\/api\/settings\/system'/);
+
+    assert.match(settingsContainer, /'\/api\/settings\/specialist-booking-policy'/);
+    assert.match(settingsContainer, /canManageSpecialistBookingPolicy/);
+    assert.match(settingsContainer, /saveSpecialistBookingPolicy/);
     assert.match(specialistsContainer, /'\/api\/specialists'/);
     assert.match(specialistsContainer, /baseSessionPrice/);
     assert.match(specialistsContainer, /defaultSessionContinuationMin/);
@@ -43,6 +48,12 @@ describe('web smoke (auth/settings/specialists/appointments contracts)', () => {
     assert.match(appointmentsContainer, /\/notify/);
     assert.match(appointmentDialog, /appointments\.markPaidAction/);
     assert.match(appointmentDialog, /appointments\.notifyAction/);
+
+    assert.match(settingsCard, /specialistPolicyTitle/);
+    assert.match(settingsCard, /cancelGracePeriodHours/);
+    assert.match(settingsCard, /refundOnLateCancel/);
+    assert.match(settingsCard, /autoCancelUnpaidEnabled/);
+    assert.match(settingsCard, /unpaidAutoCancelAfterHours/);
     assert.match(specialistsTable, /AppIcons\.edit/);
     assert.match(specialistsTable, /AppIcons\.delete/);
   });


### PR DESCRIPTION
### Motivation
- Ensure `specialist_booking_policies` behavior is covered by automated tests for both UI wiring and backend validation/authorization to reduce regressions. 
- Verify API contract surface used by the frontend (`GET/PUT /api/settings/specialist-booking-policy`) and that the Settings UI exposes the expected fields. 

### Description
- Add backend unit tests `server/tests/settings.specialist-booking-policy.unit.test.ts` to validate `specialistBookingPolicySchema` bounds and `canManageSpecialistBookingPolicies` RBAC helper. 
- Add backend route-smoke tests `server/tests/settings.specialist-booking-policy.routes.smoke.test.ts` exercising `GET` and `PUT /api/settings/specialist-booking-policy` with the service layer mocked. 
- Extend frontend smoke contract `web/tests/e2e/smoke.e2e.test.mjs` to assert the settings container calls the specialist booking policy API and that `SettingsCard` contains the booking policy UI fields. 
- Update `settings-rework-plan.md` to record that test coverage for `specialist_booking_policies` (frontend smoke + backend unit/route-smoke) was added. 

### Testing
- Ran the frontend smoke test with `npm --prefix web test` and it passed (web smoke suite: 3 tests, 3 passed). 
- Ran backend tests with Vitest using `cd server && DATABASE_PUBLIC_URL=postgresql://postgres:postgres@localhost:5432/postgres npx vitest run --config vitest.config.ts tests/settings.specialist-booking-policy.unit.test.ts tests/settings.specialist-booking-policy.routes.smoke.test.ts` and they passed (2 files, 5 tests, 5 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee05755c108333bf141354064cd8e1)