### PR TITLE
Add notification settings, scheduler jobs and email-only delivery MVP

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -12,7 +12,7 @@ Node.js/Express API для web-клиента и интеграций.
   Поддерживаются `POST /api/auth/verify-email` и `POST /api/auth/resend-verification-code`.
 - Web roles: owner/admin/specialist/client.
 - RBAC policy (централизованные проверки прав) в `src/policies/rolePermissions.ts`.
-- Settings API: system (owner), account (owner/admin), user (all users).
+- Settings API: system (owner), account (owner/admin), user (all users), account notification defaults (owner/admin).
 - CRUD: users, specialists.
   - При создании пользователей owner/admin отправляется invite-link вместо временного пароля.
   - Приглашённый пользователь создаётся неактивным и активируется только после verify-email / accept-invite.
@@ -25,6 +25,8 @@ Node.js/Express API для web-клиента и интеграций.
 - Google OAuth (`start` + `callback`).
 - Email delivery через Brevo SMTP API.
 - Оповещения о записи с fallback-цепочкой: Telegram -> Email.
+- Notification defaults backend foundation: `account_notification_defaults`, `specialist_notification_settings`, `client_notification_settings` + scheduler job для автосоздания дефолтов на аккаунт.
+- Notification delivery job (MVP): email-only отправка `appointment_reminder` (24h/1h) и `payment_reminder` (24h после создания) с дедупликацией через таблицу `notifications`.
 - Локализованные API-сообщения (`ru/en`).
 
 ## Команды
@@ -58,3 +60,17 @@ npm run -w @scheduletm/server test
 - Глобальный обзор: [`../README.md`](../README.md)
 - Карта модуля: [`./PROJECT_MAP.md`](./PROJECT_MAP.md)
 - Роли и права (RBAC): [`./docs/rbac.md`](./docs/rbac.md)
+
+
+### Notification defaults endpoint
+
+- `GET /api/settings/account-notification-defaults`
+  - доступ: `owner`, `admin`;
+  - гарантирует наличие базовых дефолтов по типам (`appointment_created`, `appointment_reminder`, `payment_reminder`) и возвращает их.
+
+
+### Notification delivery (MVP now)
+
+- Канал доставки в scheduler: только `email` (reuse `sendAppointmentNotificationEmail`).
+- Ручной `POST /api/appointments/:id/notify` тоже использует общий email-dispatch сервис (форсированная отправка, независимо от account defaults).
+- Планово scheduler уважает `account_notification_defaults.enabled` и `preferred_channel` (`email`).

--- a/server/src/db/migrations/20260426130000_create_notification_settings_tables.ts
+++ b/server/src/db/migrations/20260426130000_create_notification_settings_tables.ts
@@ -1,0 +1,119 @@
+import type { Knex } from 'knex';
+
+const NOTIFICATION_TYPES = ['appointment_created', 'appointment_reminder', 'payment_reminder'];
+const CHANNELS = ['email', 'viber', 'whatsapp', 'sms'];
+const FREQUENCIES = ['immediate', 'daily'];
+
+function buildInClause(values: string[]) {
+  return values.map((value) => `'${value}'`).join(', ');
+}
+
+function addNotificationTypeCheck(knex: Knex, tableName: string, columnName: string) {
+  return knex.raw(
+    `ALTER TABLE "${tableName}" ADD CONSTRAINT "${tableName}_${columnName}_check" CHECK ("${columnName}" IN (${buildInClause(NOTIFICATION_TYPES)}))`,
+  );
+}
+
+function addChannelCheck(knex: Knex, tableName: string, columnName: string) {
+  return knex.raw(
+    `ALTER TABLE "${tableName}" ADD CONSTRAINT "${tableName}_${columnName}_check" CHECK ("${columnName}" IN (${buildInClause(CHANNELS)}))`,
+  );
+}
+
+async function createAccountNotificationDefaultsTable(knex: Knex) {
+  const hasTable = await knex.schema.hasTable('account_notification_defaults');
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable('account_notification_defaults', (table) => {
+    table.increments('id').primary();
+    table.integer('account_id').notNullable().references('id').inTable('accounts').onDelete('CASCADE');
+    table.string('notification_type', 64).notNullable();
+    table.string('preferred_channel', 32).notNullable();
+    table.boolean('enabled').notNullable().defaultTo(true);
+    table.jsonb('send_timings').notNullable().defaultTo('[]');
+    table.string('frequency', 32).notNullable().defaultTo('immediate');
+    table.timestamps(true, true);
+
+    table.unique(['account_id', 'notification_type', 'preferred_channel'], {
+      indexName: 'account_notification_defaults_account_type_channel_unique',
+    });
+    table.index(['account_id'], 'account_notification_defaults_account_id_index');
+  });
+
+  await addNotificationTypeCheck(knex, 'account_notification_defaults', 'notification_type');
+  await addChannelCheck(knex, 'account_notification_defaults', 'preferred_channel');
+  await knex.raw(
+    `ALTER TABLE "account_notification_defaults" ADD CONSTRAINT "account_notification_defaults_frequency_check" CHECK ("frequency" IN (${buildInClause(FREQUENCIES)}))`,
+  );
+}
+
+async function createSpecialistNotificationSettingsTable(knex: Knex) {
+  const hasTable = await knex.schema.hasTable('specialist_notification_settings');
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable('specialist_notification_settings', (table) => {
+    table.increments('id').primary();
+    table.integer('account_id').notNullable().references('id').inTable('accounts').onDelete('CASCADE');
+    table.integer('specialist_id').notNullable().references('id').inTable('specialists').onDelete('CASCADE');
+    table.string('notification_type', 64).notNullable();
+    table.string('preferred_channel', 32).notNullable();
+    table.boolean('enabled').notNullable().defaultTo(true);
+    table.jsonb('send_timings').notNullable().defaultTo('[]');
+    table.string('frequency', 32).notNullable().defaultTo('immediate');
+    table.timestamps(true, true);
+
+    table.unique(['account_id', 'specialist_id', 'notification_type', 'preferred_channel'], {
+      indexName: 'specialist_notification_settings_account_specialist_type_channel_unique',
+    });
+    table.index(['account_id'], 'specialist_notification_settings_account_id_index');
+    table.index(['specialist_id'], 'specialist_notification_settings_specialist_id_index');
+  });
+
+  await addNotificationTypeCheck(knex, 'specialist_notification_settings', 'notification_type');
+  await addChannelCheck(knex, 'specialist_notification_settings', 'preferred_channel');
+  await knex.raw(
+    `ALTER TABLE "specialist_notification_settings" ADD CONSTRAINT "specialist_notification_settings_frequency_check" CHECK ("frequency" IN (${buildInClause(FREQUENCIES)}))`,
+  );
+}
+
+async function createClientNotificationSettingsTable(knex: Knex) {
+  const hasTable = await knex.schema.hasTable('client_notification_settings');
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable('client_notification_settings', (table) => {
+    table.increments('id').primary();
+    table.integer('account_id').notNullable().references('id').inTable('accounts').onDelete('CASCADE');
+    table.integer('client_id').notNullable().references('id').inTable('clients').onDelete('CASCADE');
+    table.string('notification_type', 64).notNullable();
+    table.string('channel', 32).notNullable();
+    table.boolean('enabled').notNullable().defaultTo(true);
+    table.timestamps(true, true);
+
+    table.unique(['account_id', 'client_id', 'notification_type', 'channel'], {
+      indexName: 'client_notification_settings_account_client_type_channel_unique',
+    });
+    table.index(['account_id'], 'client_notification_settings_account_id_index');
+    table.index(['client_id'], 'client_notification_settings_client_id_index');
+  });
+
+  await addNotificationTypeCheck(knex, 'client_notification_settings', 'notification_type');
+  await addChannelCheck(knex, 'client_notification_settings', 'channel');
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await createAccountNotificationDefaultsTable(knex);
+  await createSpecialistNotificationSettingsTable(knex);
+  await createClientNotificationSettingsTable(knex);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('client_notification_settings');
+  await knex.schema.dropTableIfExists('specialist_notification_settings');
+  await knex.schema.dropTableIfExists('account_notification_defaults');
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,8 +2,15 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const [{ createApp }, { env }] = await Promise.all([import('./app.js'), import('./config/env.js')]);
+const [{ createApp }, { env }, { startNotificationDefaultsJob }, { startAppointmentNotificationsJob }] = await Promise.all([
+  import('./app.js'),
+  import('./config/env.js'),
+  import('./jobs/notificationDefaults.job.js'),
+  import('./jobs/appointmentNotifications.job.js'),
+]);
 
 createApp().listen(env.PORT, () => {
+  startNotificationDefaultsJob();
+  startAppointmentNotificationsJob();
   console.log(`server listening on http://localhost:${env.PORT}`);
 });

--- a/server/src/jobs/appointmentNotifications.job.ts
+++ b/server/src/jobs/appointmentNotifications.job.ts
@@ -1,0 +1,149 @@
+import {
+  listAppointmentsAllAccounts,
+  listUnpaidAppointmentsCreatedBetweenAllAccounts,
+} from '../repositories/appointmentRepository.js';
+import { hasSentNotification, insertSentNotification } from '../repositories/notificationRepository.js';
+import { sendAppointmentNotificationByType } from '../services/appointmentNotificationService.js';
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_WINDOW_MIN = 10;
+
+const REMINDER_TIMINGS = [
+  { key: '24h', minutesBefore: 24 * 60 },
+  { key: '1h', minutesBefore: 60 },
+] as const;
+
+const PAYMENT_TIMINGS = [
+  { key: '24h', minutesAfterCreate: 24 * 60 },
+] as const;
+
+function createWindow(now: Date, baseMinutes: number, windowMinutes: number, direction: 'future' | 'past') {
+  const from = new Date(now);
+  const to = new Date(now);
+
+  if (direction === 'future') {
+    from.setMinutes(from.getMinutes() + (baseMinutes - windowMinutes));
+    to.setMinutes(to.getMinutes() + baseMinutes);
+  } else {
+    from.setMinutes(from.getMinutes() - baseMinutes);
+    to.setMinutes(to.getMinutes() - (baseMinutes - windowMinutes));
+  }
+
+  return { from, to };
+}
+
+async function deliverAndMark(input: {
+  appointmentId: number;
+  accountId: number;
+  userId: number;
+  email: string;
+  typeKey: string;
+  sendAt: Date;
+  payload: Record<string, unknown>;
+  sender: () => Promise<boolean>;
+}) {
+  const sent = await hasSentNotification(input.appointmentId, input.typeKey, 'email');
+  if (sent) {
+    return false;
+  }
+
+  const delivered = await input.sender();
+  if (!delivered) {
+    return false;
+  }
+
+  await insertSentNotification({
+    accountId: input.accountId,
+    appointmentId: input.appointmentId,
+    userId: input.userId,
+    type: input.typeKey,
+    channel: 'email',
+    sendAt: input.sendAt,
+    recipientEmail: input.email,
+    payload: input.payload,
+  });
+
+  return true;
+}
+
+export function startAppointmentNotificationsJob(intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timeout {
+  return setInterval(() => {
+    void runAppointmentNotificationsJob();
+  }, intervalMs);
+}
+
+export async function runAppointmentNotificationsJob(now = new Date(), windowMinutes = DEFAULT_WINDOW_MIN): Promise<number> {
+  let deliveredCount = 0;
+
+  for (const timing of REMINDER_TIMINGS) {
+    const window = createWindow(now, timing.minutesBefore, windowMinutes, 'future');
+    const appointments = await listAppointmentsAllAccounts({ from: window.from, to: window.to });
+
+    for (const appointment of appointments) {
+      const email = appointment.client_email?.trim() ?? '';
+      if (!email) {
+        continue;
+      }
+
+      const didDeliver = await deliverAndMark({
+        appointmentId: appointment.id,
+        accountId: appointment.account_id,
+        userId: appointment.user_id,
+        email,
+        typeKey: `appointment_reminder:${timing.key}`,
+        sendAt: now,
+        payload: { timing: timing.key },
+        sender: async () => {
+          const result = await sendAppointmentNotificationByType({
+            accountId: appointment.account_id,
+            appointment,
+            notificationType: 'appointment_reminder',
+          });
+
+          return result.delivered;
+        },
+      });
+
+      if (didDeliver) {
+        deliveredCount += 1;
+      }
+    }
+  }
+
+  for (const timing of PAYMENT_TIMINGS) {
+    const window = createWindow(now, timing.minutesAfterCreate, windowMinutes, 'past');
+    const appointments = await listUnpaidAppointmentsCreatedBetweenAllAccounts(window.from, window.to);
+
+    for (const appointment of appointments) {
+      const email = appointment.client_email?.trim() ?? '';
+      if (!email) {
+        continue;
+      }
+
+      const didDeliver = await deliverAndMark({
+        appointmentId: appointment.id,
+        accountId: appointment.account_id,
+        userId: appointment.user_id,
+        email,
+        typeKey: `payment_reminder:${timing.key}`,
+        sendAt: now,
+        payload: { timing: timing.key },
+        sender: async () => {
+          const result = await sendAppointmentNotificationByType({
+            accountId: appointment.account_id,
+            appointment,
+            notificationType: 'payment_reminder',
+          });
+
+          return result.delivered;
+        },
+      });
+
+      if (didDeliver) {
+        deliveredCount += 1;
+      }
+    }
+  }
+
+  return deliveredCount;
+}

--- a/server/src/jobs/notificationDefaults.job.ts
+++ b/server/src/jobs/notificationDefaults.job.ts
@@ -1,0 +1,25 @@
+import { listAccountIdsWithoutNotificationDefaults } from '../repositories/accountNotificationDefaultsRepository.js';
+import { buildDefaultAccountNotificationSettings, getAccountNotificationDefaults } from '../services/notificationSettingsService.js';
+
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+export function startNotificationDefaultsJob(intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timeout {
+  return setInterval(() => {
+    void runNotificationDefaultsJob();
+  }, intervalMs);
+}
+
+export async function runNotificationDefaultsJob(batchSize = DEFAULT_BATCH_SIZE): Promise<number> {
+  const accountIds = await listAccountIdsWithoutNotificationDefaults(batchSize);
+  if (accountIds.length === 0) {
+    return 0;
+  }
+
+  const defaults = buildDefaultAccountNotificationSettings();
+  await Promise.all(accountIds.map(async (accountId) => {
+    await getAccountNotificationDefaults(accountId);
+  }));
+
+  return defaults.length * accountIds.length;
+}

--- a/server/src/repositories/accountNotificationDefaultsRepository.ts
+++ b/server/src/repositories/accountNotificationDefaultsRepository.ts
@@ -1,0 +1,55 @@
+import { db } from '../db/knex.js';
+import type { AccountNotificationDefault } from '../services/notificationSettingsService.js';
+
+export type AccountNotificationDefaultRecord = {
+  id: number;
+  account_id: number;
+  notification_type: string;
+  preferred_channel: string;
+  enabled: boolean;
+  send_timings: unknown;
+  frequency: string;
+};
+
+export async function findAccountNotificationDefaults(accountId: number): Promise<AccountNotificationDefaultRecord[]> {
+  return db('account_notification_defaults')
+    .where({ account_id: accountId })
+    .select<AccountNotificationDefaultRecord[]>('*');
+}
+
+export async function ensureAccountNotificationDefaults(
+  accountId: number,
+  defaults: AccountNotificationDefault[],
+): Promise<void> {
+  if (defaults.length === 0) {
+    return;
+  }
+
+  await db('account_notification_defaults')
+    .insert(
+      defaults.map((item) => ({
+        account_id: accountId,
+        notification_type: item.notificationType,
+        preferred_channel: item.preferredChannel,
+        enabled: item.enabled,
+        send_timings: JSON.stringify(item.sendTimings),
+        frequency: item.frequency,
+        created_at: db.fn.now(),
+        updated_at: db.fn.now(),
+      })),
+    )
+    .onConflict(['account_id', 'notification_type', 'preferred_channel'])
+    .ignore();
+}
+
+export async function listAccountIdsWithoutNotificationDefaults(limit: number): Promise<number[]> {
+  const rows = await db('accounts as a')
+    .leftJoin('account_notification_defaults as andf', 'andf.account_id', 'a.id')
+    .whereNull('andf.id')
+    .groupBy('a.id')
+    .orderBy('a.id', 'asc')
+    .limit(limit)
+    .select<{ id: number }[]>('a.id');
+
+  return rows.map((row) => row.id);
+}

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -291,3 +291,27 @@ export async function countAppointmentsBySpecialistId(accountId: number, special
 
   return Number(row?.count ?? 0);
 }
+
+
+export async function listUnpaidAppointmentsCreatedBetweenAllAccounts(
+  from: Date,
+  to: Date,
+): Promise<AppointmentRecord[]> {
+  return db('appointments')
+    .leftJoin('clients', function joinClients() {
+      this.on('clients.id', '=', 'appointments.user_id').andOn('clients.account_id', '=', 'appointments.account_id');
+    })
+    .where('appointments.is_paid', false)
+    .whereIn('appointments.status', ['new', 'confirmed'])
+    .where('appointments.created_at', '>=', from)
+    .where('appointments.created_at', '<=', to)
+    .orderBy('appointments.created_at', 'asc')
+    .select<AppointmentRecord[]>(
+      'appointments.*',
+      'clients.first_name as client_first_name',
+      'clients.last_name as client_last_name',
+      'clients.username as client_username',
+      'clients.phone as client_phone',
+      'clients.email as client_email',
+    );
+}

--- a/server/src/repositories/notificationRepository.ts
+++ b/server/src/repositories/notificationRepository.ts
@@ -1,0 +1,46 @@
+import { db } from '../db/knex.js';
+
+export async function hasSentNotification(
+  appointmentId: number,
+  type: string,
+  channel: 'email',
+): Promise<boolean> {
+  const row = await db('notifications')
+    .where({
+      appointment_id: appointmentId,
+      type,
+      channel,
+      status: 'sent',
+    })
+    .first<{ id: number }>('id');
+
+  return Boolean(row?.id);
+}
+
+export async function insertSentNotification(input: {
+  accountId: number;
+  appointmentId: number;
+  userId: number;
+  type: string;
+  channel: 'email';
+  sendAt: Date;
+  recipientEmail: string;
+  payload?: Record<string, unknown>;
+}): Promise<void> {
+  await db('notifications').insert({
+    account_id: input.accountId,
+    user_id: input.userId,
+    appointment_id: input.appointmentId,
+    type: input.type,
+    channel: input.channel,
+    status: 'sent',
+    send_at: input.sendAt,
+    sent_at: db.fn.now(),
+    recipient_email: input.recipientEmail,
+    payload_json: JSON.stringify(input.payload ?? {}),
+    attempts: 1,
+    max_attempts: 1,
+    created_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  });
+}

--- a/server/src/routes/settingsRoutes.ts
+++ b/server/src/routes/settingsRoutes.ts
@@ -13,6 +13,7 @@ import {
   updateSystemSettings,
   updateUserSettings,
   canManageSpecialistBookingPolicies,
+  getAccountNotificationDefaults,
 } from '../services/settingsService.js';
 
 export const settingsRoutes = Router();
@@ -61,6 +62,16 @@ settingsRoutes.put('/account', requireAccessToken, async (req, res) => {
   }
 
   return res.json(updated);
+});
+
+
+settingsRoutes.get('/account-notification-defaults', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  if (!canManageAccountSettings(user.role)) {
+    return res.status(403).json({ message: t(req, 'forbiddenAccountSettings') });
+  }
+
+  return res.json({ items: await getAccountNotificationDefaults(user) });
 });
 
 settingsRoutes.get('/user', requireAccessToken, async (req, res) => {

--- a/server/src/services/appointmentNotificationService.ts
+++ b/server/src/services/appointmentNotificationService.ts
@@ -1,0 +1,48 @@
+import type { AppointmentRecord } from '../repositories/appointmentRepository.js';
+import { findSpecialistById } from '../repositories/specialistRepository.js';
+import { sendAppointmentNotificationEmail } from './emailDeliveryService.js';
+import {
+  getAccountNotificationDefaults,
+  type NotificationType,
+} from './notificationSettingsService.js';
+
+function resolveClientName(appointment: AppointmentRecord): string {
+  return `${appointment.client_first_name ?? ''} ${appointment.client_last_name ?? ''}`.trim() || 'Клиент';
+}
+
+export async function sendAppointmentNotificationByType(input: {
+  accountId: number;
+  appointment: AppointmentRecord;
+  notificationType: NotificationType;
+  force?: boolean;
+}): Promise<{ delivered: boolean; channel: 'email' | null; reason?: string }> {
+  const email = input.appointment.client_email?.trim() ?? '';
+  if (!email) {
+    return { delivered: false, channel: null, reason: 'missing_email' };
+  }
+
+  if (!input.force) {
+    const defaults = await getAccountNotificationDefaults(input.accountId);
+    const active = defaults.find((item) => item.notificationType === input.notificationType);
+
+    if (!active?.enabled) {
+      return { delivered: false, channel: null, reason: 'disabled' };
+    }
+
+    if (active.preferredChannel !== 'email') {
+      return { delivered: false, channel: null, reason: 'unsupported_channel' };
+    }
+  }
+
+  const specialist = await findSpecialistById(input.accountId, input.appointment.specialist_id);
+  const delivered = await sendAppointmentNotificationEmail({
+    to: email,
+    clientName: resolveClientName(input.appointment),
+    specialistName: specialist?.name ?? 'специалист',
+    scheduledAt: input.appointment.appointment_at.toISOString(),
+  });
+
+  return delivered
+    ? { delivered: true, channel: 'email' }
+    : { delivered: false, channel: null, reason: 'delivery_failed' };
+}

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -29,13 +29,11 @@ import {
   type SpecialistRecord,
 } from '../repositories/specialistRepository.js';
 import { findWebUserById } from '../repositories/webUserRepository.js';
-import { findTelegramIntegrationByAccountId } from '../repositories/webUserIntegrationRepository.js';
 import { listExternalBusySlots, type ExternalBusySlot } from './calendarAvailabilityService.js';
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 import { canCreateAppointments, canManageAllAppointments, canMarkPaidAndNotify, isClientRole } from '../policies/rolePermissions.js';
-import { sendTelegramBotMessage } from './telegramService.js';
-import { sendAppointmentNotificationEmail } from './emailDeliveryService.js';
+import { sendAppointmentNotificationByType } from './appointmentNotificationService.js';
 
 type AppointmentClientDto = {
   id: number;
@@ -443,6 +441,12 @@ export async function createAppointmentForActor(
   const rows = await listAppointments({ accountId, specialistId: created.specialist_id });
   const hydrated = rows.find((item) => item.id === created.id) ?? created;
 
+  await sendAppointmentNotificationByType({
+    accountId,
+    appointment: hydrated,
+    notificationType: 'appointment_created',
+  }).catch(() => undefined);
+
   return mapAppointment(hydrated);
 }
 
@@ -613,34 +617,20 @@ export async function notifyAppointmentForActor(actor: User, appointmentId: numb
   }
 
   const client = await findClientById(accountId, existing.user_id);
-  const specialist = await findSpecialistById(accountId, existing.specialist_id);
-  const specialistName = specialist?.name ?? 'специалист';
-  const clientName = `${client?.first_name ?? ''} ${client?.last_name ?? ''}`.trim() || 'Клиент';
-  const scheduledAt = existing.appointment_at.toISOString();
+  const delivered = await sendAppointmentNotificationByType({
+    accountId,
+    appointment: {
+      ...existing,
+      client_first_name: client?.first_name ?? existing.client_first_name,
+      client_last_name: client?.last_name ?? existing.client_last_name,
+      client_email: client?.email ?? existing.client_email,
+    },
+    notificationType: 'appointment_reminder',
+    force: true,
+  });
 
-  const telegramIntegration = await findTelegramIntegrationByAccountId(accountId);
-  const telegramDelivered = telegramIntegration?.telegram_bot_token && client?.telegram_id
-    ? await sendTelegramBotMessage(
-      telegramIntegration.telegram_bot_token,
-      client.telegram_id,
-      `Напоминание о записи: ${scheduledAt}, ${specialistName}.`,
-    )
-    : false;
-
-  if (!telegramDelivered) {
-    const email = client?.email?.trim() ?? '';
-    const emailDelivered = email
-      ? await sendAppointmentNotificationEmail({
-        to: email,
-        clientName,
-        specialistName,
-        scheduledAt,
-      })
-      : false;
-
-    if (!emailDelivered) {
-      throw new Error('NOTIFICATION_DELIVERY_FAILED');
-    }
+  if (!delivered.delivered) {
+    throw new Error('NOTIFICATION_DELIVERY_FAILED');
   }
 
   await appendAuditEvent(accountId, appointmentId, actor, 'notify');

--- a/server/src/services/notificationSettingsService.ts
+++ b/server/src/services/notificationSettingsService.ts
@@ -1,0 +1,77 @@
+import { ensureAccountNotificationDefaults, findAccountNotificationDefaults } from '../repositories/accountNotificationDefaultsRepository.js';
+
+export const NOTIFICATION_TYPES = ['appointment_created', 'appointment_reminder', 'payment_reminder'] as const;
+export const NOTIFICATION_CHANNELS = ['email', 'viber', 'whatsapp', 'sms'] as const;
+export const NOTIFICATION_FREQUENCIES = ['immediate', 'daily'] as const;
+
+export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
+export type NotificationChannel = (typeof NOTIFICATION_CHANNELS)[number];
+export type NotificationFrequency = (typeof NOTIFICATION_FREQUENCIES)[number];
+
+export type AccountNotificationDefault = {
+  notificationType: NotificationType;
+  preferredChannel: NotificationChannel;
+  enabled: boolean;
+  sendTimings: string[];
+  frequency: NotificationFrequency;
+};
+
+const DEFAULTS_BY_TYPE: Record<NotificationType, Omit<AccountNotificationDefault, 'notificationType'>> = {
+  appointment_created: {
+    preferredChannel: 'email',
+    enabled: true,
+    sendTimings: ['immediate'],
+    frequency: 'immediate',
+  },
+  appointment_reminder: {
+    preferredChannel: 'email',
+    enabled: true,
+    sendTimings: ['24h', '1h'],
+    frequency: 'immediate',
+  },
+  payment_reminder: {
+    preferredChannel: 'email',
+    enabled: true,
+    sendTimings: ['24h'],
+    frequency: 'daily',
+  },
+};
+
+export function buildDefaultAccountNotificationSettings(): AccountNotificationDefault[] {
+  return NOTIFICATION_TYPES.map((notificationType) => ({
+    notificationType,
+    ...DEFAULTS_BY_TYPE[notificationType],
+  }));
+}
+
+function parseSendTimings(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+export async function getAccountNotificationDefaults(accountId: number): Promise<AccountNotificationDefault[]> {
+  await ensureAccountNotificationDefaults(accountId, buildDefaultAccountNotificationSettings());
+
+  const rows = await findAccountNotificationDefaults(accountId);
+  return rows
+    .map((row) => ({
+      notificationType: row.notification_type as NotificationType,
+      preferredChannel: row.preferred_channel as NotificationChannel,
+      enabled: row.enabled,
+      sendTimings: parseSendTimings(row.send_timings),
+      frequency: row.frequency as NotificationFrequency,
+    }))
+    .sort((a, b) => a.notificationType.localeCompare(b.notificationType));
+}

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -24,6 +24,7 @@ import { canManageAccountSettings, canManageSystemSettings } from '../policies/r
 export { canManageAccountSettings, canManageSystemSettings } from '../policies/rolePermissions.js';
 import { findSpecialistById, findSpecialistByWebUserId } from '../repositories/specialistRepository.js';
 import { WebUserRole } from '../types/webUserRole.js';
+import { getAccountNotificationDefaults as getAccountNotificationDefaultsCore } from './notificationSettingsService.js';
 
 export type SystemSettings = {
   dailyDigestEnabled: boolean;
@@ -337,4 +338,8 @@ export async function updateSpecialistBookingPolicy(
   });
 
   return getSpecialistBookingPolicy(actor, resolvedSpecialistId);
+}
+
+export async function getAccountNotificationDefaults(actor: User) {
+  return getAccountNotificationDefaultsCore(actor.accountId);
 }

--- a/server/tests/appointment-notification.service.unit.test.ts
+++ b/server/tests/appointment-notification.service.unit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { sendAppointmentNotificationByType } from '../src/services/appointmentNotificationService.js';
+
+const getAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+const findSpecialistByIdMock = vi.hoisted(() => vi.fn());
+const sendAppointmentNotificationEmailMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/notificationSettingsService.js', () => ({
+  getAccountNotificationDefaults: getAccountNotificationDefaultsMock,
+}));
+
+vi.mock('../src/repositories/specialistRepository.js', () => ({
+  findSpecialistById: findSpecialistByIdMock,
+}));
+
+vi.mock('../src/services/emailDeliveryService.js', () => ({
+  sendAppointmentNotificationEmail: sendAppointmentNotificationEmailMock,
+}));
+
+describe('appointment notification service unit', () => {
+  beforeEach(() => {
+    getAccountNotificationDefaultsMock.mockReset();
+    findSpecialistByIdMock.mockReset();
+    sendAppointmentNotificationEmailMock.mockReset();
+  });
+
+  it('does not send when notification type disabled', async () => {
+    getAccountNotificationDefaultsMock.mockResolvedValue([
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: false, sendTimings: ['24h'], frequency: 'immediate' },
+    ]);
+
+    const result = await sendAppointmentNotificationByType({
+      accountId: 1,
+      notificationType: 'appointment_reminder',
+      appointment: {
+        id: 1,
+        account_id: 1,
+        specialist_id: 1,
+        appointment_at: new Date(),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 5,
+        service_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        client_email: 'a@b.com',
+      },
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toBe('disabled');
+    expect(sendAppointmentNotificationEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('sends via email when enabled', async () => {
+    getAccountNotificationDefaultsMock.mockResolvedValue([
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: true, sendTimings: ['24h'], frequency: 'immediate' },
+    ]);
+    findSpecialistByIdMock.mockResolvedValue({ name: 'Dr. Test' });
+    sendAppointmentNotificationEmailMock.mockResolvedValue(true);
+
+    const result = await sendAppointmentNotificationByType({
+      accountId: 1,
+      notificationType: 'appointment_reminder',
+      appointment: {
+        id: 1,
+        account_id: 1,
+        specialist_id: 1,
+        appointment_at: new Date('2026-04-26T10:00:00.000Z'),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 5,
+        service_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        client_first_name: 'Ivan',
+        client_last_name: 'Petrov',
+        client_email: 'a@b.com',
+      },
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(sendAppointmentNotificationEmailMock).toHaveBeenCalledOnce();
+  });
+});

--- a/server/tests/appointment-notifications.job.unit.test.ts
+++ b/server/tests/appointment-notifications.job.unit.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runAppointmentNotificationsJob } from '../src/jobs/appointmentNotifications.job.js';
+
+const listAppointmentsAllAccountsMock = vi.hoisted(() => vi.fn());
+const listUnpaidAppointmentsCreatedBetweenAllAccountsMock = vi.hoisted(() => vi.fn());
+const hasSentNotificationMock = vi.hoisted(() => vi.fn());
+const insertSentNotificationMock = vi.hoisted(() => vi.fn());
+const sendAppointmentNotificationByTypeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/repositories/appointmentRepository.js', () => ({
+  listAppointmentsAllAccounts: listAppointmentsAllAccountsMock,
+  listUnpaidAppointmentsCreatedBetweenAllAccounts: listUnpaidAppointmentsCreatedBetweenAllAccountsMock,
+}));
+
+vi.mock('../src/repositories/notificationRepository.js', () => ({
+  hasSentNotification: hasSentNotificationMock,
+  insertSentNotification: insertSentNotificationMock,
+}));
+
+vi.mock('../src/services/appointmentNotificationService.js', () => ({
+  sendAppointmentNotificationByType: sendAppointmentNotificationByTypeMock,
+}));
+
+describe('appointment notifications job unit', () => {
+  beforeEach(() => {
+    listAppointmentsAllAccountsMock.mockReset();
+    listUnpaidAppointmentsCreatedBetweenAllAccountsMock.mockReset();
+    hasSentNotificationMock.mockReset();
+    insertSentNotificationMock.mockReset();
+    sendAppointmentNotificationByTypeMock.mockReset();
+
+    listAppointmentsAllAccountsMock.mockResolvedValue([]);
+    listUnpaidAppointmentsCreatedBetweenAllAccountsMock.mockResolvedValue([]);
+    hasSentNotificationMock.mockResolvedValue(false);
+    sendAppointmentNotificationByTypeMock.mockResolvedValue({ delivered: true });
+  });
+
+  it('delivers reminder and writes sent notification once', async () => {
+    listAppointmentsAllAccountsMock.mockResolvedValueOnce([
+      {
+        id: 11,
+        account_id: 2,
+        specialist_id: 3,
+        appointment_at: new Date('2026-04-27T12:00:00.000Z'),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 8,
+        service_id: 1,
+        created_at: new Date('2026-04-26T12:00:00.000Z'),
+        updated_at: new Date('2026-04-26T12:00:00.000Z'),
+        client_email: 'client@test.com',
+      },
+    ]);
+
+    const delivered = await runAppointmentNotificationsJob(new Date('2026-04-26T12:00:00.000Z'));
+
+    expect(delivered).toBe(1);
+    expect(insertSentNotificationMock).toHaveBeenCalledOnce();
+  });
+
+  it('skips already sent notification (edge case dedupe)', async () => {
+    listAppointmentsAllAccountsMock.mockResolvedValueOnce([
+      {
+        id: 11,
+        account_id: 2,
+        specialist_id: 3,
+        appointment_at: new Date('2026-04-27T12:00:00.000Z'),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 8,
+        service_id: 1,
+        created_at: new Date('2026-04-26T12:00:00.000Z'),
+        updated_at: new Date('2026-04-26T12:00:00.000Z'),
+        client_email: 'client@test.com',
+      },
+    ]);
+    hasSentNotificationMock.mockResolvedValue(true);
+
+    const delivered = await runAppointmentNotificationsJob(new Date('2026-04-26T12:00:00.000Z'));
+
+    expect(delivered).toBe(0);
+    expect(sendAppointmentNotificationByTypeMock).not.toHaveBeenCalled();
+    expect(insertSentNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/settings.notification-defaults.routes.smoke.test.ts
+++ b/server/tests/settings.notification-defaults.routes.smoke.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import { createApp } from '../src/app.js';
+import { WebUserRole } from '../src/types/webUserRole.js';
+
+const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
+const getAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/authService.js', () => ({
+  resolveUserByAccessToken: resolveUserByAccessTokenMock,
+}));
+
+vi.mock('../src/services/settingsService.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/services/settingsService.js')>('../src/services/settingsService.js');
+  return {
+    ...actual,
+    getAccountNotificationDefaults: getAccountNotificationDefaultsMock,
+  };
+});
+
+const authedUser = {
+  id: '101',
+  accountId: 1,
+  email: 'owner@example.com',
+  role: WebUserRole.Owner,
+  passwordSalt: 'salt',
+  passwordHash: 'hash',
+  createdAt: '2026-04-22T09:00:00.000Z',
+};
+
+describe('settings account notification defaults route-smoke scenarios (mocked service layer)', () => {
+  const app = createApp();
+  let baseUrl = '';
+  let server: Awaited<ReturnType<typeof app.listen>>;
+
+  beforeAll(async () => {
+    server = await new Promise((resolve) => {
+      const started = app.listen(0, () => resolve(started));
+    });
+
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    resolveUserByAccessTokenMock.mockReset();
+    getAccountNotificationDefaultsMock.mockReset();
+
+    resolveUserByAccessTokenMock.mockResolvedValue(authedUser);
+  });
+
+  it('GET /api/settings/account-notification-defaults returns defaults', async () => {
+    getAccountNotificationDefaultsMock.mockResolvedValue([
+      {
+        notificationType: 'appointment_reminder',
+        preferredChannel: 'email',
+        enabled: true,
+        sendTimings: ['24h', '1h'],
+        frequency: 'immediate',
+      },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/settings/account-notification-defaults`, {
+      method: 'GET',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      items: [
+        {
+          notificationType: 'appointment_reminder',
+          preferredChannel: 'email',
+        },
+      ],
+    });
+  });
+
+  it('returns 403 for client role', async () => {
+    resolveUserByAccessTokenMock.mockResolvedValue({ ...authedUser, role: WebUserRole.Client });
+
+    const response = await fetch(`${baseUrl}/api/settings/account-notification-defaults`, {
+      method: 'GET',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/server/tests/settings.notification-defaults.unit.test.ts
+++ b/server/tests/settings.notification-defaults.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  NOTIFICATION_TYPES,
+  buildDefaultAccountNotificationSettings,
+  getAccountNotificationDefaults,
+} from '../src/services/notificationSettingsService.js';
+
+const ensureAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+const findAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/repositories/accountNotificationDefaultsRepository.js', () => ({
+  ensureAccountNotificationDefaults: ensureAccountNotificationDefaultsMock,
+  findAccountNotificationDefaults: findAccountNotificationDefaultsMock,
+}));
+
+describe('notification defaults unit', () => {
+  it('builds complete MVP defaults for all notification types', () => {
+    const defaults = buildDefaultAccountNotificationSettings();
+
+    expect(defaults).toHaveLength(NOTIFICATION_TYPES.length);
+    expect(defaults.map((item) => item.notificationType).sort()).toEqual([...NOTIFICATION_TYPES].sort());
+  });
+
+  it('returns parsed send timings and sorts by notification type', async () => {
+    findAccountNotificationDefaultsMock.mockResolvedValue([
+      {
+        notification_type: 'payment_reminder',
+        preferred_channel: 'email',
+        enabled: true,
+        send_timings: '["24h"]',
+        frequency: 'daily',
+      },
+      {
+        notification_type: 'appointment_created',
+        preferred_channel: 'email',
+        enabled: true,
+        send_timings: ['immediate'],
+        frequency: 'immediate',
+      },
+    ]);
+
+    const items = await getAccountNotificationDefaults(11);
+
+    expect(ensureAccountNotificationDefaultsMock).toHaveBeenCalledOnce();
+    expect(items[0]?.notificationType).toBe('appointment_created');
+    expect(items[1]?.sendTimings).toEqual(['24h']);
+  });
+
+  it('handles invalid send timings payload as empty array', async () => {
+    findAccountNotificationDefaultsMock.mockResolvedValue([
+      {
+        notification_type: 'appointment_reminder',
+        preferred_channel: 'email',
+        enabled: true,
+        send_timings: '{invalid json}',
+        frequency: 'immediate',
+      },
+    ]);
+
+    const items = await getAccountNotificationDefaults(11);
+    expect(items[0]?.sendTimings).toEqual([]);
+  });
+});

--- a/settings-rework-plan.md
+++ b/settings-rework-plan.md
@@ -18,9 +18,54 @@
 
 ### ⏭️ Следующая итерация
 
-1. Настройки оповещений (`account_notification_defaults`, `specialist_notification_settings`, `client_notification_settings`).
+1. Доработка отправки оповещений (см. чеклист ниже: effective settings, specialist/client overrides, fallback channels, retries, observability).
 2. Авто-отмена неоплаченных записей через scheduler/jobs.
 3. Полная сквозная UX-поддержка последствий поздней отмены (refund/no-refund) в web и bot.
+
+### 📌 Что осталось доделать именно по отправке оповещений
+
+**Уже есть (backend MVP foundation):**
+- таблицы `account_notification_defaults`, `specialist_notification_settings`, `client_notification_settings`;
+- автосоздание account defaults;
+- email-only scheduler для `appointment_reminder` и `payment_reminder`;
+- manual notify endpoint использует общий email dispatch.
+
+**Осталось реализовать:**
+1. **Effective settings pipeline**
+   - считать итоговые настройки по цепочке `account -> specialist -> client`;
+   - учитывать `client_notification_settings.enabled=false` как deny на канал.
+
+2. **Specialist/Client overrides API + права**
+   - CRUD/read endpoints для `specialist_notification_settings` и `client_notification_settings`;
+   - role-gates и scope-проверки (owner/admin/specialist/client).
+
+3. **Fallback channels (после email MVP)**
+   - добавить реальные провайдеры/адаптеры для `viber`, `whatsapp`, `sms`;
+   - включить последовательный fallback по `preferred_channel`.
+
+4. **Надёжность доставки**
+   - retry policy (`pending/retry/failed`) для scheduler-отправок;
+   - backoff/next_retry_at и ограничение `max_attempts`;
+   - дедупликация на уровне idempotency key для каждого timing.
+
+5. **Тайминги и бизнес-правила**
+   - хранить и валидировать `send_timings` как доменную модель (а не только raw JSON);
+   - привести payment reminder rule к единому полю `N hours` в API/DTO.
+
+6. **Наблюдаемость и аудит**
+   - метрики доставок/ошибок по каналам и типам;
+   - диагностические причины skip (`disabled`, `no-contact`, `client-deny`, `unsupported-channel`).
+
+7. **Frontend + UX**
+   - единый экран матрицы `notification_type × channel`;
+   - секции account/specialist/client;
+   - управление таймингами и preview effective settings.
+
+8. **Тесты (edge cases, обязательно):**
+   - приоритет переопределений (account vs specialist vs client deny);
+   - поведение fallback-цепочки при частичных отказах каналов;
+   - дедуп и retry после рестарта job-процесса;
+   - корректность окон таймингов на границах (±1 мин, DST, timezone).
 
 ---
 


### PR DESCRIPTION
### Motivation

- Add backend foundation for account/specialist/client notification settings and enable automated reminder/payment emails as an MVP.
- Ensure accounts get sane default notification settings and provide a manual endpoint to view them.

### Description

- Add DB migration `20260426130000_create_notification_settings_tables.ts` to create `account_notification_defaults`, `specialist_notification_settings`, and `client_notification_settings` tables with constraints and indexes.
- Implement repositories and services: `accountNotificationDefaultsRepository`, `notificationRepository`, and `notificationSettingsService` to build, persist and fetch account defaults and to deduplicate sent notifications.
- Add jobs: `notificationDefaults.job.ts` to auto-create defaults for accounts and `appointmentNotifications.job.ts` to schedule email-only reminders (`24h`, `1h`) and payment reminders with windowing and deduplication logic; register both jobs in `src/index.ts`.
- Implement `appointmentNotificationService` that resolves effective account defaults and dispatches email via existing `sendAppointmentNotificationEmail`, and modify `appointmentService` to use the new service on create/notify flows.
- Add route `GET /api/settings/account-notification-defaults` and hook `getAccountNotificationDefaults` into settings service, and update `server/README.md` and `settings-rework-plan.md` to document the feature and remaining work.
- Add unit and smoke tests for the new services, job and route and a new `listUnpaidAppointmentsCreatedBetweenAllAccounts` repository helper used by the payment reminder job.

### Testing

- Ran the server test suite with `npm run -w @scheduletm/server test` (Vitest) covering new unit tests `appointment-notification.service.unit.test.ts`, `appointment-notifications.job.unit.test.ts`, `settings.notification-defaults.unit.test.ts` and route smoke `settings.notification-defaults.routes.smoke.test.ts`, and all tests passed.
- New unit tests verify default building, send-timings parsing, email dispatch conditions and job deduplication behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0e8b7ee8833387ad9f41a44c6921)