### PR TITLE
Add notification logs UI and API with scoped access and resend support

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -73,6 +73,15 @@ npm run -w @scheduletm/server test
   - гарантирует наличие базовых дефолтов по типам (`appointment_created`, `appointment_reminder`, `payment_reminder`) и возвращает их.
 
 
+### Notification logs API
+
+- `GET /api/notifications`
+  - доступ: `owner`, `admin`, `specialist`;
+  - scope: `owner` видит все аккаунты (опциональный фильтр `accountId`), `admin` только свой `account_id`, `specialist` только уведомления своих клиентов;
+  - фильтры: `accountId`, `specialistId`, `userId`.
+- `POST /api/notifications/:id/resend`
+  - повторно ставит в очередь только недоставленные уведомления (`failed`, `retry`, `cancelled`) в рамках доступного scope.
+
 ### Notification delivery (MVP now)
 
 - Каналы доставки в scheduler:

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { appointmentRoutes } from './routes/appointmentRoutes.js';
 import { settingsRoutes } from './routes/settingsRoutes.js';
 import { specialistRoutes } from './routes/specialistRoutes.js';
 import { userManagementRoutes } from './routes/userManagementRoutes.js';
+import { notificationRoutes } from './routes/notificationRoutes.js';
 
 export const createApp = () => {
   const app = express();
@@ -40,6 +41,7 @@ export const createApp = () => {
   app.use('/api/specialists', specialistRoutes);
   app.use('/api/users', userManagementRoutes);
   app.use('/api/integrations', integrationRoutes);
+  app.use('/api/notifications', notificationRoutes);
 
   app.use((_req, res) => {
     res.status(404).json({ message: 'Not found' });

--- a/server/src/i18n/dictionaries.ts
+++ b/server/src/i18n/dictionaries.ts
@@ -69,7 +69,13 @@ export const dictionaries = {
       appointmentCancelFailed: 'Unable to cancel appointment',
       appointmentRescheduleFailed: 'Unable to reschedule appointment',
       appointmentMarkPaidFailed: 'Unable to confirm payment',
-      appointmentNotifyFailed: 'Unable to send notification'
+      appointmentNotifyFailed: 'Unable to send notification',
+      invalidNotificationId: 'Invalid notification id',
+      notificationNotFound: 'Notification not found',
+      forbiddenNotificationScope: 'Insufficient permissions for this notification',
+      notificationsLoadFailed: 'Unable to load notifications',
+      notificationResendSuccess: 'Notification queued for resend',
+      notificationResendFailed: 'Unable to resend notification'
     }
   },
   ru: {
@@ -142,7 +148,13 @@ export const dictionaries = {
       appointmentCancelFailed: 'Не удалось отменить запись',
       appointmentRescheduleFailed: 'Не удалось перенести запись',
       appointmentMarkPaidFailed: 'Не удалось подтвердить оплату',
-      appointmentNotifyFailed: 'Не удалось отправить уведомление'
+      appointmentNotifyFailed: 'Не удалось отправить уведомление',
+      invalidNotificationId: 'Некорректный id уведомления',
+      notificationNotFound: 'Уведомление не найдено',
+      forbiddenNotificationScope: 'Недостаточно прав для этого уведомления',
+      notificationsLoadFailed: 'Не удалось загрузить уведомления',
+      notificationResendSuccess: 'Уведомление поставлено в очередь на повторную отправку',
+      notificationResendFailed: 'Не удалось повторно отправить уведомление'
     }
   }
 } as const;

--- a/server/src/repositories/notificationRepository.ts
+++ b/server/src/repositories/notificationRepository.ts
@@ -3,6 +3,26 @@ import { db } from '../db/knex.js';
 const DEFAULT_MAX_ATTEMPTS = 3;
 const RETRY_BACKOFF_MINUTES = [5, 15, 30] as const;
 
+export type NotificationLogRecord = {
+  id: number;
+  account_id: number;
+  user_id: number;
+  appointment_id: number;
+  specialist_id: number;
+  type: string;
+  channel: string;
+  status: string;
+  attempts: number;
+  max_attempts: number;
+  recipient_email: string | null;
+  last_error: string | null;
+  send_at: Date;
+  next_retry_at: Date | null;
+  sent_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
 function computeNextRetryAt(now: Date, attemptNo: number): Date {
   const backoffMinutes = RETRY_BACKOFF_MINUTES[Math.min(attemptNo - 1, RETRY_BACKOFF_MINUTES.length - 1)];
   return new Date(now.getTime() + backoffMinutes * 60 * 1000);
@@ -189,4 +209,110 @@ export async function insertSentNotification(input: {
       next_retry_at: null,
       updated_at: db.fn.now(),
     });
+}
+
+export async function listNotificationLogs(filters: {
+  accountId?: number;
+  specialistId?: number;
+  userId?: number;
+  limit?: number;
+}): Promise<NotificationLogRecord[]> {
+  const query = db('notifications as n')
+    .join('appointments as a', function joinAppointments() {
+      this.on('a.id', '=', 'n.appointment_id').andOn('a.account_id', '=', 'n.account_id');
+    })
+    .orderBy('n.created_at', 'desc')
+    .limit(filters.limit ?? 300);
+
+  if (filters.accountId !== undefined) {
+    query.where('n.account_id', filters.accountId);
+  }
+
+  if (filters.specialistId !== undefined) {
+    query.where('a.specialist_id', filters.specialistId);
+  }
+
+  if (filters.userId !== undefined) {
+    query.where('n.user_id', filters.userId);
+  }
+
+  return query.select<NotificationLogRecord[]>(
+    'n.id',
+    'n.account_id',
+    'n.user_id',
+    'n.appointment_id',
+    'a.specialist_id',
+    'n.type',
+    'n.channel',
+    'n.status',
+    'n.attempts',
+    'n.max_attempts',
+    'n.recipient_email',
+    'n.last_error',
+    'n.send_at',
+    'n.next_retry_at',
+    'n.sent_at',
+    'n.created_at',
+    'n.updated_at',
+  );
+}
+
+export async function findNotificationLogById(notificationId: number): Promise<NotificationLogRecord | null> {
+  const row = await db('notifications as n')
+    .join('appointments as a', function joinAppointments() {
+      this.on('a.id', '=', 'n.appointment_id').andOn('a.account_id', '=', 'n.account_id');
+    })
+    .where('n.id', notificationId)
+    .first<NotificationLogRecord>(
+      'n.id',
+      'n.account_id',
+      'n.user_id',
+      'n.appointment_id',
+      'a.specialist_id',
+      'n.type',
+      'n.channel',
+      'n.status',
+      'n.attempts',
+      'n.max_attempts',
+      'n.recipient_email',
+      'n.last_error',
+      'n.send_at',
+      'n.next_retry_at',
+      'n.sent_at',
+      'n.created_at',
+      'n.updated_at',
+    );
+
+  return row ?? null;
+}
+
+export async function resetNotificationForResend(input: {
+  notificationId: number;
+  accountId?: number;
+  specialistId?: number;
+}): Promise<boolean> {
+  const query = db('notifications as n')
+    .join('appointments as a', function joinAppointments() {
+      this.on('a.id', '=', 'n.appointment_id').andOn('a.account_id', '=', 'n.account_id');
+    })
+    .where('n.id', input.notificationId)
+    .whereIn('n.status', ['failed', 'retry', 'cancelled']);
+
+  if (input.accountId !== undefined) {
+    query.andWhere('n.account_id', input.accountId);
+  }
+
+  if (input.specialistId !== undefined) {
+    query.andWhere('a.specialist_id', input.specialistId);
+  }
+
+  const updated = await query.update({
+    status: 'pending',
+    attempts: 0,
+    last_error: null,
+    next_retry_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  });
+
+  return updated > 0;
 }

--- a/server/src/routes/notificationRoutes.ts
+++ b/server/src/routes/notificationRoutes.ts
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { t } from '../i18n/index.js';
+import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
+import {
+  getNotificationLogsForActor,
+  resendFailedNotificationForActor,
+} from '../services/notificationLogService.js';
+
+const listNotificationQuerySchema = z.object({
+  accountId: z.coerce.number().int().positive().optional(),
+  specialistId: z.coerce.number().int().positive().optional(),
+  userId: z.coerce.number().int().positive().optional(),
+});
+
+export const notificationRoutes = Router();
+
+notificationRoutes.use(requireAccessToken);
+
+notificationRoutes.get('/', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const parsed = listNotificationQuerySchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  try {
+    const data = await getNotificationLogsForActor(actor, parsed.data);
+    return res.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+
+    if (message === 'SPECIALIST_PROFILE_NOT_FOUND' || message === 'FORBIDDEN_NOTIFICATION_SCOPE') {
+      return res.status(403).json({ message: t(req, 'forbiddenNotificationScope') });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: t(req, 'notificationsLoadFailed') });
+  }
+});
+
+notificationRoutes.post('/:id/resend', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const notificationId = Number(req.params.id);
+
+  if (!Number.isInteger(notificationId) || notificationId <= 0) {
+    return res.status(400).json({ message: t(req, 'invalidNotificationId') });
+  }
+
+  try {
+    const resent = await resendFailedNotificationForActor(actor, notificationId);
+    if (!resent) {
+      return res.status(404).json({ message: t(req, 'notificationNotFound') });
+    }
+
+    return res.json({ message: t(req, 'notificationResendSuccess') });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'UNKNOWN';
+
+    if (message === 'SPECIALIST_PROFILE_NOT_FOUND' || message === 'FORBIDDEN_NOTIFICATION_SCOPE') {
+      return res.status(403).json({ message: t(req, 'forbiddenNotificationScope') });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: t(req, 'notificationResendFailed') });
+  }
+});

--- a/server/src/services/notificationLogService.ts
+++ b/server/src/services/notificationLogService.ts
@@ -1,0 +1,127 @@
+import { canManageAllAppointments } from '../policies/rolePermissions.js';
+import {
+  findNotificationLogById,
+  listNotificationLogs,
+  resetNotificationForResend,
+  type NotificationLogRecord,
+} from '../repositories/notificationRepository.js';
+import { findSpecialistByWebUserId } from '../repositories/specialistRepository.js';
+import { WebUserRole } from '../types/webUserRole.js';
+import type { User } from '../types/domain.js';
+
+export type NotificationLogDto = {
+  id: number;
+  accountId: number;
+  userId: number;
+  appointmentId: number;
+  specialistId: number;
+  status: string;
+  type: string;
+  channel: string;
+  attempts: number;
+  maxAttempts: number;
+  recipientEmail: string | null;
+  lastError: string | null;
+  sendAt: string;
+  nextRetryAt: string | null;
+  sentAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function mapLog(item: NotificationLogRecord): NotificationLogDto {
+  return {
+    id: item.id,
+    accountId: item.account_id,
+    userId: item.user_id,
+    appointmentId: item.appointment_id,
+    specialistId: item.specialist_id,
+    status: item.status,
+    type: item.type,
+    channel: item.channel,
+    attempts: item.attempts,
+    maxAttempts: item.max_attempts,
+    recipientEmail: item.recipient_email,
+    lastError: item.last_error,
+    sendAt: item.send_at.toISOString(),
+    nextRetryAt: item.next_retry_at ? item.next_retry_at.toISOString() : null,
+    sentAt: item.sent_at ? item.sent_at.toISOString() : null,
+    createdAt: item.created_at.toISOString(),
+    updatedAt: item.updated_at.toISOString(),
+  };
+}
+
+async function resolveSpecialistScope(actor: User): Promise<number | null> {
+  if (actor.role !== WebUserRole.Specialist) {
+    return null;
+  }
+
+  const specialist = await findSpecialistByWebUserId(actor.accountId, Number(actor.id));
+  if (!specialist) {
+    throw new Error('SPECIALIST_PROFILE_NOT_FOUND');
+  }
+
+  return specialist.id;
+}
+
+function resolveAccountScope(actor: User, requestedAccountId?: number): number | null {
+  if (actor.role === WebUserRole.Owner) {
+    return requestedAccountId ?? null;
+  }
+
+  return actor.accountId;
+}
+
+export async function getNotificationLogsForActor(
+  actor: User,
+  filters: { accountId?: number; specialistId?: number; userId?: number },
+): Promise<{ items: NotificationLogDto[] }> {
+  const specialistScopeId = await resolveSpecialistScope(actor);
+
+  const items = await listNotificationLogs({
+    accountId: resolveAccountScope(actor, filters.accountId) ?? undefined,
+    specialistId: specialistScopeId ?? filters.specialistId,
+    userId: filters.userId,
+  });
+
+  return { items: items.map(mapLog) };
+}
+
+export async function resendFailedNotificationForActor(actor: User, notificationId: number): Promise<boolean> {
+  const specialistScopeId = await resolveSpecialistScope(actor);
+
+  const log = await findNotificationLogById(notificationId);
+  if (!log) {
+    return false;
+  }
+
+  if (!canManageAllAppointments(actor.role) && actor.role !== WebUserRole.Specialist) {
+    throw new Error('FORBIDDEN_NOTIFICATION_SCOPE');
+  }
+
+  if (actor.role === WebUserRole.Owner) {
+    return resetNotificationForResend({ notificationId });
+  }
+
+  if (actor.role === WebUserRole.Admin) {
+    if (log.account_id !== actor.accountId) {
+      throw new Error('FORBIDDEN_NOTIFICATION_SCOPE');
+    }
+
+    return resetNotificationForResend({ notificationId, accountId: actor.accountId });
+  }
+
+  if (actor.role === WebUserRole.Specialist) {
+    if (log.account_id !== actor.accountId || log.specialist_id !== specialistScopeId) {
+      throw new Error('FORBIDDEN_NOTIFICATION_SCOPE');
+    }
+
+    return resetNotificationForResend({
+      notificationId,
+      accountId: actor.accountId,
+      specialistId: specialistScopeId ?? undefined,
+    });
+  }
+
+  throw new Error('FORBIDDEN_NOTIFICATION_SCOPE');
+}

--- a/server/tests/notifications.routes.smoke.test.ts
+++ b/server/tests/notifications.routes.smoke.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import { createApp } from '../src/app.js';
+import { WebUserRole } from '../src/types/webUserRole.js';
+
+const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
+const getNotificationLogsForActorMock = vi.hoisted(() => vi.fn());
+const resendFailedNotificationForActorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/authService.js', () => ({
+  resolveUserByAccessToken: resolveUserByAccessTokenMock,
+}));
+
+vi.mock('../src/services/notificationLogService.js', () => ({
+  getNotificationLogsForActor: getNotificationLogsForActorMock,
+  resendFailedNotificationForActor: resendFailedNotificationForActorMock,
+}));
+
+const authedUser = {
+  id: '101',
+  accountId: 1,
+  email: 'owner@example.com',
+  role: WebUserRole.Owner,
+  passwordSalt: 'salt',
+  passwordHash: 'hash',
+  createdAt: '2026-04-22T09:00:00.000Z',
+};
+
+describe('notifications API route-smoke scenarios (mocked service layer)', () => {
+  const app = createApp();
+  let baseUrl = '';
+  let server: Awaited<ReturnType<typeof app.listen>>;
+
+  beforeAll(async () => {
+    server = await new Promise((resolve) => {
+      const started = app.listen(0, () => resolve(started));
+    });
+
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    resolveUserByAccessTokenMock.mockReset();
+    getNotificationLogsForActorMock.mockReset();
+    resendFailedNotificationForActorMock.mockReset();
+
+    resolveUserByAccessTokenMock.mockResolvedValue(authedUser);
+  });
+
+  it('list: GET /api/notifications returns items', async () => {
+    getNotificationLogsForActorMock.mockResolvedValue({
+      items: [{
+        id: 1,
+        accountId: 10,
+        specialistId: 20,
+        userId: 30,
+        appointmentId: 100,
+        status: 'failed',
+        type: 'appointment_reminder',
+        channel: 'email',
+        attempts: 3,
+        maxAttempts: 3,
+        recipientEmail: 'x@example.com',
+        lastError: 'smtp failed',
+        sendAt: '2026-04-27T10:00:00.000Z',
+        nextRetryAt: null,
+        sentAt: null,
+        createdAt: '2026-04-27T10:00:00.000Z',
+        updatedAt: '2026-04-27T10:05:00.000Z',
+      }],
+    });
+
+    const response = await fetch(`${baseUrl}/api/notifications?accountId=10&specialistId=20&userId=30`, {
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ items: [{ id: 1 }] });
+  });
+
+  it('resend: POST /api/notifications/:id/resend returns success message', async () => {
+    resendFailedNotificationForActorMock.mockResolvedValue(true);
+
+    const response = await fetch(`${baseUrl}/api/notifications/1/resend`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer smoke-token' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ message: expect.any(String) });
+  });
+});

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -8,6 +8,7 @@ import { AppointmentsPage } from '../pages/AppointmentsPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { SpecialistsPage } from '../pages/SpecialistsPage';
 import { UsersPage } from '../pages/UsersPage';
+import { NotificationLogsPage } from '../pages/NotificationLogsPage';
 import { useAuth } from '../shared/auth/AuthContext';
 
 function ProtectedRoute({ children }: { children: ReactElement }) {
@@ -87,6 +88,14 @@ export const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <UsersPage />
+          </ProtectedRoute>
+        )
+      },
+      {
+        path: '/notification-logs',
+        element: (
+          <ProtectedRoute>
+            <NotificationLogsPage />
           </ProtectedRoute>
         )
       }

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -55,6 +55,9 @@ export function MainLayout() {
     ...(user?.role === 'owner' || user?.role === 'admin' || user?.role === 'specialist'
       ? [{ to: '/users', label: t('common.users'), icon: 'users' as const }]
       : []),
+    ...(user?.role === 'owner' || user?.role === 'admin' || user?.role === 'specialist'
+      ? [{ to: '/notification-logs', label: t('common.notificationLogs'), icon: 'notifications' as const }]
+      : []),
     { to: '/settings', label: t('common.settings'), icon: 'settings' as const }
   ];
 

--- a/web/src/containers/NotificationLogsContainer.tsx
+++ b/web/src/containers/NotificationLogsContainer.tsx
@@ -1,0 +1,216 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiClient, authHeaders } from '../shared/api/client';
+import { resolveApiError } from '../shared/api/error';
+import { useAuth } from '../shared/auth/AuthContext';
+import { useI18n } from '../shared/i18n/I18nContext';
+import type { NotificationLogItem, NotificationLogsResponse, VerifyEmailResponse } from '../shared/types/api';
+import { WebUserRole } from '../shared/types/roles';
+import { AppPage } from '../shared/ui/AppPage';
+
+type Filters = {
+  accountId: string;
+  specialistId: string;
+  userId: string;
+};
+
+const FAILED_STATUSES = new Set(['failed', 'retry', 'cancelled']);
+
+export function NotificationLogsContainer() {
+  const { accessToken, user } = useAuth();
+  const { t } = useI18n();
+  const navigate = useNavigate();
+
+  const [items, setItems] = useState<NotificationLogItem[]>([]);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isResendingId, setIsResendingId] = useState<number | null>(null);
+  const [filters, setFilters] = useState<Filters>({
+    accountId: '',
+    specialistId: '',
+    userId: '',
+  });
+
+  const canViewLogs = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin || user?.role === WebUserRole.Specialist;
+
+  const loadLogs = useCallback(async () => {
+    if (!accessToken || !canViewLogs) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get<NotificationLogsResponse>('/api/notifications', {
+        headers: authHeaders(accessToken),
+        params: {
+          ...(filters.accountId ? { accountId: Number(filters.accountId) } : {}),
+          ...(filters.specialistId ? { specialistId: Number(filters.specialistId) } : {}),
+          ...(filters.userId ? { userId: Number(filters.userId) } : {}),
+        },
+      });
+
+      setItems(response.data.items);
+      setError('');
+    } catch (err) {
+      setError(resolveApiError(err, {
+        fallbackMessage: t('notificationLogs.errors.load'),
+        networkMessage: t('common.errors.network'),
+      }).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken, canViewLogs, filters.accountId, filters.specialistId, filters.userId, t]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      navigate('/login');
+      return;
+    }
+
+    void loadLogs();
+  }, [accessToken, loadLogs, navigate]);
+
+  const resend = async (item: NotificationLogItem) => {
+    if (!accessToken) {
+      return;
+    }
+
+    setIsResendingId(item.id);
+    try {
+      const response = await apiClient.post<VerifyEmailResponse>(`/api/notifications/${item.id}/resend`, {}, {
+        headers: authHeaders(accessToken),
+      });
+      setSuccess(response.data.message || t('notificationLogs.success.resent'));
+      setError('');
+      await loadLogs();
+    } catch (err) {
+      setError(resolveApiError(err, {
+        fallbackMessage: t('notificationLogs.errors.resend'),
+        networkMessage: t('common.errors.network'),
+      }).message);
+      setSuccess('');
+    } finally {
+      setIsResendingId(null);
+    }
+  };
+
+  return (
+    <AppPage title={t('notificationLogs.pageTitle')} subtitle={t('notificationLogs.pageSubtitle')}>
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+
+      {!canViewLogs ? (
+        <Alert severity="info">{t('notificationLogs.accessDenied')}</Alert>
+      ) : (
+        <Stack spacing={2}>
+          <Card>
+            <CardContent>
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                {user?.role === WebUserRole.Owner && (
+                  <TextField
+                    label={t('notificationLogs.filters.accountId')}
+                    value={filters.accountId}
+                    onChange={(event) => setFilters((prev) => ({ ...prev, accountId: event.target.value.replace(/\D/g, '') }))}
+                    size="small"
+                  />
+                )}
+                <TextField
+                  label={t('notificationLogs.filters.specialistId')}
+                  value={filters.specialistId}
+                  onChange={(event) => setFilters((prev) => ({ ...prev, specialistId: event.target.value.replace(/\D/g, '') }))}
+                  size="small"
+                />
+                <TextField
+                  label={t('notificationLogs.filters.userId')}
+                  value={filters.userId}
+                  onChange={(event) => setFilters((prev) => ({ ...prev, userId: event.target.value.replace(/\D/g, '') }))}
+                  size="small"
+                />
+                <Button variant="contained" onClick={() => void loadLogs()}>{t('notificationLogs.filters.apply')}</Button>
+              </Stack>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent>
+              {isLoading ? (
+                <Stack spacing={2}>
+                  <Skeleton variant="rounded" height={40} />
+                  <Skeleton variant="rounded" height={220} />
+                </Stack>
+              ) : items.length === 0 ? (
+                <Typography color="text.secondary">{t('notificationLogs.empty')}</Typography>
+              ) : (
+                <Box sx={{ overflowX: 'auto' }}>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>ID</TableCell>
+                        <TableCell>{t('notificationLogs.columns.accountId')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.specialistId')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.userId')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.type')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.channel')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.status')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.attempts')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.lastError')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.createdAt')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.actions')}</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {items.map((item) => (
+                        <TableRow key={item.id} hover>
+                          <TableCell>{item.id}</TableCell>
+                          <TableCell>{item.accountId}</TableCell>
+                          <TableCell>{item.specialistId}</TableCell>
+                          <TableCell>{item.userId}</TableCell>
+                          <TableCell>{item.type}</TableCell>
+                          <TableCell>{item.channel}</TableCell>
+                          <TableCell>
+                            <Chip label={item.status} size="small" color={item.status === 'sent' ? 'success' : 'default'} />
+                          </TableCell>
+                          <TableCell>{item.attempts}/{item.maxAttempts}</TableCell>
+                          <TableCell sx={{ maxWidth: 280 }}>{item.lastError || '—'}</TableCell>
+                          <TableCell>{new Date(item.createdAt).toLocaleString()}</TableCell>
+                          <TableCell>
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              disabled={!FAILED_STATUSES.has(item.status) || isResendingId === item.id}
+                              onClick={() => void resend(item)}
+                            >
+                              {t('notificationLogs.resend')}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Stack>
+      )}
+    </AppPage>
+  );
+}

--- a/web/src/pages/NotificationLogsPage.tsx
+++ b/web/src/pages/NotificationLogsPage.tsx
@@ -1,0 +1,5 @@
+import { NotificationLogsContainer } from '../containers/NotificationLogsContainer';
+
+export function NotificationLogsPage() {
+  return <NotificationLogsContainer />;
+}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -13,6 +13,7 @@ export const dictionaries = {
       appointments: 'Appointments',
       specialists: 'Specialists',
       users: 'Users',
+      notificationLogs: 'Notification logs',
       profileMenuAria: 'Open profile menu',
       appearancePaletteAria: 'Select color palette',
       themeToggleAria: 'Toggle theme mode',
@@ -206,6 +207,38 @@ export const dictionaries = {
         inviteResent: 'Invite link sent.'
       }
     },
+    notificationLogs: {
+      pageTitle: 'Notification logs',
+      pageSubtitle: 'Delivery history and retry for failed notifications.',
+      accessDenied: 'You do not have access to notification logs.',
+      empty: 'No notification logs found.',
+      resend: 'Resend',
+      filters: {
+        accountId: 'Account ID',
+        specialistId: 'Specialist ID',
+        userId: 'User ID',
+        apply: 'Apply filters'
+      },
+      columns: {
+        accountId: 'Account',
+        specialistId: 'Specialist',
+        userId: 'Client',
+        type: 'Type',
+        channel: 'Channel',
+        status: 'Status',
+        attempts: 'Attempts',
+        lastError: 'Error',
+        createdAt: 'Created at',
+        actions: 'Actions'
+      },
+      errors: {
+        load: 'Unable to load notification logs.',
+        resend: 'Unable to resend notification.'
+      },
+      success: {
+        resent: 'Notification queued for resend.'
+      }
+    },
     appointments: {
       pageTitle: 'Appointments',
       pageSubtitle: 'Calendar view with schedule by day and time.',
@@ -269,6 +302,7 @@ export const dictionaries = {
       appointments: 'Записи',
       specialists: 'Специалисты',
       users: 'Пользователи',
+      notificationLogs: 'Логи уведомлений',
       profileMenuAria: 'Открыть меню профиля',
       appearancePaletteAria: 'Выбрать цветовую палитру',
       themeToggleAria: 'Переключить тему',
@@ -462,6 +496,38 @@ export const dictionaries = {
         inviteResent: 'Ссылка-приглашение отправлена.'
       }
     },
+    notificationLogs: {
+      pageTitle: 'Логи уведомлений',
+      pageSubtitle: 'История доставки и повторная отправка недоставленных уведомлений.',
+      accessDenied: 'У вас нет доступа к логам уведомлений.',
+      empty: 'Логи уведомлений не найдены.',
+      resend: 'Повторить отправку',
+      filters: {
+        accountId: 'ID аккаунта',
+        specialistId: 'ID специалиста',
+        userId: 'ID клиента',
+        apply: 'Применить фильтры'
+      },
+      columns: {
+        accountId: 'Аккаунт',
+        specialistId: 'Специалист',
+        userId: 'Клиент',
+        type: 'Тип',
+        channel: 'Канал',
+        status: 'Статус',
+        attempts: 'Попытки',
+        lastError: 'Ошибка',
+        createdAt: 'Создано',
+        actions: 'Действия'
+      },
+      errors: {
+        load: 'Не удалось загрузить логи уведомлений.',
+        resend: 'Не удалось повторно отправить уведомление.'
+      },
+      success: {
+        resent: 'Уведомление поставлено в очередь на повторную отправку.'
+      }
+    },
     appointments: {
       pageTitle: 'Записи',
       pageSubtitle: 'Календарный вид с расписанием по дням и времени.',
@@ -528,6 +594,7 @@ export type TranslationKey =
   | 'common.appointments'
   | 'common.specialists'
   | 'common.users'
+  | 'common.notificationLogs'
   | 'common.profileMenuAria'
   | 'common.appearancePaletteAria'
   | 'common.themeToggleAria'
@@ -727,6 +794,28 @@ export type TranslationKey =
   | 'appointments.fields.scheduledAt'
   | 'appointments.fields.status'
   | 'appointments.fields.meetingLink'
+  | 'notificationLogs.pageTitle'
+  | 'notificationLogs.pageSubtitle'
+  | 'notificationLogs.accessDenied'
+  | 'notificationLogs.empty'
+  | 'notificationLogs.resend'
+  | 'notificationLogs.filters.accountId'
+  | 'notificationLogs.filters.specialistId'
+  | 'notificationLogs.filters.userId'
+  | 'notificationLogs.filters.apply'
+  | 'notificationLogs.columns.accountId'
+  | 'notificationLogs.columns.specialistId'
+  | 'notificationLogs.columns.userId'
+  | 'notificationLogs.columns.type'
+  | 'notificationLogs.columns.channel'
+  | 'notificationLogs.columns.status'
+  | 'notificationLogs.columns.attempts'
+  | 'notificationLogs.columns.lastError'
+  | 'notificationLogs.columns.createdAt'
+  | 'notificationLogs.columns.actions'
+  | 'notificationLogs.errors.load'
+  | 'notificationLogs.errors.resend'
+  | 'notificationLogs.success.resent'
   | 'appointments.fields.notes';
 
 export const DEFAULT_LOCALE: Locale = 'ru';

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -185,3 +185,27 @@ export type ManagedUserItem = {
 export type ManagedUsersListResponse = {
   users: ManagedUserItem[];
 };
+
+export type NotificationLogItem = {
+  id: number;
+  accountId: number;
+  userId: number;
+  appointmentId: number;
+  specialistId: number;
+  status: string;
+  type: string;
+  channel: string;
+  attempts: number;
+  maxAttempts: number;
+  recipientEmail: string | null;
+  lastError: string | null;
+  sendAt: string;
+  nextRetryAt: string | null;
+  sentAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type NotificationLogsResponse = {
+  items: NotificationLogItem[];
+};

--- a/web/src/shared/ui/AppIcons.tsx
+++ b/web/src/shared/ui/AppIcons.tsx
@@ -7,6 +7,7 @@ import GroupRounded from '@mui/icons-material/GroupRounded';
 import LightModeRounded from '@mui/icons-material/LightModeRounded';
 import LoginRounded from '@mui/icons-material/LoginRounded';
 import LogoutRounded from '@mui/icons-material/LogoutRounded';
+import NotificationsRounded from '@mui/icons-material/NotificationsRounded';
 import PaletteRounded from '@mui/icons-material/PaletteRounded';
 import PersonAddRounded from '@mui/icons-material/PersonAddRounded';
 import PeopleAltRounded from '@mui/icons-material/PeopleAltRounded';
@@ -23,6 +24,7 @@ export const AppIcons = {
   lightMode: LightModeRounded,
   login: LoginRounded,
   logout: LogoutRounded,
+  notifications: NotificationsRounded,
   palette: PaletteRounded,
   register: PersonAddRounded,
   users: PeopleAltRounded,


### PR DESCRIPTION
### Motivation

- Provide a UI for delivery logs and a way to retry undelivered notifications (resend) for operational support. 
- Enforce role-based scopes so owners/admins/specialists only see/resend notifications within their permitted account/specialist scope.

### Description

- Added backend API routes `GET /api/notifications` and `POST /api/notifications/:id/resend` and mounted them in the app. 
- Implemented `notificationLogService` with role/scope resolution (owner/admin/specialist) and repository additions `listNotificationLogs`, `findNotificationLogById`, and `resetNotificationForResend` to query logs and re-queue failed items. 
- Extended `notificationRepository` types and logic to join `appointments` for `specialist_id` filtering and to reset failed notification records to `pending`. 
- Added localized messages for errors/successes and documented the new API in `server/README.md`. 
- Added frontend `NotificationLogsContainer` + `NotificationLogsPage`, router entry, menu item and icon, i18n keys (EN/RU), and API types to display logs, filter by `accountId`/`specialistId`/`userId`, and trigger resend for failed statuses. 
- Added smoke tests for the new routes (`server/tests/notifications.routes.smoke.test.ts`).

### Testing

- Ran backend typecheck with `npm run -w @scheduletm/server typecheck` and it succeeded. 
- Ran frontend typecheck with `npm run -w @scheduletm/web typecheck` and it succeeded. 
- Ran the notifications route smoke tests with `npm run -w @scheduletm/server test -- notifications.routes.smoke.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5ef36350833384978a628cdf446a)