### PR TITLE
Add Telegram delivery for appointment reminders with email fallback

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -26,7 +26,10 @@ Node.js/Express API для web-клиента и интеграций.
 - Email delivery через Brevo SMTP API.
 - Оповещения о записи с fallback-цепочкой: Telegram -> Email.
 - Notification defaults backend foundation: `account_notification_defaults`, `specialist_notification_settings`, `client_notification_settings` + scheduler job для автосоздания дефолтов на аккаунт.
-- Notification delivery job (MVP): email-only отправка `appointment_reminder` (24h/1h) и `payment_reminder` (24h после создания) с дедупликацией через таблицу `notifications`.
+- Notification delivery job (MVP): отправка `appointment_reminder` / `payment_reminder` по effective channel order:
+  - `telegram` (если у клиента есть `telegram_id` + `username` и в аккаунте подключён `telegram_bot_token`);
+  - fallback на `email`;
+  - дедупликация через таблицу `notifications`.
 - Локализованные API-сообщения (`ru/en`).
 
 ## Команды
@@ -71,6 +74,8 @@ npm run -w @scheduletm/server test
 
 ### Notification delivery (MVP now)
 
-- Канал доставки в scheduler: только `email` (reuse `sendAppointmentNotificationEmail`).
-- Ручной `POST /api/appointments/:id/notify` тоже использует общий email-dispatch сервис (форсированная отправка, независимо от account defaults).
-- Планово scheduler уважает `account_notification_defaults.enabled` и `preferred_channel` (`email`).
+- Каналы доставки в scheduler:
+  - `telegram` (через bot token аккаунта + `clients.telegram_id`);
+  - fallback `email`.
+- Ручной `POST /api/appointments/:id/notify` использует общий dispatch-сервис (форсированная отправка: сначала `telegram`, затем `email` при доступности контактов).
+- Scheduler уважает effective settings (`account -> specialist -> client deny`) и применяет fallback по доступным каналам.

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -19,6 +19,7 @@ export type AppointmentRecord = {
   client_first_name?: string | null;
   client_last_name?: string | null;
   client_username?: string | null;
+  client_telegram_id?: string | null;
   client_phone?: string | null;
   client_email?: string | null;
 };
@@ -90,6 +91,7 @@ export async function listAppointments(filters: AppointmentListFilters): Promise
     'clients.first_name as client_first_name',
     'clients.last_name as client_last_name',
     'clients.username as client_username',
+    'clients.telegram_id as client_telegram_id',
     'clients.phone as client_phone',
     'clients.email as client_email',
   );
@@ -139,6 +141,7 @@ export async function listAppointmentsAllAccounts(filters: Omit<AppointmentListF
     'clients.first_name as client_first_name',
     'clients.last_name as client_last_name',
     'clients.username as client_username',
+    'clients.telegram_id as client_telegram_id',
     'clients.phone as client_phone',
     'clients.email as client_email',
   );

--- a/server/src/services/appointmentNotificationService.ts
+++ b/server/src/services/appointmentNotificationService.ts
@@ -1,7 +1,10 @@
 import type { AppointmentRecord } from '../repositories/appointmentRepository.js';
 import { findSpecialistById } from '../repositories/specialistRepository.js';
+import { findTelegramIntegrationByAccountId } from '../repositories/webUserIntegrationRepository.js';
 import { sendAppointmentNotificationEmail } from './emailDeliveryService.js';
+import { sendTelegramBotMessage } from './telegramService.js';
 import {
+  type NotificationChannel,
   getEffectiveNotificationSetting,
   type NotificationType,
 } from './notificationSettingsService.js';
@@ -15,12 +18,12 @@ export async function sendAppointmentNotificationByType(input: {
   appointment: AppointmentRecord;
   notificationType: NotificationType;
   force?: boolean;
-}): Promise<{ delivered: boolean; channel: 'email' | null; reason?: string }> {
+}): Promise<{ delivered: boolean; channel: 'email' | 'telegram' | null; reason?: string }> {
   const email = input.appointment.client_email?.trim() ?? '';
-  if (!email) {
-    return { delivered: false, channel: null, reason: 'missing_email' };
-  }
+  const telegramUsername = input.appointment.client_username?.trim() ?? '';
+  const telegramChatId = input.appointment.client_telegram_id?.trim() ?? '';
 
+  let channelsToTry: NotificationChannel[] = ['telegram', 'email'];
   if (!input.force) {
     const active = await getEffectiveNotificationSetting({
       accountId: input.accountId,
@@ -37,21 +40,58 @@ export async function sendAppointmentNotificationByType(input: {
       return { delivered: false, channel: null, reason: active.deniedByClient ? 'client_deny' : 'disabled' };
     }
 
-    const firstSupportedChannel = active.deliveryChannels.find((item) => item === 'email');
-    if (!firstSupportedChannel) {
+    channelsToTry = active.deliveryChannels;
+    if (channelsToTry.length === 0) {
       return { delivered: false, channel: null, reason: 'unsupported_channel' };
     }
   }
 
   const specialist = await findSpecialistById(input.accountId, input.appointment.specialist_id);
-  const delivered = await sendAppointmentNotificationEmail({
-    to: email,
-    clientName: resolveClientName(input.appointment),
-    specialistName: specialist?.name ?? 'специалист',
-    scheduledAt: input.appointment.appointment_at.toISOString(),
-  });
+  for (const channel of channelsToTry) {
+    if (channel === 'telegram') {
+      if (!telegramChatId || !telegramUsername) {
+        continue;
+      }
 
-  return delivered
-    ? { delivered: true, channel: 'email' }
-    : { delivered: false, channel: null, reason: 'delivery_failed' };
+      const integration = await findTelegramIntegrationByAccountId(input.accountId);
+      const telegramToken = integration?.telegram_bot_token?.trim() ?? '';
+      if (!telegramToken) {
+        continue;
+      }
+
+      const delivered = await sendTelegramBotMessage(
+        telegramToken,
+        telegramChatId,
+        `Напоминание: запись к ${specialist?.name ?? 'специалист'} на ${input.appointment.appointment_at.toISOString()}.`,
+      );
+      if (delivered) {
+        return { delivered: true, channel: 'telegram' };
+      }
+
+      continue;
+    }
+
+    if (channel === 'email') {
+      if (!email) {
+        continue;
+      }
+
+      const delivered = await sendAppointmentNotificationEmail({
+        to: email,
+        clientName: resolveClientName(input.appointment),
+        specialistName: specialist?.name ?? 'специалист',
+        scheduledAt: input.appointment.appointment_at.toISOString(),
+      });
+
+      if (delivered) {
+        return { delivered: true, channel: 'email' };
+      }
+    }
+  }
+
+  if (!telegramChatId && !email) {
+    return { delivered: false, channel: null, reason: 'no_contact' };
+  }
+
+  return { delivered: false, channel: null, reason: 'delivery_failed' };
 }

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -623,6 +623,8 @@ export async function notifyAppointmentForActor(actor: User, appointmentId: numb
       ...existing,
       client_first_name: client?.first_name ?? existing.client_first_name,
       client_last_name: client?.last_name ?? existing.client_last_name,
+      client_username: client?.username ?? existing.client_username,
+      client_telegram_id: client?.telegram_id ?? existing.client_telegram_id,
       client_email: client?.email ?? existing.client_email,
     },
     notificationType: 'appointment_reminder',

--- a/server/tests/appointment-notification.service.unit.test.ts
+++ b/server/tests/appointment-notification.service.unit.test.ts
@@ -4,6 +4,8 @@ import { sendAppointmentNotificationByType } from '../src/services/appointmentNo
 const getEffectiveNotificationSettingMock = vi.hoisted(() => vi.fn());
 const findSpecialistByIdMock = vi.hoisted(() => vi.fn());
 const sendAppointmentNotificationEmailMock = vi.hoisted(() => vi.fn());
+const findTelegramIntegrationByAccountIdMock = vi.hoisted(() => vi.fn());
+const sendTelegramBotMessageMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/services/notificationSettingsService.js', () => ({
   getEffectiveNotificationSetting: getEffectiveNotificationSettingMock,
@@ -17,11 +19,21 @@ vi.mock('../src/services/emailDeliveryService.js', () => ({
   sendAppointmentNotificationEmail: sendAppointmentNotificationEmailMock,
 }));
 
+vi.mock('../src/repositories/webUserIntegrationRepository.js', () => ({
+  findTelegramIntegrationByAccountId: findTelegramIntegrationByAccountIdMock,
+}));
+
+vi.mock('../src/services/telegramService.js', () => ({
+  sendTelegramBotMessage: sendTelegramBotMessageMock,
+}));
+
 describe('appointment notification service unit', () => {
   beforeEach(() => {
     getEffectiveNotificationSettingMock.mockReset();
     findSpecialistByIdMock.mockReset();
     sendAppointmentNotificationEmailMock.mockReset();
+    findTelegramIntegrationByAccountIdMock.mockReset();
+    sendTelegramBotMessageMock.mockReset();
   });
 
   it('does not send when notification type disabled', async () => {
@@ -51,6 +63,41 @@ describe('appointment notification service unit', () => {
 
     expect(result.delivered).toBe(false);
     expect(result.reason).toBe('disabled');
+    expect(sendAppointmentNotificationEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('sends via telegram when enabled and client has telegram id + username', async () => {
+    getEffectiveNotificationSettingMock.mockResolvedValue(
+      { notificationType: 'appointment_reminder', preferredChannel: 'telegram', deliveryChannels: ['telegram', 'email'], enabled: true, sendTimings: ['24h'], frequency: 'immediate', deniedByClient: false },
+    );
+    findSpecialistByIdMock.mockResolvedValue({ name: 'Dr. Test' });
+    findTelegramIntegrationByAccountIdMock.mockResolvedValue({ telegram_bot_token: 'token' });
+    sendTelegramBotMessageMock.mockResolvedValue(true);
+
+    const result = await sendAppointmentNotificationByType({
+      accountId: 1,
+      notificationType: 'appointment_reminder',
+      appointment: {
+        id: 1,
+        account_id: 1,
+        specialist_id: 1,
+        appointment_at: new Date('2026-04-26T10:00:00.000Z'),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 5,
+        service_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        client_username: 'client_user',
+        client_telegram_id: '12345',
+      },
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.channel).toBe('telegram');
+    expect(sendTelegramBotMessageMock).toHaveBeenCalledOnce();
     expect(sendAppointmentNotificationEmailMock).not.toHaveBeenCalled();
   });
 

--- a/settings-rework-plan.md
+++ b/settings-rework-plan.md
@@ -28,6 +28,7 @@
 7. Server: добавлено сохранение account notification defaults через `PUT /api/settings/account-notification-defaults`.
 8. Server: обновлена логика выбора канала отправки (учёт fallback-цепочки, skip неподдержанных каналов с попыткой перейти к доступному `email`).
 9. Server/DB: добавлена поддержка канала `telegram` в валидации и DB check constraints для notification settings таблиц.
+10. Server: добавлена фактическая отправка `appointment`-оповещений в `telegram` при наличии у клиента `telegram_id` + `username` и подключённого `telegram_bot_token` в аккаунте (с fallback на email).
 
 ### ⏭️ Следующая итерация
 
@@ -54,7 +55,8 @@
 
 3. **Fallback channels (после email MVP)**
    - ✅ включен выбор fallback-цепочки на уровне effective settings;
-   - ⏳ добавить реальные провайдеры/адаптеры для `telegram`, `viber`, `whatsapp`, `sms`.
+   - 🟡 `telegram`: реализован через bot token + `clients.telegram_id` (при наличии также `username`);
+   - ⏳ добавить реальные провайдеры/адаптеры для `viber`, `whatsapp`, `sms`.
 
 4. **Надёжность доставки**
    - retry policy (`pending/retry/failed`) для scheduler-отправок;


### PR DESCRIPTION
### Motivation

- Add Telegram as a delivery channel for appointment notifications so clients with Telegram can receive reminders when account bot token and client contacts are available.
- Respect effective notification settings and fallback ordering (`telegram` → `email`) so scheduler/manual notify follow account→specialist→client overrides.

### Description

- Extend `AppointmentRecord` and repository selects to include `client_telegram_id` and expose it in appointment queries. 
- Replace email-only dispatch in `sendAppointmentNotificationByType` with a channel pipeline that iterates `deliveryChannels` from `getEffectiveNotificationSetting`, attempts `telegram` first (using `findTelegramIntegrationByAccountId` and `sendTelegramBotMessage`) and falls back to `email` (using `sendAppointmentNotificationEmail`).
- Update manual notify flow in `notifyAppointmentForActor` to hydrate `client_username` and `client_telegram_id` from `clients` when invoking the dispatch service. 
- Add unit test coverage and mocks for Telegram integration and bot sending in `server/tests/appointment-notification.service.unit.test.ts`, and update documentation (`server/README.md` and `settings-rework-plan.md`) to describe Telegram support and fallback behavior.

### Testing

- Added/updated unit tests in `server/tests/appointment-notification.service.unit.test.ts` covering disabled notifications, email path, and a new Telegram-success path. 
- Ran the server test suite with `npm run -w @scheduletm/server test` and the appointment notification unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1d31e2a0833387e91d59e29dd236)