### PR TITLE
Add notification retry/backoff pipeline, idempotency and processing states

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ scheduletm/
 - Роли: `owner` / `admin` / `specialist` / `client` (RBAC policy централизована в server).
 - Settings: system + account + user settings, plus user integrations.
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
-- Notifications: appointment notify flow with channel fallback (Telegram -> Email).
+- Notifications: appointment notify flow with channel fallback (Telegram -> Email) + retry/backoff pipeline in scheduler (`pending/retry/processing/sent/failed`, `next_retry_at`, `max_attempts`, idempotent key per `appointment_id + type + channel`).
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
 - Scheduler: auto-cancel unpaid appointments by specialist booking policy (`auto_cancel_unpaid_enabled`, `unpaid_auto_cancel_after_hours`) with audit reason `auto_cancel_unpaid`.
 - Specialists и Users CRUD (с role-gates).

--- a/server/README.md
+++ b/server/README.md
@@ -29,7 +29,8 @@ Node.js/Express API для web-клиента и интеграций.
 - Notification delivery job (MVP): отправка `appointment_reminder` / `payment_reminder` по effective channel order:
   - `telegram` (если у клиента есть `telegram_id` + `username` и в аккаунте подключён `telegram_bot_token`);
   - fallback на `email`;
-  - дедупликация через таблицу `notifications`.
+  - дедупликация через таблицу `notifications` по ключу `appointment_id + type + channel`;
+  - retry/backoff и управление состояниями отправки: `pending -> processing -> sent` или `retry/failed` с `next_retry_at`, `attempts`, `max_attempts`.
 - Локализованные API-сообщения (`ru/en`).
 
 ## Команды

--- a/server/src/db/migrations/20260427110000_add_notification_retry_uniqueness.ts
+++ b/server/src/db/migrations/20260427110000_add_notification_retry_uniqueness.ts
@@ -1,0 +1,37 @@
+import type { Knex } from 'knex';
+
+const STATUS_CHECK = `status IN ('pending', 'processing', 'retry', 'sent', 'failed', 'cancelled')`;
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable('notifications');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex.raw(
+    'ALTER TABLE "notifications" DROP CONSTRAINT IF EXISTS "notifications_status_check"',
+  );
+  await knex.raw(
+    `ALTER TABLE "notifications" ADD CONSTRAINT "notifications_status_check" CHECK (${STATUS_CHECK})`,
+  );
+
+  await knex.raw(
+    'CREATE UNIQUE INDEX IF NOT EXISTS "notifications_idempotency_unique_index" ON "notifications" ("appointment_id", "type", "channel")',
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable('notifications');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex.raw('DROP INDEX IF EXISTS "notifications_idempotency_unique_index"');
+
+  await knex.raw(
+    'ALTER TABLE "notifications" DROP CONSTRAINT IF EXISTS "notifications_status_check"',
+  );
+  await knex.raw(
+    `ALTER TABLE "notifications" ADD CONSTRAINT "notifications_status_check" CHECK (status IN ('pending', 'retry', 'sent', 'failed', 'cancelled'))`,
+  );
+}

--- a/server/src/jobs/appointmentNotifications.job.ts
+++ b/server/src/jobs/appointmentNotifications.job.ts
@@ -2,7 +2,12 @@ import {
   listAppointmentsAllAccounts,
   listUnpaidAppointmentsCreatedBetweenAllAccounts,
 } from '../repositories/appointmentRepository.js';
-import { hasSentNotification, insertSentNotification } from '../repositories/notificationRepository.js';
+import {
+  claimNotificationForDelivery,
+  markNotificationDeliveryFailure,
+  markNotificationSent,
+  upsertNotificationJob,
+} from '../repositories/notificationRepository.js';
 import { sendAppointmentNotificationByType } from '../services/appointmentNotificationService.js';
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
@@ -40,19 +45,9 @@ async function deliverAndMark(input: {
   typeKey: string;
   sendAt: Date;
   payload: Record<string, unknown>;
-  sender: () => Promise<boolean>;
+  sender: () => Promise<{ delivered: boolean; reason?: string }>;
 }) {
-  const sent = await hasSentNotification(input.appointmentId, input.typeKey, 'email');
-  if (sent) {
-    return false;
-  }
-
-  const delivered = await input.sender();
-  if (!delivered) {
-    return false;
-  }
-
-  await insertSentNotification({
+  const job = await upsertNotificationJob({
     accountId: input.accountId,
     appointmentId: input.appointmentId,
     userId: input.userId,
@@ -63,7 +58,32 @@ async function deliverAndMark(input: {
     payload: input.payload,
   });
 
-  return true;
+  if (job.status === 'sent' || job.status === 'failed') {
+    return false;
+  }
+
+  const claimed = await claimNotificationForDelivery({ notificationId: job.id, now: input.sendAt });
+  if (!claimed) {
+    return false;
+  }
+
+  const result = await input.sender();
+  if (result.delivered) {
+    await markNotificationSent({
+      notificationId: job.id,
+      recipientEmail: input.email,
+      sentAt: input.sendAt,
+    });
+    return true;
+  }
+
+  await markNotificationDeliveryFailure({
+    notificationId: job.id,
+    error: result.reason ?? 'delivery_failed',
+    now: input.sendAt,
+  });
+
+  return false;
 }
 
 export function startAppointmentNotificationsJob(intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timeout {
@@ -94,13 +114,11 @@ export async function runAppointmentNotificationsJob(now = new Date(), windowMin
         sendAt: now,
         payload: { timing: timing.key },
         sender: async () => {
-          const result = await sendAppointmentNotificationByType({
+          return sendAppointmentNotificationByType({
             accountId: appointment.account_id,
             appointment,
             notificationType: 'appointment_reminder',
           });
-
-          return result.delivered;
         },
       });
 
@@ -129,13 +147,11 @@ export async function runAppointmentNotificationsJob(now = new Date(), windowMin
         sendAt: now,
         payload: { timing: timing.key },
         sender: async () => {
-          const result = await sendAppointmentNotificationByType({
+          return sendAppointmentNotificationByType({
             accountId: appointment.account_id,
             appointment,
             notificationType: 'payment_reminder',
           });
-
-          return result.delivered;
         },
       });
 

--- a/server/src/repositories/notificationRepository.ts
+++ b/server/src/repositories/notificationRepository.ts
@@ -1,5 +1,13 @@
 import { db } from '../db/knex.js';
 
+const DEFAULT_MAX_ATTEMPTS = 3;
+const RETRY_BACKOFF_MINUTES = [5, 15, 30] as const;
+
+function computeNextRetryAt(now: Date, attemptNo: number): Date {
+  const backoffMinutes = RETRY_BACKOFF_MINUTES[Math.min(attemptNo - 1, RETRY_BACKOFF_MINUTES.length - 1)];
+  return new Date(now.getTime() + backoffMinutes * 60 * 1000);
+}
+
 export async function hasSentNotification(
   appointmentId: number,
   type: string,
@@ -17,6 +25,126 @@ export async function hasSentNotification(
   return Boolean(row?.id);
 }
 
+export async function upsertNotificationJob(input: {
+  accountId: number;
+  appointmentId: number;
+  userId: number;
+  type: string;
+  channel: 'email';
+  sendAt: Date;
+  recipientEmail: string;
+  payload?: Record<string, unknown>;
+  maxAttempts?: number;
+}): Promise<{ id: number; status: string; attempts: number; max_attempts: number }> {
+  const [row] = await db('notifications')
+    .insert({
+      account_id: input.accountId,
+      user_id: input.userId,
+      appointment_id: input.appointmentId,
+      type: input.type,
+      channel: input.channel,
+      status: 'pending',
+      send_at: input.sendAt,
+      next_retry_at: input.sendAt,
+      recipient_email: input.recipientEmail,
+      payload_json: JSON.stringify(input.payload ?? {}),
+      attempts: 0,
+      max_attempts: input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    })
+    .onConflict(['appointment_id', 'type', 'channel'])
+    .ignore()
+    .returning<{ id: number; status: string; attempts: number; max_attempts: number }[]>(
+      ['id', 'status', 'attempts', 'max_attempts'],
+    );
+
+  if (row) {
+    return row;
+  }
+
+  const existing = await db('notifications')
+    .where({
+      appointment_id: input.appointmentId,
+      type: input.type,
+      channel: input.channel,
+    })
+    .first<{ id: number; status: string; attempts: number; max_attempts: number }>(
+      ['id', 'status', 'attempts', 'max_attempts'],
+    );
+
+  if (!existing) {
+    throw new Error('Notification job upsert failed');
+  }
+
+  return existing;
+}
+
+export async function claimNotificationForDelivery(input: {
+  notificationId: number;
+  now?: Date;
+}): Promise<boolean> {
+  const now = input.now ?? new Date();
+  const updated = await db('notifications')
+    .where('id', input.notificationId)
+    .whereIn('status', ['pending', 'retry'])
+    .where('attempts', '<', db.ref('max_attempts'))
+    .andWhere((builder) => {
+      builder.whereNull('next_retry_at').orWhere('next_retry_at', '<=', now);
+    })
+    .update({
+      status: 'processing',
+      updated_at: db.fn.now(),
+    });
+
+  return updated > 0;
+}
+
+export async function markNotificationSent(input: {
+  notificationId: number;
+  recipientEmail: string;
+  sentAt?: Date;
+}): Promise<void> {
+  await db('notifications')
+    .where('id', input.notificationId)
+    .update({
+      status: 'sent',
+      sent_at: input.sentAt ?? db.fn.now(),
+      recipient_email: input.recipientEmail,
+      last_error: null,
+      next_retry_at: null,
+      updated_at: db.fn.now(),
+    });
+}
+
+export async function markNotificationDeliveryFailure(input: {
+  notificationId: number;
+  error: string;
+  now?: Date;
+}): Promise<void> {
+  const now = input.now ?? new Date();
+  const current = await db('notifications')
+    .where('id', input.notificationId)
+    .first<{ attempts: number; max_attempts: number }>(['attempts', 'max_attempts']);
+
+  if (!current) {
+    return;
+  }
+
+  const nextAttempts = current.attempts + 1;
+  const exhausted = nextAttempts >= current.max_attempts;
+
+  await db('notifications')
+    .where('id', input.notificationId)
+    .update({
+      attempts: nextAttempts,
+      status: exhausted ? 'failed' : 'retry',
+      last_error: input.error,
+      next_retry_at: exhausted ? null : computeNextRetryAt(now, nextAttempts),
+      updated_at: db.fn.now(),
+    });
+}
+
 export async function insertSentNotification(input: {
   accountId: number;
   appointmentId: number;
@@ -27,20 +155,38 @@ export async function insertSentNotification(input: {
   recipientEmail: string;
   payload?: Record<string, unknown>;
 }): Promise<void> {
-  await db('notifications').insert({
-    account_id: input.accountId,
-    user_id: input.userId,
-    appointment_id: input.appointmentId,
+  await upsertNotificationJob({
+    accountId: input.accountId,
+    appointmentId: input.appointmentId,
+    userId: input.userId,
     type: input.type,
     channel: input.channel,
-    status: 'sent',
-    send_at: input.sendAt,
-    sent_at: db.fn.now(),
-    recipient_email: input.recipientEmail,
-    payload_json: JSON.stringify(input.payload ?? {}),
-    attempts: 1,
-    max_attempts: 1,
-    created_at: db.fn.now(),
-    updated_at: db.fn.now(),
+    sendAt: input.sendAt,
+    recipientEmail: input.recipientEmail,
+    payload: input.payload,
+    maxAttempts: 1,
   });
+
+  const record = await db('notifications')
+    .where({
+      appointment_id: input.appointmentId,
+      type: input.type,
+      channel: input.channel,
+    })
+    .first<{ id: number }>('id');
+
+  if (!record) {
+    return;
+  }
+
+  await db('notifications')
+    .where('id', record.id)
+    .update({
+      attempts: 1,
+      status: 'sent',
+      sent_at: db.fn.now(),
+      recipient_email: input.recipientEmail,
+      next_retry_at: null,
+      updated_at: db.fn.now(),
+    });
 }

--- a/server/tests/appointment-notifications.job.unit.test.ts
+++ b/server/tests/appointment-notifications.job.unit.test.ts
@@ -3,8 +3,10 @@ import { runAppointmentNotificationsJob } from '../src/jobs/appointmentNotificat
 
 const listAppointmentsAllAccountsMock = vi.hoisted(() => vi.fn());
 const listUnpaidAppointmentsCreatedBetweenAllAccountsMock = vi.hoisted(() => vi.fn());
-const hasSentNotificationMock = vi.hoisted(() => vi.fn());
-const insertSentNotificationMock = vi.hoisted(() => vi.fn());
+const upsertNotificationJobMock = vi.hoisted(() => vi.fn());
+const claimNotificationForDeliveryMock = vi.hoisted(() => vi.fn());
+const markNotificationSentMock = vi.hoisted(() => vi.fn());
+const markNotificationDeliveryFailureMock = vi.hoisted(() => vi.fn());
 const sendAppointmentNotificationByTypeMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/repositories/appointmentRepository.js', () => ({
@@ -13,8 +15,10 @@ vi.mock('../src/repositories/appointmentRepository.js', () => ({
 }));
 
 vi.mock('../src/repositories/notificationRepository.js', () => ({
-  hasSentNotification: hasSentNotificationMock,
-  insertSentNotification: insertSentNotificationMock,
+  upsertNotificationJob: upsertNotificationJobMock,
+  claimNotificationForDelivery: claimNotificationForDeliveryMock,
+  markNotificationSent: markNotificationSentMock,
+  markNotificationDeliveryFailure: markNotificationDeliveryFailureMock,
 }));
 
 vi.mock('../src/services/appointmentNotificationService.js', () => ({
@@ -25,14 +29,17 @@ describe('appointment notifications job unit', () => {
   beforeEach(() => {
     listAppointmentsAllAccountsMock.mockReset();
     listUnpaidAppointmentsCreatedBetweenAllAccountsMock.mockReset();
-    hasSentNotificationMock.mockReset();
-    insertSentNotificationMock.mockReset();
+    upsertNotificationJobMock.mockReset();
+    claimNotificationForDeliveryMock.mockReset();
+    markNotificationSentMock.mockReset();
+    markNotificationDeliveryFailureMock.mockReset();
     sendAppointmentNotificationByTypeMock.mockReset();
 
     listAppointmentsAllAccountsMock.mockResolvedValue([]);
     listUnpaidAppointmentsCreatedBetweenAllAccountsMock.mockResolvedValue([]);
-    hasSentNotificationMock.mockResolvedValue(false);
-    sendAppointmentNotificationByTypeMock.mockResolvedValue({ delivered: true });
+    upsertNotificationJobMock.mockResolvedValue({ id: 1, status: 'pending', attempts: 0, max_attempts: 3 });
+    claimNotificationForDeliveryMock.mockResolvedValue(true);
+    sendAppointmentNotificationByTypeMock.mockResolvedValue({ delivered: true, channel: 'email' });
   });
 
   it('delivers reminder and writes sent notification once', async () => {
@@ -57,7 +64,8 @@ describe('appointment notifications job unit', () => {
     const delivered = await runAppointmentNotificationsJob(new Date('2026-04-26T12:00:00.000Z'));
 
     expect(delivered).toBe(1);
-    expect(insertSentNotificationMock).toHaveBeenCalledOnce();
+    expect(markNotificationSentMock).toHaveBeenCalledOnce();
+    expect(markNotificationDeliveryFailureMock).not.toHaveBeenCalled();
   });
 
   it('skips already sent notification (edge case dedupe)', async () => {
@@ -78,12 +86,39 @@ describe('appointment notifications job unit', () => {
         client_email: 'client@test.com',
       },
     ]);
-    hasSentNotificationMock.mockResolvedValue(true);
+    upsertNotificationJobMock.mockResolvedValue({ id: 1, status: 'sent', attempts: 1, max_attempts: 3 });
 
     const delivered = await runAppointmentNotificationsJob(new Date('2026-04-26T12:00:00.000Z'));
 
     expect(delivered).toBe(0);
     expect(sendAppointmentNotificationByTypeMock).not.toHaveBeenCalled();
-    expect(insertSentNotificationMock).not.toHaveBeenCalled();
+    expect(markNotificationSentMock).not.toHaveBeenCalled();
+  });
+
+  it('marks retry when delivery fails', async () => {
+    listAppointmentsAllAccountsMock.mockResolvedValueOnce([
+      {
+        id: 11,
+        account_id: 2,
+        specialist_id: 3,
+        appointment_at: new Date('2026-04-27T12:00:00.000Z'),
+        status: 'new',
+        comment: null,
+        duration_min: 30,
+        is_paid: false,
+        user_id: 8,
+        service_id: 1,
+        created_at: new Date('2026-04-26T12:00:00.000Z'),
+        updated_at: new Date('2026-04-26T12:00:00.000Z'),
+        client_email: 'client@test.com',
+      },
+    ]);
+    sendAppointmentNotificationByTypeMock.mockResolvedValueOnce({ delivered: false, channel: null, reason: 'delivery_failed' });
+
+    const delivered = await runAppointmentNotificationsJob(new Date('2026-04-26T12:00:00.000Z'));
+
+    expect(delivered).toBe(0);
+    expect(markNotificationDeliveryFailureMock).toHaveBeenCalledOnce();
+    expect(markNotificationSentMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- Introduce robust notification delivery with deduplication and retry semantics to avoid duplicate sends and to handle transient failures.
- Add DB-level uniqueness and richer status tracking so notification jobs can be claimed, retried with backoff, and marked as sent/failed.

### Description
- Add migration `20260427110000_add_notification_retry_uniqueness.ts` to create a unique index on `notifications(appointment_id, type, channel)` and extend the `status` check to include `processing` and `retry`.
- Implement notification job lifecycle in `server/src/repositories/notificationRepository.ts` with `upsertNotificationJob`, `claimNotificationForDelivery`, `markNotificationSent`, `markNotificationDeliveryFailure`, and a `computeNextRetryAt` backoff using configurable `max_attempts` and retry intervals.
- Update delivery flow in `server/src/jobs/appointmentNotifications.job.ts` to upsert a notification job, claim it for delivery, call the sender, and then mark success or failure (instead of naive sent checks and inserts).
- Update `insertSentNotification` to reuse the upsert/update flow so sent records are consistent with the new job model, and update READMEs to document the new pipeline behavior.

### Testing
- Unit tests in `server/tests/appointment-notifications.job.unit.test.ts` were updated to mock the new repository functions and cover successful delivery, dedupe-skipping when job status is `sent`, and marking retry on delivery failure.
- Ran the server unit test suite via `npm run -w @scheduletm/server test` (Vitest) and the updated notification job tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef305a1464833394de0ba4e1aea44e)