### PR TITLE
Add specialist/client notification overrides and effective settings pipeline (server)

### DIFF
--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -130,6 +130,32 @@ export const specialistBookingPolicySchema = z.object({
   unpaidAutoCancelAfterHours: z.coerce.number().int().min(1).max(720),
 }).partial();
 
+const notificationTypeSchema = z.enum(['appointment_created', 'appointment_reminder', 'payment_reminder']);
+const notificationChannelSchema = z.enum(['email', 'viber', 'whatsapp', 'sms']);
+const notificationFrequencySchema = z.enum(['immediate', 'daily']);
+
+export const specialistNotificationSettingsPatchSchema = z.object({
+  notificationType: notificationTypeSchema,
+  preferredChannel: notificationChannelSchema,
+  enabled: z.boolean(),
+  sendTimings: z.array(z.string().trim().min(1)).max(16),
+  frequency: notificationFrequencySchema,
+});
+
+export const specialistNotificationSettingsBatchSchema = z.object({
+  items: z.array(specialistNotificationSettingsPatchSchema).max(64),
+});
+
+export const clientNotificationSettingsPatchSchema = z.object({
+  notificationType: notificationTypeSchema,
+  channel: notificationChannelSchema,
+  enabled: z.boolean(),
+});
+
+export const clientNotificationSettingsBatchSchema = z.object({
+  items: z.array(clientNotificationSettingsPatchSchema).max(64),
+});
+
 export const specialistUserCreationSchema = z.object({
   email: z
     .string()

--- a/server/src/repositories/clientNotificationSettingsRepository.ts
+++ b/server/src/repositories/clientNotificationSettingsRepository.ts
@@ -1,0 +1,49 @@
+import { db } from '../db/knex.js';
+
+export type ClientNotificationSettingRecord = {
+  id: number;
+  account_id: number;
+  client_id: number;
+  notification_type: string;
+  channel: string;
+  enabled: boolean;
+};
+
+export async function findClientNotificationSettings(
+  accountId: number,
+  clientId: number,
+): Promise<ClientNotificationSettingRecord[]> {
+  return db('client_notification_settings')
+    .where({ account_id: accountId, client_id: clientId })
+    .select<ClientNotificationSettingRecord[]>('*');
+}
+
+export async function upsertClientNotificationSettings(
+  accountId: number,
+  clientId: number,
+  items: Array<{
+    notificationType: string;
+    channel: string;
+    enabled: boolean;
+  }>,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  await db('client_notification_settings')
+    .insert(items.map((item) => ({
+      account_id: accountId,
+      client_id: clientId,
+      notification_type: item.notificationType,
+      channel: item.channel,
+      enabled: item.enabled,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    })))
+    .onConflict(['account_id', 'client_id', 'notification_type', 'channel'])
+    .merge({
+      enabled: db.raw('excluded.enabled'),
+      updated_at: db.fn.now(),
+    });
+}

--- a/server/src/repositories/specialistNotificationSettingsRepository.ts
+++ b/server/src/repositories/specialistNotificationSettingsRepository.ts
@@ -1,0 +1,57 @@
+import { db } from '../db/knex.js';
+
+export type SpecialistNotificationSettingRecord = {
+  id: number;
+  account_id: number;
+  specialist_id: number;
+  notification_type: string;
+  preferred_channel: string;
+  enabled: boolean;
+  send_timings: unknown;
+  frequency: string;
+};
+
+export async function findSpecialistNotificationSettings(
+  accountId: number,
+  specialistId: number,
+): Promise<SpecialistNotificationSettingRecord[]> {
+  return db('specialist_notification_settings')
+    .where({ account_id: accountId, specialist_id: specialistId })
+    .select<SpecialistNotificationSettingRecord[]>('*');
+}
+
+export async function upsertSpecialistNotificationSettings(
+  accountId: number,
+  specialistId: number,
+  items: Array<{
+    notificationType: string;
+    preferredChannel: string;
+    enabled: boolean;
+    sendTimings: string[];
+    frequency: string;
+  }>,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  await db('specialist_notification_settings')
+    .insert(items.map((item) => ({
+      account_id: accountId,
+      specialist_id: specialistId,
+      notification_type: item.notificationType,
+      preferred_channel: item.preferredChannel,
+      enabled: item.enabled,
+      send_timings: JSON.stringify(item.sendTimings),
+      frequency: item.frequency,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    })))
+    .onConflict(['account_id', 'specialist_id', 'notification_type', 'preferred_channel'])
+    .merge({
+      enabled: db.raw('excluded.enabled'),
+      send_timings: db.raw('excluded.send_timings'),
+      frequency: db.raw('excluded.frequency'),
+      updated_at: db.fn.now(),
+    });
+}

--- a/server/src/routes/settingsRoutes.ts
+++ b/server/src/routes/settingsRoutes.ts
@@ -14,6 +14,11 @@ import {
   updateUserSettings,
   canManageSpecialistBookingPolicies,
   getAccountNotificationDefaults,
+  getClientNotificationSettings,
+  getEffectiveNotificationSetting,
+  getSpecialistNotificationSettings,
+  putClientNotificationSettings,
+  putSpecialistNotificationSettings,
 } from '../services/settingsService.js';
 
 export const settingsRoutes = Router();
@@ -72,6 +77,85 @@ settingsRoutes.get('/account-notification-defaults', requireAccessToken, async (
   }
 
   return res.json({ items: await getAccountNotificationDefaults(user) });
+});
+
+settingsRoutes.get('/specialist-notification-settings', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const specialistId = typeof req.query.specialistId === 'string' ? Number(req.query.specialistId) : undefined;
+  const items = await getSpecialistNotificationSettings(user, Number.isFinite(specialistId) ? specialistId : undefined);
+
+  if (!items) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  return res.json({ items });
+});
+
+settingsRoutes.put('/specialist-notification-settings', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const specialistId = typeof req.query.specialistId === 'string' ? Number(req.query.specialistId) : undefined;
+  const items = await putSpecialistNotificationSettings(
+    user,
+    Number.isFinite(specialistId) ? specialistId : undefined,
+    req.body,
+  );
+
+  if (!items) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  return res.json({ items });
+});
+
+settingsRoutes.get('/client-notification-settings', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const clientId = typeof req.query.clientId === 'string' ? Number(req.query.clientId) : undefined;
+  const items = await getClientNotificationSettings(user, Number.isFinite(clientId) ? clientId : undefined);
+
+  if (!items) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  return res.json({ items });
+});
+
+settingsRoutes.put('/client-notification-settings', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const clientId = typeof req.query.clientId === 'string' ? Number(req.query.clientId) : undefined;
+  const items = await putClientNotificationSettings(user, Number.isFinite(clientId) ? clientId : undefined, req.body);
+
+  if (!items) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  return res.json({ items });
+});
+
+settingsRoutes.get('/effective-notification-setting', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  const notificationType = req.query.notificationType;
+  const specialistId = typeof req.query.specialistId === 'string' ? Number(req.query.specialistId) : undefined;
+  const clientId = typeof req.query.clientId === 'string' ? Number(req.query.clientId) : undefined;
+  const supported = notificationType === 'appointment_created'
+    || notificationType === 'appointment_reminder'
+    || notificationType === 'payment_reminder';
+
+  if (!supported) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  const item = await getEffectiveNotificationSetting(
+    user,
+    notificationType,
+    Number.isFinite(specialistId) ? specialistId : undefined,
+    Number.isFinite(clientId) ? clientId : undefined,
+  );
+
+  if (!item) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  return res.json(item);
 });
 
 settingsRoutes.get('/user', requireAccessToken, async (req, res) => {

--- a/server/src/services/appointmentNotificationService.ts
+++ b/server/src/services/appointmentNotificationService.ts
@@ -2,7 +2,7 @@ import type { AppointmentRecord } from '../repositories/appointmentRepository.js
 import { findSpecialistById } from '../repositories/specialistRepository.js';
 import { sendAppointmentNotificationEmail } from './emailDeliveryService.js';
 import {
-  getAccountNotificationDefaults,
+  getEffectiveNotificationSetting,
   type NotificationType,
 } from './notificationSettingsService.js';
 
@@ -22,11 +22,19 @@ export async function sendAppointmentNotificationByType(input: {
   }
 
   if (!input.force) {
-    const defaults = await getAccountNotificationDefaults(input.accountId);
-    const active = defaults.find((item) => item.notificationType === input.notificationType);
+    const active = await getEffectiveNotificationSetting({
+      accountId: input.accountId,
+      specialistId: input.appointment.specialist_id,
+      clientId: input.appointment.user_id,
+      notificationType: input.notificationType,
+    });
 
-    if (!active?.enabled) {
-      return { delivered: false, channel: null, reason: 'disabled' };
+    if (!active) {
+      return { delivered: false, channel: null, reason: 'missing_settings' };
+    }
+
+    if (!active.enabled) {
+      return { delivered: false, channel: null, reason: active.deniedByClient ? 'client_deny' : 'disabled' };
     }
 
     if (active.preferredChannel !== 'email') {

--- a/server/src/services/notificationSettingsService.ts
+++ b/server/src/services/notificationSettingsService.ts
@@ -1,4 +1,16 @@
 import { ensureAccountNotificationDefaults, findAccountNotificationDefaults } from '../repositories/accountNotificationDefaultsRepository.js';
+import {
+  findSpecialistNotificationSettings,
+  upsertSpecialistNotificationSettings,
+} from '../repositories/specialistNotificationSettingsRepository.js';
+import {
+  findClientNotificationSettings,
+  upsertClientNotificationSettings,
+} from '../repositories/clientNotificationSettingsRepository.js';
+import {
+  clientNotificationSettingsBatchSchema,
+  specialistNotificationSettingsBatchSchema,
+} from '../config/schemas.js';
 
 export const NOTIFICATION_TYPES = ['appointment_created', 'appointment_reminder', 'payment_reminder'] as const;
 export const NOTIFICATION_CHANNELS = ['email', 'viber', 'whatsapp', 'sms'] as const;
@@ -14,6 +26,22 @@ export type AccountNotificationDefault = {
   enabled: boolean;
   sendTimings: string[];
   frequency: NotificationFrequency;
+};
+
+export type SpecialistNotificationSetting = AccountNotificationDefault;
+export type ClientNotificationSetting = {
+  notificationType: NotificationType;
+  channel: NotificationChannel;
+  enabled: boolean;
+};
+
+export type EffectiveNotificationSetting = {
+  notificationType: NotificationType;
+  preferredChannel: NotificationChannel;
+  enabled: boolean;
+  sendTimings: string[];
+  frequency: NotificationFrequency;
+  deniedByClient: boolean;
 };
 
 const DEFAULTS_BY_TYPE: Record<NotificationType, Omit<AccountNotificationDefault, 'notificationType'>> = {
@@ -74,4 +102,99 @@ export async function getAccountNotificationDefaults(accountId: number): Promise
       frequency: row.frequency as NotificationFrequency,
     }))
     .sort((a, b) => a.notificationType.localeCompare(b.notificationType));
+}
+
+function toAccountLikeSettings(rows: Array<{
+  notification_type: string;
+  preferred_channel: string;
+  enabled: boolean;
+  send_timings: unknown;
+  frequency: string;
+}>): SpecialistNotificationSetting[] {
+  return rows.map((row) => ({
+    notificationType: row.notification_type as NotificationType,
+    preferredChannel: row.preferred_channel as NotificationChannel,
+    enabled: row.enabled,
+    sendTimings: parseSendTimings(row.send_timings),
+    frequency: row.frequency as NotificationFrequency,
+  }));
+}
+
+export async function getSpecialistNotificationSettings(
+  accountId: number,
+  specialistId: number,
+): Promise<SpecialistNotificationSetting[]> {
+  const rows = await findSpecialistNotificationSettings(accountId, specialistId);
+  return toAccountLikeSettings(rows).sort((a, b) => a.notificationType.localeCompare(b.notificationType));
+}
+
+export async function putSpecialistNotificationSettings(
+  accountId: number,
+  specialistId: number,
+  payload: unknown,
+): Promise<SpecialistNotificationSetting[] | null> {
+  const parsed = specialistNotificationSettingsBatchSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+
+  await upsertSpecialistNotificationSettings(accountId, specialistId, parsed.data.items);
+  return getSpecialistNotificationSettings(accountId, specialistId);
+}
+
+export async function getClientNotificationSettings(
+  accountId: number,
+  clientId: number,
+): Promise<ClientNotificationSetting[]> {
+  const rows = await findClientNotificationSettings(accountId, clientId);
+  return rows
+    .map((row) => ({
+      notificationType: row.notification_type as NotificationType,
+      channel: row.channel as NotificationChannel,
+      enabled: row.enabled,
+    }))
+    .sort((a, b) => a.notificationType.localeCompare(b.notificationType) || a.channel.localeCompare(b.channel));
+}
+
+export async function putClientNotificationSettings(
+  accountId: number,
+  clientId: number,
+  payload: unknown,
+): Promise<ClientNotificationSetting[] | null> {
+  const parsed = clientNotificationSettingsBatchSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+
+  await upsertClientNotificationSettings(accountId, clientId, parsed.data.items);
+  return getClientNotificationSettings(accountId, clientId);
+}
+
+export async function getEffectiveNotificationSetting(input: {
+  accountId: number;
+  specialistId: number;
+  clientId: number;
+  notificationType: NotificationType;
+}): Promise<EffectiveNotificationSetting | null> {
+  const accountSettings = await getAccountNotificationDefaults(input.accountId);
+  const accountBase = accountSettings.find((item) => item.notificationType === input.notificationType);
+  if (!accountBase) {
+    return null;
+  }
+
+  const specialistSettings = await getSpecialistNotificationSettings(input.accountId, input.specialistId);
+  const specialistOverride = specialistSettings.find((item) => item.notificationType === input.notificationType);
+  const picked = specialistOverride ?? accountBase;
+
+  const clientSettings = await getClientNotificationSettings(input.accountId, input.clientId);
+  const deny = clientSettings.find((item) =>
+    item.notificationType === input.notificationType
+    && item.channel === picked.preferredChannel
+    && !item.enabled);
+
+  return {
+    ...picked,
+    enabled: picked.enabled && !Boolean(deny),
+    deniedByClient: Boolean(deny),
+  };
 }

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -23,8 +23,16 @@ import { verifyTelegramBotToken } from './telegramService.js';
 import { canManageAccountSettings, canManageSystemSettings } from '../policies/rolePermissions.js';
 export { canManageAccountSettings, canManageSystemSettings } from '../policies/rolePermissions.js';
 import { findSpecialistById, findSpecialistByWebUserId } from '../repositories/specialistRepository.js';
+import { findClientById } from '../repositories/clientRepository.js';
 import { WebUserRole } from '../types/webUserRole.js';
-import { getAccountNotificationDefaults as getAccountNotificationDefaultsCore } from './notificationSettingsService.js';
+import {
+  getAccountNotificationDefaults as getAccountNotificationDefaultsCore,
+  getClientNotificationSettings as getClientNotificationSettingsCore,
+  getEffectiveNotificationSetting as getEffectiveNotificationSettingCore,
+  getSpecialistNotificationSettings as getSpecialistNotificationSettingsCore,
+  putClientNotificationSettings as putClientNotificationSettingsCore,
+  putSpecialistNotificationSettings as putSpecialistNotificationSettingsCore,
+} from './notificationSettingsService.js';
 
 export type SystemSettings = {
   dailyDigestEnabled: boolean;
@@ -342,4 +350,97 @@ export async function updateSpecialistBookingPolicy(
 
 export async function getAccountNotificationDefaults(actor: User) {
   return getAccountNotificationDefaultsCore(actor.accountId);
+}
+
+async function resolveSpecialistIdForNotifications(actor: User, specialistId?: number): Promise<number | null> {
+  if (actor.role === WebUserRole.Owner || actor.role === WebUserRole.Admin) {
+    if (!specialistId || !Number.isInteger(specialistId)) {
+      return null;
+    }
+
+    const specialist = await findSpecialistById(actor.accountId, specialistId);
+    return specialist?.id ?? null;
+  }
+
+  if (actor.role === WebUserRole.Specialist) {
+    const own = await findSpecialistByWebUserId(actor.accountId, Number(actor.id));
+    return own?.id ?? null;
+  }
+
+  return null;
+}
+
+async function resolveClientIdForNotifications(actor: User, clientId?: number): Promise<number | null> {
+  if (actor.role === WebUserRole.Owner || actor.role === WebUserRole.Admin || actor.role === WebUserRole.Specialist) {
+    if (!clientId || !Number.isInteger(clientId)) {
+      return null;
+    }
+
+    const client = await findClientById(actor.accountId, clientId);
+    return client?.id ?? null;
+  }
+
+  if (actor.role === WebUserRole.Client) {
+    const own = await findWebUserById(actor.accountId, Number(actor.id));
+    return own?.client_id ?? null;
+  }
+
+  return null;
+}
+
+export async function getSpecialistNotificationSettings(actor: User, specialistId?: number) {
+  const resolvedSpecialistId = await resolveSpecialistIdForNotifications(actor, specialistId);
+  if (!resolvedSpecialistId) {
+    return null;
+  }
+
+  return getSpecialistNotificationSettingsCore(actor.accountId, resolvedSpecialistId);
+}
+
+export async function putSpecialistNotificationSettings(actor: User, specialistId: number | undefined, payload: unknown) {
+  const resolvedSpecialistId = await resolveSpecialistIdForNotifications(actor, specialistId);
+  if (!resolvedSpecialistId) {
+    return null;
+  }
+
+  return putSpecialistNotificationSettingsCore(actor.accountId, resolvedSpecialistId, payload);
+}
+
+export async function getClientNotificationSettings(actor: User, clientId?: number) {
+  const resolvedClientId = await resolveClientIdForNotifications(actor, clientId);
+  if (!resolvedClientId) {
+    return null;
+  }
+
+  return getClientNotificationSettingsCore(actor.accountId, resolvedClientId);
+}
+
+export async function putClientNotificationSettings(actor: User, clientId: number | undefined, payload: unknown) {
+  const resolvedClientId = await resolveClientIdForNotifications(actor, clientId);
+  if (!resolvedClientId) {
+    return null;
+  }
+
+  return putClientNotificationSettingsCore(actor.accountId, resolvedClientId, payload);
+}
+
+export async function getEffectiveNotificationSetting(
+  actor: User,
+  notificationType: 'appointment_created' | 'appointment_reminder' | 'payment_reminder',
+  specialistId?: number,
+  clientId?: number,
+) {
+  const resolvedSpecialistId = await resolveSpecialistIdForNotifications(actor, specialistId);
+  const resolvedClientId = await resolveClientIdForNotifications(actor, clientId);
+
+  if (!resolvedSpecialistId || !resolvedClientId) {
+    return null;
+  }
+
+  return getEffectiveNotificationSettingCore({
+    accountId: actor.accountId,
+    specialistId: resolvedSpecialistId,
+    clientId: resolvedClientId,
+    notificationType,
+  });
 }

--- a/server/tests/appointment-notification.service.unit.test.ts
+++ b/server/tests/appointment-notification.service.unit.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { sendAppointmentNotificationByType } from '../src/services/appointmentNotificationService.js';
 
-const getAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+const getEffectiveNotificationSettingMock = vi.hoisted(() => vi.fn());
 const findSpecialistByIdMock = vi.hoisted(() => vi.fn());
 const sendAppointmentNotificationEmailMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/services/notificationSettingsService.js', () => ({
-  getAccountNotificationDefaults: getAccountNotificationDefaultsMock,
+  getEffectiveNotificationSetting: getEffectiveNotificationSettingMock,
 }));
 
 vi.mock('../src/repositories/specialistRepository.js', () => ({
@@ -19,15 +19,15 @@ vi.mock('../src/services/emailDeliveryService.js', () => ({
 
 describe('appointment notification service unit', () => {
   beforeEach(() => {
-    getAccountNotificationDefaultsMock.mockReset();
+    getEffectiveNotificationSettingMock.mockReset();
     findSpecialistByIdMock.mockReset();
     sendAppointmentNotificationEmailMock.mockReset();
   });
 
   it('does not send when notification type disabled', async () => {
-    getAccountNotificationDefaultsMock.mockResolvedValue([
-      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: false, sendTimings: ['24h'], frequency: 'immediate' },
-    ]);
+    getEffectiveNotificationSettingMock.mockResolvedValue(
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: false, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
+    );
 
     const result = await sendAppointmentNotificationByType({
       accountId: 1,
@@ -55,9 +55,9 @@ describe('appointment notification service unit', () => {
   });
 
   it('sends via email when enabled', async () => {
-    getAccountNotificationDefaultsMock.mockResolvedValue([
-      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: true, sendTimings: ['24h'], frequency: 'immediate' },
-    ]);
+    getEffectiveNotificationSettingMock.mockResolvedValue(
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: true, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
+    );
     findSpecialistByIdMock.mockResolvedValue({ name: 'Dr. Test' });
     sendAppointmentNotificationEmailMock.mockResolvedValue(true);
 
@@ -85,5 +85,34 @@ describe('appointment notification service unit', () => {
 
     expect(result.delivered).toBe(true);
     expect(sendAppointmentNotificationEmailMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns client_deny when denied by client channel override (edge case)', async () => {
+    getEffectiveNotificationSettingMock.mockResolvedValue(
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: false, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: true },
+    );
+
+    const result = await sendAppointmentNotificationByType({
+      accountId: 1,
+      notificationType: 'appointment_reminder',
+      appointment: {
+        id: 1,
+        account_id: 1,
+        specialist_id: 1,
+        appointment_at: new Date(),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 5,
+        service_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        client_email: 'a@b.com',
+      },
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toBe('client_deny');
   });
 });

--- a/server/tests/settings.notification-defaults.unit.test.ts
+++ b/server/tests/settings.notification-defaults.unit.test.ts
@@ -3,14 +3,29 @@ import {
   NOTIFICATION_TYPES,
   buildDefaultAccountNotificationSettings,
   getAccountNotificationDefaults,
+  getEffectiveNotificationSetting,
 } from '../src/services/notificationSettingsService.js';
 
 const ensureAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
 const findAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+const findSpecialistNotificationSettingsMock = vi.hoisted(() => vi.fn());
+const upsertSpecialistNotificationSettingsMock = vi.hoisted(() => vi.fn());
+const findClientNotificationSettingsMock = vi.hoisted(() => vi.fn());
+const upsertClientNotificationSettingsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/repositories/accountNotificationDefaultsRepository.js', () => ({
   ensureAccountNotificationDefaults: ensureAccountNotificationDefaultsMock,
   findAccountNotificationDefaults: findAccountNotificationDefaultsMock,
+}));
+
+vi.mock('../src/repositories/specialistNotificationSettingsRepository.js', () => ({
+  findSpecialistNotificationSettings: findSpecialistNotificationSettingsMock,
+  upsertSpecialistNotificationSettings: upsertSpecialistNotificationSettingsMock,
+}));
+
+vi.mock('../src/repositories/clientNotificationSettingsRepository.js', () => ({
+  findClientNotificationSettings: findClientNotificationSettingsMock,
+  upsertClientNotificationSettings: upsertClientNotificationSettingsMock,
 }));
 
 describe('notification defaults unit', () => {
@@ -59,5 +74,45 @@ describe('notification defaults unit', () => {
 
     const items = await getAccountNotificationDefaults(11);
     expect(items[0]?.sendTimings).toEqual([]);
+  });
+
+  it('resolves effective with specialist override over account defaults', async () => {
+    findAccountNotificationDefaultsMock.mockResolvedValue([
+      { notification_type: 'appointment_reminder', preferred_channel: 'email', enabled: true, send_timings: ['24h'], frequency: 'immediate' },
+    ]);
+    findSpecialistNotificationSettingsMock.mockResolvedValue([
+      { notification_type: 'appointment_reminder', preferred_channel: 'email', enabled: false, send_timings: ['1h'], frequency: 'immediate' },
+    ]);
+    findClientNotificationSettingsMock.mockResolvedValue([]);
+
+    const effective = await getEffectiveNotificationSetting({
+      accountId: 1,
+      specialistId: 2,
+      clientId: 3,
+      notificationType: 'appointment_reminder',
+    });
+
+    expect(effective?.enabled).toBe(false);
+    expect(effective?.sendTimings).toEqual(['1h']);
+  });
+
+  it('resolves client deny over enabled specialist/account config (edge case)', async () => {
+    findAccountNotificationDefaultsMock.mockResolvedValue([
+      { notification_type: 'appointment_reminder', preferred_channel: 'email', enabled: true, send_timings: ['24h'], frequency: 'immediate' },
+    ]);
+    findSpecialistNotificationSettingsMock.mockResolvedValue([]);
+    findClientNotificationSettingsMock.mockResolvedValue([
+      { notification_type: 'appointment_reminder', channel: 'email', enabled: false },
+    ]);
+
+    const effective = await getEffectiveNotificationSetting({
+      accountId: 1,
+      specialistId: 2,
+      clientId: 3,
+      notificationType: 'appointment_reminder',
+    });
+
+    expect(effective?.enabled).toBe(false);
+    expect(effective?.deniedByClient).toBe(true);
   });
 });

--- a/server/tests/settings.notification-overrides.routes.smoke.test.ts
+++ b/server/tests/settings.notification-overrides.routes.smoke.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import { createApp } from '../src/app.js';
+import { WebUserRole } from '../src/types/webUserRole.js';
+
+const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
+const getSpecialistNotificationSettingsMock = vi.hoisted(() => vi.fn());
+const getClientNotificationSettingsMock = vi.hoisted(() => vi.fn());
+const getEffectiveNotificationSettingMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/authService.js', () => ({
+  resolveUserByAccessToken: resolveUserByAccessTokenMock,
+}));
+
+vi.mock('../src/services/settingsService.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/services/settingsService.js')>('../src/services/settingsService.js');
+  return {
+    ...actual,
+    getSpecialistNotificationSettings: getSpecialistNotificationSettingsMock,
+    getClientNotificationSettings: getClientNotificationSettingsMock,
+    getEffectiveNotificationSetting: getEffectiveNotificationSettingMock,
+  };
+});
+
+const authedUser = {
+  id: '101',
+  accountId: 1,
+  email: 'owner@example.com',
+  role: WebUserRole.Owner,
+  passwordSalt: 'salt',
+  passwordHash: 'hash',
+  createdAt: '2026-04-22T09:00:00.000Z',
+};
+
+describe('settings notification overrides routes smoke', () => {
+  const app = createApp();
+  let baseUrl = '';
+  let server: Awaited<ReturnType<typeof app.listen>>;
+
+  beforeAll(async () => {
+    server = await new Promise((resolve) => {
+      const started = app.listen(0, () => resolve(started));
+    });
+
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    resolveUserByAccessTokenMock.mockReset();
+    getSpecialistNotificationSettingsMock.mockReset();
+    getClientNotificationSettingsMock.mockReset();
+    getEffectiveNotificationSettingMock.mockReset();
+
+    resolveUserByAccessTokenMock.mockResolvedValue(authedUser);
+  });
+
+  it('GET /api/settings/specialist-notification-settings returns settings items', async () => {
+    getSpecialistNotificationSettingsMock.mockResolvedValue([
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: true, sendTimings: ['24h'], frequency: 'immediate' },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/settings/specialist-notification-settings?specialistId=5`, {
+      method: 'GET',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ items: [{ notificationType: 'appointment_reminder' }] });
+  });
+
+  it('GET /api/settings/client-notification-settings returns 400 for unresolved client edge case', async () => {
+    getClientNotificationSettingsMock.mockResolvedValue(null);
+
+    const response = await fetch(`${baseUrl}/api/settings/client-notification-settings`, {
+      method: 'GET',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('GET /api/settings/effective-notification-setting returns merged payload', async () => {
+    getEffectiveNotificationSettingMock.mockResolvedValue({
+      notificationType: 'appointment_reminder',
+      preferredChannel: 'email',
+      enabled: false,
+      sendTimings: ['1h'],
+      frequency: 'immediate',
+      deniedByClient: true,
+    });
+
+    const response = await fetch(`${baseUrl}/api/settings/effective-notification-setting?notificationType=appointment_reminder&specialistId=5&clientId=7`, {
+      method: 'GET',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ deniedByClient: true, enabled: false });
+  });
+});

--- a/settings-rework-plan.md
+++ b/settings-rework-plan.md
@@ -15,6 +15,11 @@
 4. Тестовое покрытие для `specialist_booking_policies`:
    - frontend: интеграционный smoke-контракт для загрузки/сохранения и UI-полей;
    - backend: unit-тесты схемы/доступов и route-smoke для `GET/PUT /api/settings/specialist-booking-policy`.
+5. Закрыт server MVP-блок по notification settings overrides:
+   - добавлены server endpoints для `specialist_notification_settings` и `client_notification_settings`;
+   - добавлен endpoint effective settings с приоритетом `account -> specialist -> client deny`;
+   - `appointmentNotificationService` переведён на effective pipeline (с причиной `client_deny` для deny-case);
+   - покрыто unit + route-smoke тестами для edge scenarios приоритетов и deny.
 
 ### ⏭️ Следующая итерация
 
@@ -31,13 +36,13 @@
 - manual notify endpoint использует общий email dispatch.
 
 **Осталось реализовать:**
-1. **Effective settings pipeline**
-   - считать итоговые настройки по цепочке `account -> specialist -> client`;
-   - учитывать `client_notification_settings.enabled=false` как deny на канал.
+1. **Effective settings pipeline** ✅ (server MVP)
+   - реализован расчёт итоговых настроек по цепочке `account -> specialist -> client`;
+   - реализован deny на канал при `client_notification_settings.enabled=false`.
 
-2. **Specialist/Client overrides API + права**
-   - CRUD/read endpoints для `specialist_notification_settings` и `client_notification_settings`;
-   - role-gates и scope-проверки (owner/admin/specialist/client).
+2. **Specialist/Client overrides API + права** ✅ (server MVP)
+   - добавлены read/update endpoints для `specialist_notification_settings` и `client_notification_settings`;
+   - реализованы scope-проверки: owner/admin/specialist/client (в рамках MVP read/update сценариев).
 
 3. **Fallback channels (после email MVP)**
    - добавить реальные провайдеры/адаптеры для `viber`, `whatsapp`, `sms`;
@@ -62,10 +67,10 @@
    - управление таймингами и preview effective settings.
 
 8. **Тесты (edge cases, обязательно):**
-   - приоритет переопределений (account vs specialist vs client deny);
-   - поведение fallback-цепочки при частичных отказах каналов;
-   - дедуп и retry после рестарта job-процесса;
-   - корректность окон таймингов на границах (±1 мин, DST, timezone).
+   - ✅ приоритет переопределений (account vs specialist vs client deny);
+   - ⏳ поведение fallback-цепочки при частичных отказах каналов;
+   - ⏳ дедуп и retry после рестарта job-процесса;
+   - ⏳ корректность окон таймингов на границах (±1 мин, DST, timezone).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Implement server-side notification overrides and an `effective` settings resolver to follow the `account -> specialist -> client` priority model from the settings rework plan.
- Surface client-level denies (channel opt-outs) into delivery decisions so scheduler and manual sends respect recipient preferences.
- Cover edge cases with focused unit and route-smoke tests to ensure correct priority/deny behavior.

### Description
- Added repositories `specialistNotificationSettingsRepository` and `clientNotificationSettingsRepository` with `find` and `upsert` behavior for the new tables.
- Extended schemas with batch validation: `specialistNotificationSettingsBatchSchema` and `clientNotificationSettingsBatchSchema` for server-side payload checks. 
- Implemented notification settings service extensions: read/update helpers for specialist/client overrides and `getEffectiveNotificationSetting` that resolves `account -> specialist -> client deny` and returns `deniedByClient`. 
- Exposed new endpoints in settings routes: `GET/PUT /api/settings/specialist-notification-settings`, `GET/PUT /api/settings/client-notification-settings`, and `GET /api/settings/effective-notification-setting`. 
- Updated `settingsService` with role-scoped resolution for specialists and clients and plumbing to the new notification service functions. 
- Switched `appointmentNotificationService` to use the effective pipeline and added explicit `client_deny` reason for delivery decisions. 
- Added unit and route-smoke tests covering override priority, client deny behavior, and route surface for the new endpoints, and updated `settings-rework-plan.md` to mark completed server work.

### Testing
- Ran typecheck with `npm run typecheck` in `server` and it completed successfully. 
- Ran unit and smoke tests via `vitest` (with `DATABASE_PUBLIC_URL` provided during route-smoke runs): the targeted test runs passed: `tests/settings.notification-defaults.unit.test.ts`, `tests/appointment-notification.service.unit.test.ts`, `tests/settings.notification-overrides.routes.smoke.test.ts`, `tests/settings.notification-defaults.routes.smoke.test.ts`, and `tests/appointment-notifications.job.unit.test.ts` all passed when executed with the test DB connection. 
- Note: an initial test run failed without `DATABASE_PUBLIC_URL` (expected missing-env), then subsequent runs with `DATABASE_PUBLIC_URL=...` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1469466c833392d3a759a3b9ca18)