### PR TITLE
Add notification logs feature: backend queries, DTO mapping and web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ scheduletm/
 - Settings: system + account + user settings, plus user integrations.
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
 - Notifications: appointment notify flow with channel fallback (Telegram -> Email) + retry/backoff pipeline in scheduler (`pending/retry/processing/sent/failed`, `next_retry_at`, `max_attempts`, idempotent key per `appointment_id + type + channel`).
+- Notification logs page (`/notification-logs`) with role-aware access (`owner/admin/specialist`), filters and human-readable fields (specialist/client names, message, Telegram, email), including manual resend for failed deliveries.
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
 - Late cancellation UX (web + bot): before cancel confirmation the user sees refund/no-refund outcome according to specialist booking policy (`cancel_grace_period_hours`, `refund_on_late_cancel`), and after cancellation bot sends final refund status.
 - Scheduler: auto-cancel unpaid appointments by specialist booking policy (`auto_cancel_unpaid_enabled`, `unpaid_auto_cancel_after_hours`) with audit reason `auto_cancel_unpaid`.

--- a/server/README.md
+++ b/server/README.md
@@ -78,7 +78,13 @@ npm run -w @scheduletm/server test
 - `GET /api/notifications`
   - доступ: `owner`, `admin`, `specialist`;
   - scope: `owner` видит все аккаунты (опциональный фильтр `accountId`), `admin` только свой `account_id`, `specialist` только уведомления своих клиентов;
-  - фильтры: `accountId`, `specialistId`, `userId`.
+  - фильтры: `accountId`, `specialistId`, `userId`;
+  - ключевые поля в `items[]`:
+    - `specialistName` — имя специалиста (если найден);
+    - `clientName` — отображаемое имя клиента (ФИО, fallback на контакт);
+    - `message` — текст сообщения из `payload_json.message` (fallback: `payload_json.timing`);
+    - `recipientTelegram` — telegram username клиента;
+    - `recipientEmail` — email получателя уведомления.
 - `POST /api/notifications/:id/resend`
   - повторно ставит в очередь только недоставленные уведомления (`failed`, `retry`, `cancelled`) в рамках доступного scope.
 

--- a/server/src/repositories/notificationRepository.ts
+++ b/server/src/repositories/notificationRepository.ts
@@ -15,12 +15,19 @@ export type NotificationLogRecord = {
   attempts: number;
   max_attempts: number;
   recipient_email: string | null;
+  recipient_chat_id: string | null;
+  payload_json: Record<string, unknown> | null;
   last_error: string | null;
   send_at: Date;
   next_retry_at: Date | null;
   sent_at: Date | null;
   created_at: Date;
   updated_at: Date;
+  specialist_name: string | null;
+  client_first_name: string | null;
+  client_last_name: string | null;
+  client_username: string | null;
+  client_email: string | null;
 };
 
 function computeNextRetryAt(now: Date, attemptNo: number): Date {
@@ -221,6 +228,12 @@ export async function listNotificationLogs(filters: {
     .join('appointments as a', function joinAppointments() {
       this.on('a.id', '=', 'n.appointment_id').andOn('a.account_id', '=', 'n.account_id');
     })
+    .leftJoin('specialists as s', function joinSpecialists() {
+      this.on('s.id', '=', 'a.specialist_id').andOn('s.account_id', '=', 'a.account_id');
+    })
+    .leftJoin('clients as c', function joinClients() {
+      this.on('c.id', '=', 'n.user_id').andOn('c.account_id', '=', 'n.account_id');
+    })
     .orderBy('n.created_at', 'desc')
     .limit(filters.limit ?? 300);
 
@@ -248,12 +261,19 @@ export async function listNotificationLogs(filters: {
     'n.attempts',
     'n.max_attempts',
     'n.recipient_email',
+    'n.recipient_chat_id',
+    'n.payload_json',
     'n.last_error',
     'n.send_at',
     'n.next_retry_at',
     'n.sent_at',
     'n.created_at',
     'n.updated_at',
+    's.name as specialist_name',
+    'c.first_name as client_first_name',
+    'c.last_name as client_last_name',
+    'c.username as client_username',
+    'c.email as client_email',
   );
 }
 
@@ -261,6 +281,12 @@ export async function findNotificationLogById(notificationId: number): Promise<N
   const row = await db('notifications as n')
     .join('appointments as a', function joinAppointments() {
       this.on('a.id', '=', 'n.appointment_id').andOn('a.account_id', '=', 'n.account_id');
+    })
+    .leftJoin('specialists as s', function joinSpecialists() {
+      this.on('s.id', '=', 'a.specialist_id').andOn('s.account_id', '=', 'a.account_id');
+    })
+    .leftJoin('clients as c', function joinClients() {
+      this.on('c.id', '=', 'n.user_id').andOn('c.account_id', '=', 'n.account_id');
     })
     .where('n.id', notificationId)
     .first<NotificationLogRecord>(
@@ -275,12 +301,19 @@ export async function findNotificationLogById(notificationId: number): Promise<N
       'n.attempts',
       'n.max_attempts',
       'n.recipient_email',
+      'n.recipient_chat_id',
+      'n.payload_json',
       'n.last_error',
       'n.send_at',
       'n.next_retry_at',
       'n.sent_at',
       'n.created_at',
       'n.updated_at',
+      's.name as specialist_name',
+      'c.first_name as client_first_name',
+      'c.last_name as client_last_name',
+      'c.username as client_username',
+      'c.email as client_email',
     );
 
   return row ?? null;

--- a/server/src/services/notificationLogService.ts
+++ b/server/src/services/notificationLogService.ts
@@ -20,6 +20,10 @@ export type NotificationLogDto = {
   channel: string;
   attempts: number;
   maxAttempts: number;
+  message: string | null;
+  specialistName: string | null;
+  clientName: string | null;
+  recipientTelegram: string | null;
   recipientEmail: string | null;
   lastError: string | null;
   sendAt: string;
@@ -28,6 +32,40 @@ export type NotificationLogDto = {
   createdAt: string;
   updatedAt: string;
 };
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
+
+function resolveNotificationMessage(item: NotificationLogRecord): string | null {
+  const payload = item.payload_json;
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const payloadMessage = normalizeString((payload as Record<string, unknown>).message);
+  if (payloadMessage) {
+    return payloadMessage;
+  }
+
+  return normalizeString((payload as Record<string, unknown>).timing);
+}
+
+function resolveClientName(item: NotificationLogRecord): string | null {
+  const first = item.client_first_name?.trim() ?? '';
+  const last = item.client_last_name?.trim() ?? '';
+  const full = `${first} ${last}`.trim();
+  if (full) {
+    return full;
+  }
+
+  return item.client_email?.trim() || item.client_username?.trim() || null;
+}
 
 function mapLog(item: NotificationLogRecord): NotificationLogDto {
   return {
@@ -41,6 +79,10 @@ function mapLog(item: NotificationLogRecord): NotificationLogDto {
     channel: item.channel,
     attempts: item.attempts,
     maxAttempts: item.max_attempts,
+    message: resolveNotificationMessage(item),
+    specialistName: item.specialist_name?.trim() || null,
+    clientName: resolveClientName(item),
+    recipientTelegram: item.client_username?.trim() || null,
     recipientEmail: item.recipient_email,
     lastError: item.last_error,
     sendAt: item.send_at.toISOString(),

--- a/web/README.md
+++ b/web/README.md
@@ -5,11 +5,12 @@ React SPA для owner/admin/specialist/client.
 ## Что умеет
 
 - Auth: `/login`, `/register`, `/invite/accept`, `/verify-email`.
-- Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`.
+- Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`, `/notification-logs`.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
 - Client flow: клиент работает только со своим расписанием (без доступа к чужим записям).
+- Notification logs (`/notification-logs`): таблица истории отправки с фильтрами (`accountId`, `specialistId`, `userId`) и колонками для читаемых данных (`specialistName`, `clientName`, `message`, `recipientTelegram`, `recipientEmail`) + retry action для статусов `failed/retry/cancelled`.
 
 ## Команды
 

--- a/web/src/containers/NotificationLogsContainer.tsx
+++ b/web/src/containers/NotificationLogsContainer.tsx
@@ -165,8 +165,11 @@ export function NotificationLogsContainer() {
                       <TableRow>
                         <TableCell>ID</TableCell>
                         <TableCell>{t('notificationLogs.columns.accountId')}</TableCell>
-                        <TableCell>{t('notificationLogs.columns.specialistId')}</TableCell>
-                        <TableCell>{t('notificationLogs.columns.userId')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.specialist')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.client')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.message')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.telegram')}</TableCell>
+                        <TableCell>{t('notificationLogs.columns.email')}</TableCell>
                         <TableCell>{t('notificationLogs.columns.type')}</TableCell>
                         <TableCell>{t('notificationLogs.columns.channel')}</TableCell>
                         <TableCell>{t('notificationLogs.columns.status')}</TableCell>
@@ -181,8 +184,11 @@ export function NotificationLogsContainer() {
                         <TableRow key={item.id} hover>
                           <TableCell>{item.id}</TableCell>
                           <TableCell>{item.accountId}</TableCell>
-                          <TableCell>{item.specialistId}</TableCell>
-                          <TableCell>{item.userId}</TableCell>
+                          <TableCell>{item.specialistName || `#${item.specialistId}`}</TableCell>
+                          <TableCell>{item.clientName || `#${item.userId}`}</TableCell>
+                          <TableCell sx={{ maxWidth: 220 }}>{item.message || '—'}</TableCell>
+                          <TableCell>{item.recipientTelegram || '—'}</TableCell>
+                          <TableCell>{item.recipientEmail || '—'}</TableCell>
                           <TableCell>{item.type}</TableCell>
                           <TableCell>{item.channel}</TableCell>
                           <TableCell>

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -223,6 +223,11 @@ export const dictionaries = {
         accountId: 'Account',
         specialistId: 'Specialist',
         userId: 'Client',
+        specialist: 'Specialist',
+        client: 'Client',
+        message: 'Message',
+        telegram: 'Telegram',
+        email: 'Email',
         type: 'Type',
         channel: 'Channel',
         status: 'Status',
@@ -512,6 +517,11 @@ export const dictionaries = {
         accountId: 'Аккаунт',
         specialistId: 'Специалист',
         userId: 'Клиент',
+        specialist: 'Специалист',
+        client: 'Клиент',
+        message: 'Сообщение',
+        telegram: 'Telegram',
+        email: 'Email',
         type: 'Тип',
         channel: 'Канал',
         status: 'Статус',
@@ -806,6 +816,11 @@ export type TranslationKey =
   | 'notificationLogs.columns.accountId'
   | 'notificationLogs.columns.specialistId'
   | 'notificationLogs.columns.userId'
+  | 'notificationLogs.columns.specialist'
+  | 'notificationLogs.columns.client'
+  | 'notificationLogs.columns.message'
+  | 'notificationLogs.columns.telegram'
+  | 'notificationLogs.columns.email'
   | 'notificationLogs.columns.type'
   | 'notificationLogs.columns.channel'
   | 'notificationLogs.columns.status'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -197,6 +197,10 @@ export type NotificationLogItem = {
   channel: string;
   attempts: number;
   maxAttempts: number;
+  message: string | null;
+  specialistName: string | null;
+  clientName: string | null;
+  recipientTelegram: string | null;
   recipientEmail: string | null;
   lastError: string | null;
   sendAt: string;


### PR DESCRIPTION
### Motivation

- Provide a readable notification delivery history with useful fields and filters for owners/admins/specialists and allow manual retry of failed deliveries.  
- Surface human-friendly fields (specialist name, client name, message, telegram/email) and make payload-derived message visible in the UI.  
- Expose the logs via API and show them in the web app so operators can inspect and re-queue failed notifications.

### Description

- Backend: extended `NotificationLogRecord` to include `recipient_chat_id`, `payload_json` and client/specialist fields and updated repository queries in `notificationRepository.ts` to left-join `specialists` and `clients` and select readable columns for `listNotificationLogs` and `findNotificationLogById`.  
- Backend service: added mapping helpers in `notificationLogService.ts` (`normalizeString`, `resolveNotificationMessage`, `resolveClientName`) and mapped DB rows to `NotificationLogDto` with `message`, `specialistName`, `clientName`, and `recipientTelegram`.  
- Frontend: added UI columns and rendering in `NotificationLogsContainer.tsx` to show `specialistName`, `clientName`, `message`, `recipientTelegram`, and `recipientEmail` and kept the retry action for failed statuses; updated API types in `web/src/shared/types/api.ts`.  
- Docs and i18n: updated `README.md`, `server/README.md`, `web/README.md` and translation dictionaries (`dictionaries.ts`) to document the new `/notification-logs` page and API fields and to add new translation keys.

### Testing

- Ran backend tests with `npm run -w @scheduletm/server test` and they completed successfully.  
- Ran frontend tests with `npm run -w @scheduletm/web test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6572c7688333a5785d64d81465b3)