### PR TITLE
feat: add Notifications tab + account notification defaults API and multi-channel support (incl. Telegram)

### DIFF
--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -131,7 +131,7 @@ export const specialistBookingPolicySchema = z.object({
 }).partial();
 
 const notificationTypeSchema = z.enum(['appointment_created', 'appointment_reminder', 'payment_reminder']);
-const notificationChannelSchema = z.enum(['email', 'viber', 'whatsapp', 'sms']);
+const notificationChannelSchema = z.enum(['email', 'telegram', 'viber', 'whatsapp', 'sms']);
 const notificationFrequencySchema = z.enum(['immediate', 'daily']);
 
 export const specialistNotificationSettingsPatchSchema = z.object({
@@ -144,6 +144,10 @@ export const specialistNotificationSettingsPatchSchema = z.object({
 
 export const specialistNotificationSettingsBatchSchema = z.object({
   items: z.array(specialistNotificationSettingsPatchSchema).max(64),
+});
+
+export const accountNotificationDefaultsBatchSchema = z.object({
+  items: z.array(specialistNotificationSettingsPatchSchema).max(128),
 });
 
 export const clientNotificationSettingsPatchSchema = z.object({

--- a/server/src/db/migrations/20260426170000_add_telegram_channel_to_notification_settings.ts
+++ b/server/src/db/migrations/20260426170000_add_telegram_channel_to_notification_settings.ts
@@ -1,0 +1,35 @@
+import type { Knex } from 'knex';
+
+const CHANNELS = ['email', 'telegram', 'viber', 'whatsapp', 'sms'];
+
+function buildInClause(values: string[]) {
+  return values.map((value) => `'${value}'`).join(', ');
+}
+
+async function replaceChannelCheck(knex: Knex, tableName: string, columnName: string) {
+  const constraintName = `${tableName}_${columnName}_check`;
+  await knex.raw(`ALTER TABLE "${tableName}" DROP CONSTRAINT IF EXISTS "${constraintName}"`);
+  await knex.raw(
+    `ALTER TABLE "${tableName}" ADD CONSTRAINT "${constraintName}" CHECK ("${columnName}" IN (${buildInClause(CHANNELS)}))`,
+  );
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await replaceChannelCheck(knex, 'account_notification_defaults', 'preferred_channel');
+  await replaceChannelCheck(knex, 'specialist_notification_settings', 'preferred_channel');
+  await replaceChannelCheck(knex, 'client_notification_settings', 'channel');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const channels = ['email', 'viber', 'whatsapp', 'sms'];
+  const build = (values: string[]) => values.map((value) => `'${value}'`).join(', ');
+
+  await knex.raw('ALTER TABLE "account_notification_defaults" DROP CONSTRAINT IF EXISTS "account_notification_defaults_preferred_channel_check"');
+  await knex.raw(`ALTER TABLE "account_notification_defaults" ADD CONSTRAINT "account_notification_defaults_preferred_channel_check" CHECK ("preferred_channel" IN (${build(channels)}))`);
+
+  await knex.raw('ALTER TABLE "specialist_notification_settings" DROP CONSTRAINT IF EXISTS "specialist_notification_settings_preferred_channel_check"');
+  await knex.raw(`ALTER TABLE "specialist_notification_settings" ADD CONSTRAINT "specialist_notification_settings_preferred_channel_check" CHECK ("preferred_channel" IN (${build(channels)}))`);
+
+  await knex.raw('ALTER TABLE "client_notification_settings" DROP CONSTRAINT IF EXISTS "client_notification_settings_channel_check"');
+  await knex.raw(`ALTER TABLE "client_notification_settings" ADD CONSTRAINT "client_notification_settings_channel_check" CHECK ("channel" IN (${build(channels)}))`);
+}

--- a/server/src/repositories/accountNotificationDefaultsRepository.ts
+++ b/server/src/repositories/accountNotificationDefaultsRepository.ts
@@ -53,3 +53,34 @@ export async function listAccountIdsWithoutNotificationDefaults(limit: number): 
 
   return rows.map((row) => row.id);
 }
+
+export async function upsertAccountNotificationDefaults(
+  accountId: number,
+  items: Array<{
+    notificationType: string;
+    preferredChannel: string;
+    enabled: boolean;
+    sendTimings: string[];
+    frequency: string;
+  }>,
+): Promise<void> {
+  await db('account_notification_defaults').where({ account_id: accountId }).del();
+
+  if (items.length === 0) {
+    return;
+  }
+
+  await db('account_notification_defaults')
+    .insert(
+      items.map((item) => ({
+        account_id: accountId,
+        notification_type: item.notificationType,
+        preferred_channel: item.preferredChannel,
+        enabled: item.enabled,
+        send_timings: JSON.stringify(item.sendTimings),
+        frequency: item.frequency,
+        created_at: db.fn.now(),
+        updated_at: db.fn.now(),
+      })),
+    );
+}

--- a/server/src/routes/settingsRoutes.ts
+++ b/server/src/routes/settingsRoutes.ts
@@ -18,6 +18,7 @@ import {
   getEffectiveNotificationSetting,
   getSpecialistNotificationSettings,
   putClientNotificationSettings,
+  putAccountNotificationDefaults,
   putSpecialistNotificationSettings,
 } from '../services/settingsService.js';
 
@@ -77,6 +78,20 @@ settingsRoutes.get('/account-notification-defaults', requireAccessToken, async (
   }
 
   return res.json({ items: await getAccountNotificationDefaults(user) });
+});
+
+settingsRoutes.put('/account-notification-defaults', requireAccessToken, async (req, res) => {
+  const user = (req as AuthedRequest).user;
+  if (!canManageAccountSettings(user.role)) {
+    return res.status(403).json({ message: t(req, 'forbiddenAccountSettings') });
+  }
+
+  const items = await putAccountNotificationDefaults(user, req.body);
+  if (!items) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  return res.json({ items });
 });
 
 settingsRoutes.get('/specialist-notification-settings', requireAccessToken, async (req, res) => {

--- a/server/src/services/appointmentNotificationService.ts
+++ b/server/src/services/appointmentNotificationService.ts
@@ -37,7 +37,8 @@ export async function sendAppointmentNotificationByType(input: {
       return { delivered: false, channel: null, reason: active.deniedByClient ? 'client_deny' : 'disabled' };
     }
 
-    if (active.preferredChannel !== 'email') {
+    const firstSupportedChannel = active.deliveryChannels.find((item) => item === 'email');
+    if (!firstSupportedChannel) {
       return { delivered: false, channel: null, reason: 'unsupported_channel' };
     }
   }

--- a/server/src/services/notificationSettingsService.ts
+++ b/server/src/services/notificationSettingsService.ts
@@ -1,4 +1,8 @@
-import { ensureAccountNotificationDefaults, findAccountNotificationDefaults } from '../repositories/accountNotificationDefaultsRepository.js';
+import {
+  ensureAccountNotificationDefaults,
+  findAccountNotificationDefaults,
+  upsertAccountNotificationDefaults,
+} from '../repositories/accountNotificationDefaultsRepository.js';
 import {
   findSpecialistNotificationSettings,
   upsertSpecialistNotificationSettings,
@@ -9,11 +13,12 @@ import {
 } from '../repositories/clientNotificationSettingsRepository.js';
 import {
   clientNotificationSettingsBatchSchema,
+  accountNotificationDefaultsBatchSchema,
   specialistNotificationSettingsBatchSchema,
 } from '../config/schemas.js';
 
 export const NOTIFICATION_TYPES = ['appointment_created', 'appointment_reminder', 'payment_reminder'] as const;
-export const NOTIFICATION_CHANNELS = ['email', 'viber', 'whatsapp', 'sms'] as const;
+export const NOTIFICATION_CHANNELS = ['email', 'telegram', 'viber', 'whatsapp', 'sms'] as const;
 export const NOTIFICATION_FREQUENCIES = ['immediate', 'daily'] as const;
 
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
@@ -38,6 +43,7 @@ export type ClientNotificationSetting = {
 export type EffectiveNotificationSetting = {
   notificationType: NotificationType;
   preferredChannel: NotificationChannel;
+  deliveryChannels: NotificationChannel[];
   enabled: boolean;
   sendTimings: string[];
   frequency: NotificationFrequency;
@@ -102,6 +108,19 @@ export async function getAccountNotificationDefaults(accountId: number): Promise
       frequency: row.frequency as NotificationFrequency,
     }))
     .sort((a, b) => a.notificationType.localeCompare(b.notificationType));
+}
+
+export async function putAccountNotificationDefaults(
+  accountId: number,
+  payload: unknown,
+): Promise<AccountNotificationDefault[] | null> {
+  const parsed = accountNotificationDefaultsBatchSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+
+  await upsertAccountNotificationDefaults(accountId, parsed.data.items);
+  return getAccountNotificationDefaults(accountId);
 }
 
 function toAccountLikeSettings(rows: Array<{
@@ -177,24 +196,36 @@ export async function getEffectiveNotificationSetting(input: {
   notificationType: NotificationType;
 }): Promise<EffectiveNotificationSetting | null> {
   const accountSettings = await getAccountNotificationDefaults(input.accountId);
-  const accountBase = accountSettings.find((item) => item.notificationType === input.notificationType);
+  const channelPriority = NOTIFICATION_CHANNELS;
+  const accountBaseItems = accountSettings
+    .filter((item) => item.notificationType === input.notificationType)
+    .sort((a, b) => channelPriority.indexOf(a.preferredChannel) - channelPriority.indexOf(b.preferredChannel));
+  const accountBase = accountBaseItems[0];
   if (!accountBase) {
     return null;
   }
 
   const specialistSettings = await getSpecialistNotificationSettings(input.accountId, input.specialistId);
-  const specialistOverride = specialistSettings.find((item) => item.notificationType === input.notificationType);
-  const picked = specialistOverride ?? accountBase;
+  const specialistItems = specialistSettings
+    .filter((item) => item.notificationType === input.notificationType)
+    .sort((a, b) => channelPriority.indexOf(a.preferredChannel) - channelPriority.indexOf(b.preferredChannel));
+  const pickedItems = specialistItems.length > 0 ? specialistItems : accountBaseItems;
+  const picked = pickedItems[0];
 
   const clientSettings = await getClientNotificationSettings(input.accountId, input.clientId);
-  const deny = clientSettings.find((item) =>
-    item.notificationType === input.notificationType
-    && item.channel === picked.preferredChannel
-    && !item.enabled);
+  const deniedChannels = new Set(
+    clientSettings
+      .filter((item) => item.notificationType === input.notificationType && !item.enabled)
+      .map((item) => item.channel),
+  );
+  const deliveryChannels = pickedItems
+    .filter((item) => item.enabled && !deniedChannels.has(item.preferredChannel))
+    .map((item) => item.preferredChannel);
 
   return {
     ...picked,
-    enabled: picked.enabled && !Boolean(deny),
-    deniedByClient: Boolean(deny),
+    deliveryChannels,
+    enabled: picked.enabled && deliveryChannels.length > 0,
+    deniedByClient: !deliveryChannels.includes(picked.preferredChannel),
   };
 }

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -29,6 +29,7 @@ import {
   getAccountNotificationDefaults as getAccountNotificationDefaultsCore,
   getClientNotificationSettings as getClientNotificationSettingsCore,
   getEffectiveNotificationSetting as getEffectiveNotificationSettingCore,
+  putAccountNotificationDefaults as putAccountNotificationDefaultsCore,
   getSpecialistNotificationSettings as getSpecialistNotificationSettingsCore,
   putClientNotificationSettings as putClientNotificationSettingsCore,
   putSpecialistNotificationSettings as putSpecialistNotificationSettingsCore,
@@ -350,6 +351,10 @@ export async function updateSpecialistBookingPolicy(
 
 export async function getAccountNotificationDefaults(actor: User) {
   return getAccountNotificationDefaultsCore(actor.accountId);
+}
+
+export async function putAccountNotificationDefaults(actor: User, payload: unknown) {
+  return putAccountNotificationDefaultsCore(actor.accountId, payload);
 }
 
 async function resolveSpecialistIdForNotifications(actor: User, specialistId?: number): Promise<number | null> {

--- a/server/tests/appointment-notification.service.unit.test.ts
+++ b/server/tests/appointment-notification.service.unit.test.ts
@@ -26,7 +26,7 @@ describe('appointment notification service unit', () => {
 
   it('does not send when notification type disabled', async () => {
     getEffectiveNotificationSettingMock.mockResolvedValue(
-      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: false, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', deliveryChannels: [], enabled: false, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
     );
 
     const result = await sendAppointmentNotificationByType({
@@ -56,7 +56,7 @@ describe('appointment notification service unit', () => {
 
   it('sends via email when enabled', async () => {
     getEffectiveNotificationSettingMock.mockResolvedValue(
-      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: true, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', deliveryChannels: ['email'], enabled: true, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
     );
     findSpecialistByIdMock.mockResolvedValue({ name: 'Dr. Test' });
     sendAppointmentNotificationEmailMock.mockResolvedValue(true);
@@ -89,7 +89,7 @@ describe('appointment notification service unit', () => {
 
   it('returns client_deny when denied by client channel override (edge case)', async () => {
     getEffectiveNotificationSettingMock.mockResolvedValue(
-      { notificationType: 'appointment_reminder', preferredChannel: 'email', enabled: false, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: true },
+      { notificationType: 'appointment_reminder', preferredChannel: 'email', deliveryChannels: [], enabled: false, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: true },
     );
 
     const result = await sendAppointmentNotificationByType({

--- a/server/tests/settings.notification-defaults.routes.smoke.test.ts
+++ b/server/tests/settings.notification-defaults.routes.smoke.test.ts
@@ -5,6 +5,7 @@ import { WebUserRole } from '../src/types/webUserRole.js';
 
 const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
 const getAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
+const putAccountNotificationDefaultsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/services/authService.js', () => ({
   resolveUserByAccessToken: resolveUserByAccessTokenMock,
@@ -15,6 +16,7 @@ vi.mock('../src/services/settingsService.js', async () => {
   return {
     ...actual,
     getAccountNotificationDefaults: getAccountNotificationDefaultsMock,
+    putAccountNotificationDefaults: putAccountNotificationDefaultsMock,
   };
 });
 
@@ -51,6 +53,7 @@ describe('settings account notification defaults route-smoke scenarios (mocked s
   beforeEach(() => {
     resolveUserByAccessTokenMock.mockReset();
     getAccountNotificationDefaultsMock.mockReset();
+    putAccountNotificationDefaultsMock.mockReset();
 
     resolveUserByAccessTokenMock.mockResolvedValue(authedUser);
   });
@@ -91,5 +94,39 @@ describe('settings account notification defaults route-smoke scenarios (mocked s
     });
 
     expect(response.status).toBe(403);
+  });
+
+  it('PUT /api/settings/account-notification-defaults stores defaults', async () => {
+    putAccountNotificationDefaultsMock.mockResolvedValue([
+      {
+        notificationType: 'appointment_reminder',
+        preferredChannel: 'email',
+        enabled: true,
+        sendTimings: ['1h'],
+        frequency: 'immediate',
+      },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/settings/account-notification-defaults`, {
+      method: 'PUT',
+      headers: {
+        authorization: 'Bearer smoke-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [
+          {
+            notificationType: 'appointment_reminder',
+            preferredChannel: 'email',
+            enabled: true,
+            sendTimings: ['1h'],
+            frequency: 'immediate',
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(putAccountNotificationDefaultsMock).toHaveBeenCalledOnce();
   });
 });

--- a/settings-rework-plan.md
+++ b/settings-rework-plan.md
@@ -20,10 +20,18 @@
    - добавлен endpoint effective settings с приоритетом `account -> specialist -> client deny`;
    - `appointmentNotificationService` переведён на effective pipeline (с причиной `client_deny` для deny-case);
    - покрыто unit + route-smoke тестами для edge scenarios приоритетов и deny.
+6. Web: начата и реализована UX-версия настроек оповещений:
+   - отдельная вкладка в Settings для каналов и таймингов;
+   - выбор каналов: `email`, `telegram`, `viber`, `sms`, `whatsapp`;
+   - multi-select для `appointment_reminder` и `payment_reminder` с диапазоном `1h..71h` и шагом `2h`;
+   - добавлен вариант `Disabled` для отключения каждого reminder-типа.
+7. Server: добавлено сохранение account notification defaults через `PUT /api/settings/account-notification-defaults`.
+8. Server: обновлена логика выбора канала отправки (учёт fallback-цепочки, skip неподдержанных каналов с попыткой перейти к доступному `email`).
+9. Server/DB: добавлена поддержка канала `telegram` в валидации и DB check constraints для notification settings таблиц.
 
 ### ⏭️ Следующая итерация
 
-1. Доработка отправки оповещений (см. чеклист ниже: effective settings, specialist/client overrides, fallback channels, retries, observability).
+1. Доработка отправки оповещений (см. чеклист ниже: реальные провайдеры каналов, retries, observability).
 2. Авто-отмена неоплаченных записей через scheduler/jobs.
 3. Полная сквозная UX-поддержка последствий поздней отмены (refund/no-refund) в web и bot.
 
@@ -45,8 +53,8 @@
    - реализованы scope-проверки: owner/admin/specialist/client (в рамках MVP read/update сценариев).
 
 3. **Fallback channels (после email MVP)**
-   - добавить реальные провайдеры/адаптеры для `viber`, `whatsapp`, `sms`;
-   - включить последовательный fallback по `preferred_channel`.
+   - ✅ включен выбор fallback-цепочки на уровне effective settings;
+   - ⏳ добавить реальные провайдеры/адаптеры для `telegram`, `viber`, `whatsapp`, `sms`.
 
 4. **Надёжность доставки**
    - retry policy (`pending/retry/failed`) для scheduler-отправок;
@@ -62,9 +70,10 @@
    - диагностические причины skip (`disabled`, `no-contact`, `client-deny`, `unsupported-channel`).
 
 7. **Frontend + UX**
-   - единый экран матрицы `notification_type × channel`;
-   - секции account/specialist/client;
-   - управление таймингами и preview effective settings.
+   - ✅ добавлен account-экран управления каналами и reminder-таймингами;
+   - ⏳ расширить до полной матрицы `notification_type × channel`;
+   - ⏳ секции specialist/client;
+   - ⏳ preview effective settings.
 
 8. **Тесты (edge cases, обязательно):**
    - ✅ приоритет переопределений (account vs specialist vs client deny);

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -1,7 +1,14 @@
-import { Box, FormControlLabel, Stack, Switch, Typography } from '@mui/material';
+import { Box, Checkbox, FormControl, FormControlLabel, InputLabel, ListItemText, MenuItem, Select, Stack, Switch, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import type { AccountSettings, SpecialistBookingPolicy, SystemSettings, UserSettings } from '../shared/types/api';
+import type {
+  AccountNotificationDefault,
+  AccountSettings,
+  NotificationChannel,
+  SpecialistBookingPolicy,
+  SystemSettings,
+  UserSettings,
+} from '../shared/types/api';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
 import { AppIcons } from '../shared/ui/AppIcons';
@@ -14,6 +21,7 @@ type SettingsCardCopy = {
   accountTab: string;
   userTab: string;
   specialistPolicyTab: string;
+  notificationsTab: string;
   systemTitle: string;
   accountTitle: string;
   userTitle: string;
@@ -41,6 +49,12 @@ type SettingsCardCopy = {
   refundOnLateCancel: string;
   autoCancelUnpaidEnabled: string;
   unpaidAutoCancelAfterHours: string;
+  notificationSettingsTitle: string;
+  reminderChannelsLabel: string;
+  appointmentReminderTimingsLabel: string;
+  paymentReminderTimingsLabel: string;
+  disabledOption: string;
+  channels: Record<NotificationChannel, string>;
 };
 
 type SettingsCardProps = {
@@ -48,6 +62,7 @@ type SettingsCardProps = {
   accountSettings: AccountSettings;
   userSettings: UserSettings;
   specialistBookingPolicy: SpecialistBookingPolicy;
+  accountNotificationDefaults: AccountNotificationDefault[];
   copy: SettingsCardCopy;
   canManageSystemSettings: boolean;
   canManageAccountSettings: boolean;
@@ -58,10 +73,12 @@ type SettingsCardProps = {
   isSavingAccount?: boolean;
   isSavingUser?: boolean;
   isSavingSpecialistBookingPolicy?: boolean;
+  isSavingNotificationDefaults?: boolean;
   onSaveSystem: (next: SystemSettings) => Promise<void> | void;
   onSaveAccount: (next: AccountSettings) => Promise<void> | void;
   onSaveUser: (next: UserSettings) => Promise<void> | void;
   onSaveSpecialistBookingPolicy: (next: SpecialistBookingPolicy) => Promise<void> | void;
+  onSaveNotificationDefaults: (items: AccountNotificationDefault[]) => Promise<void> | void;
   onClearTelegramBotToken: () => Promise<void> | void;
   onConnectGoogle: () => void;
   onDisconnectGoogle: () => void;
@@ -72,6 +89,7 @@ export function SettingsCard({
   accountSettings,
   userSettings,
   specialistBookingPolicy,
+  accountNotificationDefaults,
   copy,
   canManageSystemSettings,
   canManageAccountSettings,
@@ -82,15 +100,19 @@ export function SettingsCard({
   isSavingAccount = false,
   isSavingUser = false,
   isSavingSpecialistBookingPolicy = false,
+  isSavingNotificationDefaults = false,
   onSaveSystem,
   onSaveAccount,
   onSaveUser,
   onSaveSpecialistBookingPolicy,
+  onSaveNotificationDefaults,
   onClearTelegramBotToken,
   onConnectGoogle,
   onDisconnectGoogle
 }: SettingsCardProps) {
-  const [tab, setTab] = useState(canManageSystemSettings ? 0 : canManageAccountSettings ? 1 : canManageSpecialistBookingPolicy ? 2 : 3);
+  const timingOptions = ['disabled', ...Array.from({ length: 36 }, (_, index) => `${index * 2 + 1}h`)];
+  const selectableChannels: NotificationChannel[] = ['email', 'telegram', 'viber', 'sms', 'whatsapp'];
+  const [tab, setTab] = useState(canManageSystemSettings ? 0 : canManageAccountSettings ? 1 : canManageSpecialistBookingPolicy ? 2 : 4);
 
   const { control: systemControl, handleSubmit: handleSystemSubmit, reset: resetSystem } = useForm<SystemSettings>({
     defaultValues: systemSettings
@@ -105,6 +127,17 @@ export function SettingsCard({
   });
   const { control: specialistPolicyControl, handleSubmit: handleSpecialistPolicySubmit, reset: resetSpecialistPolicy } = useForm<SpecialistBookingPolicy>({
     defaultValues: specialistBookingPolicy
+  });
+  const { control: notificationDefaultsControl, handleSubmit: handleNotificationDefaultsSubmit, reset: resetNotificationDefaults } = useForm<{
+    channels: NotificationChannel[];
+    appointmentReminderTimings: string[];
+    paymentReminderTimings: string[];
+  }>({
+    defaultValues: {
+      channels: ['email'],
+      appointmentReminderTimings: ['disabled'],
+      paymentReminderTimings: ['disabled'],
+    }
   });
 
   useEffect(() => {
@@ -121,6 +154,21 @@ export function SettingsCard({
   useEffect(() => {
     resetSpecialistPolicy(specialistBookingPolicy);
   }, [resetSpecialistPolicy, specialistBookingPolicy]);
+  useEffect(() => {
+    const defaultsByType = new Map(accountNotificationDefaults.map((item) => [item.notificationType, item]));
+    const reminder = defaultsByType.get('appointment_reminder');
+    const payment = defaultsByType.get('payment_reminder');
+    const channels = accountNotificationDefaults
+      .filter((item) => item.enabled)
+      .map((item) => item.preferredChannel)
+      .filter((item, index, list) => list.indexOf(item) === index);
+
+    resetNotificationDefaults({
+      channels: channels.length > 0 ? channels : ['email'],
+      appointmentReminderTimings: reminder?.enabled ? reminder.sendTimings : ['disabled'],
+      paymentReminderTimings: payment?.enabled ? payment.sendTimings : ['disabled'],
+    });
+  }, [accountNotificationDefaults, resetNotificationDefaults]);
 
   return (
     <Box>
@@ -128,6 +176,7 @@ export function SettingsCard({
         <AppTab label={copy.systemTab} disabled={!canManageSystemSettings} />
         <AppTab label={copy.accountTab} disabled={!canManageAccountSettings} />
         <AppTab label={copy.specialistPolicyTab} disabled={!canManageSpecialistBookingPolicy} />
+        <AppTab label={copy.notificationsTab} disabled={!canManageAccountSettings} />
         <AppTab label={copy.userTab} />
       </AppTabs>
 
@@ -326,7 +375,130 @@ export function SettingsCard({
         </AppForm>
       )}
 
-      {tab === 3 && (
+      {tab === 3 && canManageAccountSettings && (
+        <AppForm
+          component="form"
+          onSubmit={handleNotificationDefaultsSubmit((values) => {
+            const enabledChannels = values.channels;
+            const appointmentEnabled = !values.appointmentReminderTimings.includes('disabled');
+            const paymentEnabled = !values.paymentReminderTimings.includes('disabled');
+            const appointmentTimings = values.appointmentReminderTimings.filter((item) => item !== 'disabled');
+            const paymentTimings = values.paymentReminderTimings.filter((item) => item !== 'disabled');
+
+            const next: AccountNotificationDefault[] = enabledChannels.flatMap((channel) => ([
+              {
+                notificationType: 'appointment_created',
+                preferredChannel: channel,
+                enabled: true,
+                sendTimings: ['immediate'],
+                frequency: 'immediate',
+              },
+              {
+                notificationType: 'appointment_reminder',
+                preferredChannel: channel,
+                enabled: appointmentEnabled,
+                sendTimings: appointmentEnabled ? appointmentTimings : [],
+                frequency: 'immediate',
+              },
+              {
+                notificationType: 'payment_reminder',
+                preferredChannel: channel,
+                enabled: paymentEnabled,
+                sendTimings: paymentEnabled ? paymentTimings : [],
+                frequency: 'daily',
+              },
+            ]));
+
+            return onSaveNotificationDefaults(next);
+          })}
+        >
+          <Typography variant="h5">{copy.notificationSettingsTitle}</Typography>
+
+          <Controller
+            name="channels"
+            control={notificationDefaultsControl}
+            render={({ field }: any) => (
+              <FormControl>
+                <InputLabel id="notification-channels-label">{copy.reminderChannelsLabel}</InputLabel>
+                <Select
+                  {...field}
+                  labelId="notification-channels-label"
+                  label={copy.reminderChannelsLabel}
+                  multiple
+                  value={field.value}
+                  onChange={(event) => field.onChange(event.target.value as NotificationChannel[])}
+                  renderValue={(selected) => (selected as NotificationChannel[]).map((item) => copy.channels[item]).join(', ')}
+                >
+                  {selectableChannels.map((channel) => (
+                    <MenuItem key={channel} value={channel}>
+                      <Checkbox checked={(field.value as NotificationChannel[]).includes(channel)} />
+                      <ListItemText primary={copy.channels[channel]} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+
+          <Controller
+            name="appointmentReminderTimings"
+            control={notificationDefaultsControl}
+            render={({ field }: any) => (
+              <FormControl>
+                <InputLabel id="appointment-reminder-timings-label">{copy.appointmentReminderTimingsLabel}</InputLabel>
+                <Select
+                  {...field}
+                  labelId="appointment-reminder-timings-label"
+                  label={copy.appointmentReminderTimingsLabel}
+                  multiple
+                  value={field.value}
+                  onChange={(event) => field.onChange(event.target.value as string[])}
+                  renderValue={(selected) => (selected as string[]).map((item) => item === 'disabled' ? copy.disabledOption : item).join(', ')}
+                >
+                  {timingOptions.map((timing) => (
+                    <MenuItem key={timing} value={timing}>
+                      <Checkbox checked={(field.value as string[]).includes(timing)} />
+                      <ListItemText primary={timing === 'disabled' ? copy.disabledOption : timing} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+
+          <Controller
+            name="paymentReminderTimings"
+            control={notificationDefaultsControl}
+            render={({ field }: any) => (
+              <FormControl>
+                <InputLabel id="payment-reminder-timings-label">{copy.paymentReminderTimingsLabel}</InputLabel>
+                <Select
+                  {...field}
+                  labelId="payment-reminder-timings-label"
+                  label={copy.paymentReminderTimingsLabel}
+                  multiple
+                  value={field.value}
+                  onChange={(event) => field.onChange(event.target.value as string[])}
+                  renderValue={(selected) => (selected as string[]).map((item) => item === 'disabled' ? copy.disabledOption : item).join(', ')}
+                >
+                  {timingOptions.map((timing) => (
+                    <MenuItem key={timing} value={timing}>
+                      <Checkbox checked={(field.value as string[]).includes(timing)} />
+                      <ListItemText primary={timing === 'disabled' ? copy.disabledOption : timing} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+
+          <AppButton type="submit" startIcon={<AppIcons.save />} isLoading={isSavingNotificationDefaults}>
+            {copy.saveSettings}
+          </AppButton>
+        </AppForm>
+      )}
+
+      {tab === 4 && (
         <AppForm component="form" onSubmit={handleUserSubmit(onSaveUser)}>
           <Typography variant="h5">{copy.userTitle}</Typography>
 

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '../shared/auth/AuthContext';
 import { useI18n } from '../shared/i18n/I18nContext';
 import { AppPage } from '../shared/ui/AppPage';
 import type {
+  AccountNotificationDefault,
   AccountSettings,
   GoogleOAuthDisconnectResponse,
   GoogleOAuthStartResponse,
@@ -53,6 +54,8 @@ const defaultSpecialistBookingPolicy: SpecialistBookingPolicy = {
   unpaidAutoCancelAfterHours: 72,
 };
 
+const defaultAccountNotificationDefaults: AccountNotificationDefault[] = [];
+
 export function SettingsContainer() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -72,6 +75,8 @@ export function SettingsContainer() {
   const [isLoadingSettings, setIsLoadingSettings] = useState(true);
   const [specialistBookingPolicy, setSpecialistBookingPolicy] = useState<SpecialistBookingPolicy>(defaultSpecialistBookingPolicy);
   const [selectedSpecialistId, setSelectedSpecialistId] = useState<number | null>(null);
+  const [accountNotificationDefaults, setAccountNotificationDefaults] = useState<AccountNotificationDefault[]>(defaultAccountNotificationDefaults);
+  const [isSavingNotificationDefaults, setIsSavingNotificationDefaults] = useState(false);
 
   const googleOauthStatus = useMemo(() => searchParams.get('google_oauth'), [searchParams]);
   const canManageSystemSettings = user?.role === 'owner';
@@ -121,6 +126,11 @@ export function SettingsContainer() {
             headers: authHeaders(accessToken)
           });
           setAccountSettings(accountResponse.data);
+
+          const notificationDefaultsResponse = await apiClient.get<{ items: AccountNotificationDefault[] }>('/api/settings/account-notification-defaults', {
+            headers: authHeaders(accessToken)
+          });
+          setAccountNotificationDefaults(notificationDefaultsResponse.data.items);
         }
 
         if (canManageSystemSettings) {
@@ -183,6 +193,32 @@ export function SettingsContainer() {
       setSuccess('');
     } finally {
       setIsSavingSystem(false);
+    }
+  };
+
+  const saveAccountNotificationDefaults = async (items: AccountNotificationDefault[]) => {
+    if (!accessToken || !canManageAccountSettings) {
+      return;
+    }
+
+    setIsSavingNotificationDefaults(true);
+    try {
+      const response = await apiClient.put<{ items: AccountNotificationDefault[] }>(
+        '/api/settings/account-notification-defaults',
+        { items },
+        { headers: authHeaders(accessToken) }
+      );
+      setAccountNotificationDefaults(response.data.items);
+      setError('');
+      setSuccess('');
+    } catch (err) {
+      setError(resolveApiError(err, {
+        fallbackMessage: t('settings.errors.save'),
+        networkMessage: t('common.errors.network')
+      }).message);
+      setSuccess('');
+    } finally {
+      setIsSavingNotificationDefaults(false);
     }
   };
 
@@ -381,6 +417,7 @@ export function SettingsContainer() {
             accountSettings={accountSettings}
             userSettings={userSettings}
             specialistBookingPolicy={specialistBookingPolicy}
+            accountNotificationDefaults={accountNotificationDefaults}
             canManageSystemSettings={canManageSystemSettings}
             canManageAccountSettings={canManageAccountSettings}
             canManageSpecialistBookingPolicy={canManageSpecialistBookingPolicy}
@@ -415,7 +452,20 @@ export function SettingsContainer() {
               cancelGracePeriodHours: t('settings.cancelGracePeriodHours'),
               refundOnLateCancel: t('settings.refundOnLateCancel'),
               autoCancelUnpaidEnabled: t('settings.autoCancelUnpaidEnabled'),
-              unpaidAutoCancelAfterHours: t('settings.unpaidAutoCancelAfterHours')
+              unpaidAutoCancelAfterHours: t('settings.unpaidAutoCancelAfterHours'),
+              notificationsTab: t('settings.tabs.notifications'),
+              notificationSettingsTitle: t('settings.notificationSettingsTitle'),
+              reminderChannelsLabel: t('settings.reminderChannelsLabel'),
+              appointmentReminderTimingsLabel: t('settings.appointmentReminderTimingsLabel'),
+              paymentReminderTimingsLabel: t('settings.paymentReminderTimingsLabel'),
+              disabledOption: t('settings.disabledOption'),
+              channels: {
+                email: t('settings.channels.email'),
+                telegram: t('settings.channels.telegram'),
+                viber: t('settings.channels.viber'),
+                sms: t('settings.channels.sms'),
+                whatsapp: t('settings.channels.whatsapp')
+              }
             }}
             isGoogleConnecting={isGoogleConnecting}
             isGoogleDisconnecting={isGoogleDisconnecting}
@@ -423,10 +473,12 @@ export function SettingsContainer() {
             isSavingAccount={isSavingAccount}
             isSavingUser={isSavingUser}
             isSavingSpecialistBookingPolicy={isSavingSpecialistPolicy}
+            isSavingNotificationDefaults={isSavingNotificationDefaults}
             onSaveSystem={saveSystemSettings}
             onSaveAccount={saveAccountSettings}
             onSaveUser={saveUserSettings}
             onSaveSpecialistBookingPolicy={saveSpecialistBookingPolicy}
+            onSaveNotificationDefaults={saveAccountNotificationDefaults}
             onClearTelegramBotToken={clearTelegramBotToken}
             onConnectGoogle={connectGoogle}
             onDisconnectGoogle={disconnectGoogle}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -77,6 +77,7 @@ export const dictionaries = {
         system: 'System settings',
         account: 'Account settings',
         specialistPolicy: 'Booking policies',
+        notifications: 'Notifications',
         user: 'User settings'
       },
       systemTitle: 'System settings',
@@ -106,6 +107,18 @@ export const dictionaries = {
       refundOnLateCancel: 'Refund on late cancel',
       autoCancelUnpaidEnabled: 'Auto-cancel unpaid appointment',
       unpaidAutoCancelAfterHours: 'Auto-cancel unpaid after (hours)',
+      notificationSettingsTitle: 'Notification settings',
+      reminderChannelsLabel: 'Channels',
+      appointmentReminderTimingsLabel: 'Appointment reminder timings',
+      paymentReminderTimingsLabel: 'Payment reminder timings',
+      disabledOption: 'Disabled',
+      channels: {
+        email: 'Email',
+        telegram: 'Telegram',
+        viber: 'Viber',
+        sms: 'SMS',
+        whatsapp: 'WhatsApp',
+      },
       googleConnectedSuccessfully: 'Google Calendar connected successfully.',
       specialists: {
         title: 'Specialists',
@@ -316,6 +329,7 @@ export const dictionaries = {
         system: 'Системные',
         account: 'Аккаунт',
         specialistPolicy: 'Правила брони',
+        notifications: 'Оповещения',
         user: 'Пользовательские'
       },
       systemTitle: 'Системные настройки',
@@ -345,6 +359,18 @@ export const dictionaries = {
       refundOnLateCancel: 'Возвращать оплату при поздней отмене',
       autoCancelUnpaidEnabled: 'Авто-отмена неоплаченной записи',
       unpaidAutoCancelAfterHours: 'Авто-отмена через (часы)',
+      notificationSettingsTitle: 'Настройки оповещений',
+      reminderChannelsLabel: 'Каналы',
+      appointmentReminderTimingsLabel: 'Напоминание о записи',
+      paymentReminderTimingsLabel: 'Напоминание об оплате',
+      disabledOption: 'Отключено',
+      channels: {
+        email: 'Email',
+        telegram: 'Telegram',
+        viber: 'Viber',
+        sms: 'SMS',
+        whatsapp: 'WhatsApp',
+      },
       googleConnectedSuccessfully: 'Google Calendar успешно подключен.',
       specialists: {
         title: 'Специалисты',
@@ -550,6 +576,7 @@ export type TranslationKey =
   | 'settings.tabs.system'
   | 'settings.tabs.account'
   | 'settings.tabs.specialistPolicy'
+  | 'settings.tabs.notifications'
   | 'settings.tabs.user'
   | 'settings.systemTitle'
   | 'settings.accountTitle'
@@ -578,6 +605,16 @@ export type TranslationKey =
   | 'settings.refundOnLateCancel'
   | 'settings.autoCancelUnpaidEnabled'
   | 'settings.unpaidAutoCancelAfterHours'
+  | 'settings.notificationSettingsTitle'
+  | 'settings.reminderChannelsLabel'
+  | 'settings.appointmentReminderTimingsLabel'
+  | 'settings.paymentReminderTimingsLabel'
+  | 'settings.disabledOption'
+  | 'settings.channels.email'
+  | 'settings.channels.telegram'
+  | 'settings.channels.viber'
+  | 'settings.channels.sms'
+  | 'settings.channels.whatsapp'
   | 'settings.googleConnectedSuccessfully'
   | 'settings.specialists.title'
   | 'settings.specialists.add'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -72,6 +72,18 @@ export type SpecialistBookingPolicy = {
   unpaidAutoCancelAfterHours: number;
 };
 
+export type NotificationType = 'appointment_created' | 'appointment_reminder' | 'payment_reminder';
+export type NotificationChannel = 'email' | 'telegram' | 'viber' | 'sms' | 'whatsapp';
+export type NotificationFrequency = 'immediate' | 'daily';
+
+export type AccountNotificationDefault = {
+  notificationType: NotificationType;
+  preferredChannel: NotificationChannel;
+  enabled: boolean;
+  sendTimings: string[];
+  frequency: NotificationFrequency;
+};
+
 export type GoogleOAuthStartResponse = {
   provider: 'google';
   authorizeUrl: string;


### PR DESCRIPTION
### Motivation
- Provide a Web UI for account-level notification preferences (channels + reminder timings) and persist those defaults on the server.
- Extend notification model to support multiple delivery channels (including `telegram`) and enable simple fallback/delivery-chain selection when deciding how to send reminders.
- Keep API and domain validation aligned so frontend and backend share the same types and constraints for notification settings.

### Description
- Frontend: added a new `Notifications` tab in settings with multi-channel selection and multi-select reminder timings, wired into the existing settings card and container (`web/src/components/SettingsCard.tsx`, `web/src/containers/SettingsContainer.tsx`) and extended API types (`web/src/shared/types/api.ts`) and i18n (`web/src/shared/i18n/dictionaries.ts`).
- Backend API: implemented `GET` and `PUT /api/settings/account-notification-defaults` routes and service plumbing to persist account defaults (`server/src/routes/settingsRoutes.ts`, `server/src/services/settingsService.ts`).
- Repository & schema: added `upsertAccountNotificationDefaults` to persist a full set per account and introduced a batch schema for account defaults and `telegram` into the allowed channels (`server/src/repositories/accountNotificationDefaultsRepository.ts`, `server/src/config/schemas.ts`).
- Effective settings & delivery chain: `getEffectiveNotificationSetting` now builds a channel-fallback/`deliveryChannels` list (honoring specialist overrides and client deny) and the appointment notification sender consults that chain to attempt email fallback (`server/src/services/notificationSettingsService.ts`, `server/src/services/appointmentNotificationService.ts`).
- DB migration: added a migration to update check constraints to include `telegram` as a valid channel (`server/src/db/migrations/20260426170000_add_telegram_channel_to_notification_settings.ts`).
- Tests & docs: updated smoke/unit tests to cover the new endpoint and adjusted mocks for the extended `EffectiveNotificationSetting` shape and updated `settings-rework-plan.md` to reflect the work done.

### Testing
- Ran type checks for server and web with `npm run -w server typecheck` and `npm run -w web typecheck`, both completed successfully.
- Ran the server tests for notification defaults and appointment notification logic with `npm run -w server test -- settings.notification-defaults.routes.smoke.test.ts settings.notification-defaults.unit.test.ts appointment-notification.service.unit.test.ts`, and all selected tests passed (3 test files, 11 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee18a110208333a1cb5142b95fa457)