### PR TITLE
feat: add owner-facing web & server error tracking with 7-day retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ scheduletm/
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
 - Notifications: appointment notify flow with channel fallback (Telegram -> Email) + retry/backoff pipeline in scheduler (`pending/retry/processing/sent/failed`, `next_retry_at`, `max_attempts`, idempotent key per `appointment_id + type + channel`).
 - Notification logs page (`/notification-logs`) with role-aware access (`owner/admin/specialist`), filters and human-readable fields (specialist/client names, message, Telegram, email), including manual resend for failed deliveries.
+- Error tracking for `web` + `server`: frontend runtime errors and backend `5xx` responses are persisted in `error_logs`; UI page `/error-logs` is available only for `owner`; retention is 7 days.
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
 - Late cancellation UX (web + bot): before cancel confirmation the user sees refund/no-refund outcome according to specialist booking policy (`cancel_grace_period_hours`, `refund_on_late_cancel`), and after cancellation bot sends final refund status.
 - Scheduler: auto-cancel unpaid appointments by specialist booking policy (`auto_cancel_unpaid_enabled`, `unpaid_auto_cancel_after_hours`) with audit reason `auto_cancel_unpaid`.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,8 @@ import { settingsRoutes } from './routes/settingsRoutes.js';
 import { specialistRoutes } from './routes/specialistRoutes.js';
 import { userManagementRoutes } from './routes/userManagementRoutes.js';
 import { notificationRoutes } from './routes/notificationRoutes.js';
+import { errorLogRoutes } from './routes/errorLogRoutes.js';
+import { trackServerError } from './services/errorTrackingService.js';
 
 export const createApp = () => {
   const app = express();
@@ -34,6 +36,20 @@ export const createApp = () => {
   );
   app.use(express.json({ limit: '32kb' }));
 
+  app.use((req, res, next) => {
+    res.on('finish', () => {
+      if (res.statusCode >= 500) {
+        void trackServerError({
+          method: req.method,
+          path: req.originalUrl,
+          error: new Error(`HTTP_${res.statusCode}`),
+        });
+      }
+    });
+
+    next();
+  });
+
   app.use(healthRoutes);
   app.use('/api/auth', authRoutes);
   app.use('/api/settings', settingsRoutes);
@@ -42,6 +58,7 @@ export const createApp = () => {
   app.use('/api/users', userManagementRoutes);
   app.use('/api/integrations', integrationRoutes);
   app.use('/api/notifications', notificationRoutes);
+  app.use('/api/error-logs', errorLogRoutes);
 
   app.use((_req, res) => {
     res.status(404).json({ message: 'Not found' });

--- a/server/src/db/migrations/20260427123000_create_error_logs.ts
+++ b/server/src/db/migrations/20260427123000_create_error_logs.ts
@@ -1,0 +1,42 @@
+import type { Knex } from 'knex';
+
+const SOURCE_CHECK = `source IN ('web', 'server')`;
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable('error_logs');
+  if (hasTable) {
+    return;
+  }
+
+  await knex.schema.createTable('error_logs', (table) => {
+    table.increments('id').primary();
+    table.integer('account_id').unsigned().nullable().references('id').inTable('accounts').onDelete('SET NULL');
+    table.integer('web_user_id').unsigned().nullable().references('id').inTable('web_users').onDelete('SET NULL');
+    table.string('source', 16).notNullable();
+    table.string('level', 16).notNullable().defaultTo('error');
+    table.string('method', 16).nullable();
+    table.string('path', 255).nullable();
+    table.text('message').notNullable();
+    table.text('stack').nullable();
+    table.jsonb('metadata_json').nullable();
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+
+  await knex.raw(
+    `ALTER TABLE "error_logs" ADD CONSTRAINT "error_logs_source_check" CHECK (${SOURCE_CHECK})`,
+  );
+
+  await knex.raw('CREATE INDEX IF NOT EXISTS "error_logs_created_at_idx" ON "error_logs" ("created_at" DESC)');
+  await knex.raw('CREATE INDEX IF NOT EXISTS "error_logs_source_created_at_idx" ON "error_logs" ("source", "created_at" DESC)');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable('error_logs');
+  if (!hasTable) {
+    return;
+  }
+
+  await knex.raw('DROP INDEX IF EXISTS "error_logs_source_created_at_idx"');
+  await knex.raw('DROP INDEX IF EXISTS "error_logs_created_at_idx"');
+  await knex.schema.dropTable('error_logs');
+}

--- a/server/src/i18n/dictionaries.ts
+++ b/server/src/i18n/dictionaries.ts
@@ -76,7 +76,10 @@ export const dictionaries = {
       forbiddenNotificationScope: 'Insufficient permissions for this notification',
       notificationsLoadFailed: 'Unable to load notifications',
       notificationResendSuccess: 'Notification queued for resend',
-      notificationResendFailed: 'Unable to resend notification'
+      notificationResendFailed: 'Unable to resend notification',
+      forbiddenErrorLogsScope: 'Insufficient permissions for error logs',
+      errorLogsLoadFailed: 'Unable to load error logs',
+      errorLogsCreateFailed: 'Unable to create error log'
     }
   },
   ru: {
@@ -156,7 +159,10 @@ export const dictionaries = {
       forbiddenNotificationScope: 'Недостаточно прав для этого уведомления',
       notificationsLoadFailed: 'Не удалось загрузить уведомления',
       notificationResendSuccess: 'Уведомление поставлено в очередь на повторную отправку',
-      notificationResendFailed: 'Не удалось повторно отправить уведомление'
+      notificationResendFailed: 'Не удалось повторно отправить уведомление',
+      forbiddenErrorLogsScope: 'Недостаточно прав для логов ошибок',
+      errorLogsLoadFailed: 'Не удалось загрузить логи ошибок',
+      errorLogsCreateFailed: 'Не удалось сохранить лог ошибки'
     }
   }
 } as const;

--- a/server/src/repositories/errorLogRepository.ts
+++ b/server/src/repositories/errorLogRepository.ts
@@ -1,0 +1,65 @@
+import { db } from '../db/knex.js';
+
+export type ErrorLogRecord = {
+  id: number;
+  account_id: number | null;
+  web_user_id: number | null;
+  source: 'web' | 'server';
+  level: string;
+  method: string | null;
+  path: string | null;
+  message: string;
+  stack: string | null;
+  metadata_json: Record<string, unknown> | null;
+  created_at: Date;
+};
+
+export async function insertErrorLog(input: {
+  accountId?: number | null;
+  webUserId?: number | null;
+  source: 'web' | 'server';
+  method?: string | null;
+  path?: string | null;
+  message: string;
+  stack?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): Promise<void> {
+  await db('error_logs').insert({
+    account_id: input.accountId ?? null,
+    web_user_id: input.webUserId ?? null,
+    source: input.source,
+    level: 'error',
+    method: input.method ?? null,
+    path: input.path ?? null,
+    message: input.message,
+    stack: input.stack ?? null,
+    metadata_json: input.metadata ?? null,
+    created_at: db.fn.now(),
+  });
+}
+
+export async function listErrorLogs(filters: {
+  source?: 'web' | 'server';
+  accountId?: number;
+  limit?: number;
+}): Promise<ErrorLogRecord[]> {
+  const query = db('error_logs').orderBy('created_at', 'desc').limit(filters.limit ?? 300);
+
+  if (filters.source) {
+    query.where('source', filters.source);
+  }
+
+  if (filters.accountId !== undefined) {
+    query.where('account_id', filters.accountId);
+  }
+
+  return query.select<ErrorLogRecord[]>('*');
+}
+
+export async function purgeExpiredErrorLogs(retentionDays = 7): Promise<number> {
+  const result = await db('error_logs')
+    .whereRaw('created_at < NOW() - (? * INTERVAL \'1 day\')', [retentionDays])
+    .delete();
+
+  return result;
+}

--- a/server/src/routes/errorLogRoutes.ts
+++ b/server/src/routes/errorLogRoutes.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { t } from '../i18n/index.js';
+import { requireAccessToken, type AuthedRequest } from '../middlewares/authMiddleware.js';
+import { getErrorLogsForActor, trackWebError } from '../services/errorTrackingService.js';
+
+const listErrorLogsQuerySchema = z.object({
+  source: z.enum(['web', 'server']).optional(),
+  accountId: z.coerce.number().int().positive().optional(),
+});
+
+const createWebErrorSchema = z.object({
+  message: z.string().trim().min(1).max(2000),
+  stack: z.string().trim().max(6000).optional(),
+  path: z.string().trim().max(255).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const errorLogRoutes = Router();
+
+errorLogRoutes.use(requireAccessToken);
+
+errorLogRoutes.get('/', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const parsed = listErrorLogsQuerySchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  try {
+    const result = await getErrorLogsForActor(actor, parsed.data);
+    return res.json(result);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'FORBIDDEN_ERROR_LOGS_SCOPE') {
+      return res.status(403).json({ message: t(req, 'forbiddenErrorLogsScope') });
+    }
+
+    console.error(error);
+    return res.status(500).json({ message: t(req, 'errorLogsLoadFailed') });
+  }
+});
+
+errorLogRoutes.post('/web', async (req, res) => {
+  const actor = (req as unknown as AuthedRequest).user;
+  const parsed = createWebErrorSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({ message: t(req, 'invalidPayloadAccountSettings') });
+  }
+
+  try {
+    await trackWebError({
+      actor,
+      message: parsed.data.message,
+      stack: parsed.data.stack,
+      path: parsed.data.path,
+      metadata: parsed.data.metadata,
+    });
+
+    return res.status(201).json({ ok: true });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: t(req, 'errorLogsCreateFailed') });
+  }
+});

--- a/server/src/services/errorTrackingService.ts
+++ b/server/src/services/errorTrackingService.ts
@@ -1,0 +1,111 @@
+import { canManageSystemSettings } from '../policies/rolePermissions.js';
+import { insertErrorLog, listErrorLogs, purgeExpiredErrorLogs, type ErrorLogRecord } from '../repositories/errorLogRepository.js';
+import type { User } from '../types/domain.js';
+
+const ERROR_MESSAGE_MAX = 2000;
+const ERROR_STACK_MAX = 6000;
+
+export type ErrorLogDto = {
+  id: number;
+  accountId: number | null;
+  webUserId: number | null;
+  source: 'web' | 'server';
+  level: string;
+  method: string | null;
+  path: string | null;
+  message: string;
+  stack: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+};
+
+function normalizeText(value: unknown, max = ERROR_MESSAGE_MAX): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().slice(0, max);
+}
+
+function mapErrorLog(item: ErrorLogRecord): ErrorLogDto {
+  return {
+    id: item.id,
+    accountId: item.account_id,
+    webUserId: item.web_user_id,
+    source: item.source,
+    level: item.level,
+    method: item.method,
+    path: item.path,
+    message: item.message,
+    stack: item.stack,
+    metadata: item.metadata_json,
+    createdAt: item.created_at.toISOString(),
+  };
+}
+
+async function cleanupExpiredLogs(): Promise<void> {
+  await purgeExpiredErrorLogs(7);
+}
+
+export async function trackWebError(input: {
+  actor: User;
+  message: unknown;
+  stack?: unknown;
+  path?: unknown;
+  metadata?: unknown;
+}): Promise<void> {
+  const message = normalizeText(input.message);
+  if (!message) {
+    return;
+  }
+
+  await insertErrorLog({
+    accountId: input.actor.accountId,
+    webUserId: Number(input.actor.id),
+    source: 'web',
+    path: normalizeText(input.path, 255) || null,
+    message,
+    stack: normalizeText(input.stack, ERROR_STACK_MAX) || null,
+    metadata: typeof input.metadata === 'object' && input.metadata !== null
+      ? (input.metadata as Record<string, unknown>)
+      : null,
+  });
+
+  await cleanupExpiredLogs();
+}
+
+export async function trackServerError(input: {
+  actor?: User;
+  method?: string;
+  path?: string;
+  error: unknown;
+}): Promise<void> {
+  const error = input.error instanceof Error ? input.error : new Error('Unknown server error');
+  await insertErrorLog({
+    accountId: input.actor?.accountId ?? null,
+    webUserId: input.actor ? Number(input.actor.id) : null,
+    source: 'server',
+    method: input.method?.slice(0, 16) ?? null,
+    path: input.path?.slice(0, 255) ?? null,
+    message: normalizeText(error.message) || 'Server error',
+    stack: normalizeText(error.stack, ERROR_STACK_MAX) || null,
+  });
+
+  await cleanupExpiredLogs();
+}
+
+export async function getErrorLogsForActor(
+  actor: User,
+  filters: { source?: 'web' | 'server'; accountId?: number },
+): Promise<{ items: ErrorLogDto[] }> {
+  if (!canManageSystemSettings(actor.role)) {
+    throw new Error('FORBIDDEN_ERROR_LOGS_SCOPE');
+  }
+
+  const items = await listErrorLogs({
+    source: filters.source,
+    accountId: filters.accountId,
+  });
+
+  return { items: items.map(mapErrorLog) };
+}

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -12,6 +12,7 @@ import {
 import { createAppTheme } from '../shared/theme/createAppTheme';
 import { router } from './router';
 import { AppErrorBoundary } from './AppErrorBoundary';
+import { WebErrorTracker } from './WebErrorTracker';
 
 function getInitialMode(): ThemeMode {
   const persisted = localStorage.getItem('ui-theme-mode');
@@ -48,6 +49,7 @@ export function App() {
         <ThemeProvider theme={theme}>
           <I18nProvider>
             <AuthProvider>
+              <WebErrorTracker />
               <CssBaseline />
               <RouterProvider router={router} />
             </AuthProvider>

--- a/web/src/app/WebErrorTracker.tsx
+++ b/web/src/app/WebErrorTracker.tsx
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import { apiClient, authHeaders } from '../shared/api/client';
+import { useAuth } from '../shared/auth/AuthContext';
+
+const MAX_TEXT_LENGTH = 2000;
+
+function normalizeText(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().slice(0, MAX_TEXT_LENGTH);
+}
+
+export function WebErrorTracker() {
+  const { accessToken } = useAuth();
+
+  useEffect(() => {
+    if (!accessToken) {
+      return;
+    }
+
+    const postError = (payload: { message: string; stack?: string; path?: string; metadata?: Record<string, unknown> }) => {
+      void apiClient.post('/api/error-logs/web', payload, {
+        headers: authHeaders(accessToken),
+      });
+    };
+
+    const onWindowError = (event: ErrorEvent) => {
+      const message = normalizeText(event.message || event.error?.message || 'Unhandled window error');
+      if (!message) {
+        return;
+      }
+
+      postError({
+        message,
+        stack: normalizeText(event.error?.stack),
+        path: normalizeText(window.location.pathname),
+        metadata: {
+          type: 'error',
+          filename: normalizeText(event.filename),
+          lineno: event.lineno,
+          colno: event.colno,
+        },
+      });
+    };
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      const message = normalizeText(reason instanceof Error ? reason.message : String(reason));
+      if (!message) {
+        return;
+      }
+
+      postError({
+        message,
+        stack: normalizeText(reason instanceof Error ? reason.stack : ''),
+        path: normalizeText(window.location.pathname),
+        metadata: { type: 'unhandledrejection' },
+      });
+    };
+
+    window.addEventListener('error', onWindowError);
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('error', onWindowError);
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    };
+  }, [accessToken]);
+
+  return null;
+}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -9,6 +9,7 @@ import { SettingsPage } from '../pages/SettingsPage';
 import { SpecialistsPage } from '../pages/SpecialistsPage';
 import { UsersPage } from '../pages/UsersPage';
 import { NotificationLogsPage } from '../pages/NotificationLogsPage';
+import { ErrorLogsPage } from '../pages/ErrorLogsPage';
 import { useAuth } from '../shared/auth/AuthContext';
 
 function ProtectedRoute({ children }: { children: ReactElement }) {
@@ -98,7 +99,16 @@ export const router = createBrowserRouter([
             <NotificationLogsPage />
           </ProtectedRoute>
         )
-      }
+      },
+
+      {
+        path: '/error-logs',
+        element: (
+          <ProtectedRoute>
+            <ErrorLogsPage />
+          </ProtectedRoute>
+        )
+      },
     ]
   }
 ]);

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -58,6 +58,9 @@ export function MainLayout() {
     ...(user?.role === 'owner' || user?.role === 'admin' || user?.role === 'specialist'
       ? [{ to: '/notification-logs', label: t('common.notificationLogs'), icon: 'notifications' as const }]
       : []),
+    ...(user?.role === 'owner'
+      ? [{ to: '/error-logs', label: t('common.errorLogs'), icon: 'errors' as const }]
+      : []),
     { to: '/settings', label: t('common.settings'), icon: 'settings' as const }
   ];
 

--- a/web/src/containers/ErrorLogsContainer.tsx
+++ b/web/src/containers/ErrorLogsContainer.tsx
@@ -1,0 +1,103 @@
+import { Alert, Card, CardContent, Chip, Skeleton, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiClient, authHeaders } from '../shared/api/client';
+import { resolveApiError } from '../shared/api/error';
+import { useAuth } from '../shared/auth/AuthContext';
+import { useI18n } from '../shared/i18n/I18nContext';
+import type { ErrorLogItem, ErrorLogsResponse } from '../shared/types/api';
+import { WebUserRole } from '../shared/types/roles';
+import { AppPage } from '../shared/ui/AppPage';
+
+export function ErrorLogsContainer() {
+  const { accessToken, user } = useAuth();
+  const { t } = useI18n();
+  const navigate = useNavigate();
+
+  const [items, setItems] = useState<ErrorLogItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const canViewLogs = user?.role === WebUserRole.Owner;
+
+  const loadLogs = useCallback(async () => {
+    if (!accessToken || !canViewLogs) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get<ErrorLogsResponse>('/api/error-logs', {
+        headers: authHeaders(accessToken),
+      });
+      setItems(response.data.items);
+      setError('');
+    } catch (err) {
+      setError(resolveApiError(err, {
+        fallbackMessage: t('errorLogs.errors.load'),
+        networkMessage: t('common.errors.network'),
+      }).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken, canViewLogs, t]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      navigate('/login');
+      return;
+    }
+
+    void loadLogs();
+  }, [accessToken, loadLogs, navigate]);
+
+  return (
+    <AppPage title={t('errorLogs.pageTitle')} subtitle={t('errorLogs.pageSubtitle')}>
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      {!canViewLogs ? (
+        <Alert severity="info">{t('errorLogs.accessDenied')}</Alert>
+      ) : (
+        <Card>
+          <CardContent>
+            {isLoading ? (
+              <Stack spacing={2}>
+                <Skeleton variant="rounded" height={40} />
+                <Skeleton variant="rounded" height={240} />
+              </Stack>
+            ) : items.length === 0 ? (
+              <Typography color="text.secondary">{t('errorLogs.empty')}</Typography>
+            ) : (
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>{t('errorLogs.columns.createdAt')}</TableCell>
+                    <TableCell>{t('errorLogs.columns.source')}</TableCell>
+                    <TableCell>{t('errorLogs.columns.path')}</TableCell>
+                    <TableCell>{t('errorLogs.columns.message')}</TableCell>
+                    <TableCell>{t('errorLogs.columns.accountId')}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {items.map((item) => (
+                    <TableRow key={item.id} hover>
+                      <TableCell>{item.id}</TableCell>
+                      <TableCell>{new Date(item.createdAt).toLocaleString()}</TableCell>
+                      <TableCell>
+                        <Chip size="small" label={item.source} color={item.source === 'server' ? 'warning' : 'default'} />
+                      </TableCell>
+                      <TableCell>{item.path || '—'}</TableCell>
+                      <TableCell sx={{ maxWidth: 420 }}>{item.message}</TableCell>
+                      <TableCell>{item.accountId ?? '—'}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </AppPage>
+  );
+}

--- a/web/src/pages/ErrorLogsPage.tsx
+++ b/web/src/pages/ErrorLogsPage.tsx
@@ -1,0 +1,5 @@
+import { ErrorLogsContainer } from '../containers/ErrorLogsContainer';
+
+export function ErrorLogsPage() {
+  return <ErrorLogsContainer />;
+}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -14,6 +14,7 @@ export const dictionaries = {
       specialists: 'Specialists',
       users: 'Users',
       notificationLogs: 'Notification logs',
+      errorLogs: 'Error logs',
       profileMenuAria: 'Open profile menu',
       appearancePaletteAria: 'Select color palette',
       themeToggleAria: 'Toggle theme mode',
@@ -244,6 +245,23 @@ export const dictionaries = {
         resent: 'Notification queued for resend.'
       }
     },
+
+    errorLogs: {
+      pageTitle: 'Error logs',
+      pageSubtitle: 'Frontend and backend errors for the last 7 days.',
+      accessDenied: 'Only owner can view error logs.',
+      empty: 'No error logs found.',
+      columns: {
+        createdAt: 'Created at',
+        source: 'Source',
+        path: 'Path',
+        message: 'Message',
+        accountId: 'Account'
+      },
+      errors: {
+        load: 'Unable to load error logs.'
+      }
+    },
     appointments: {
       pageTitle: 'Appointments',
       pageSubtitle: 'Calendar view with schedule by day and time.',
@@ -308,6 +326,7 @@ export const dictionaries = {
       specialists: 'Специалисты',
       users: 'Пользователи',
       notificationLogs: 'Логи уведомлений',
+      errorLogs: 'Логи ошибок',
       profileMenuAria: 'Открыть меню профиля',
       appearancePaletteAria: 'Выбрать цветовую палитру',
       themeToggleAria: 'Переключить тему',
@@ -538,6 +557,23 @@ export const dictionaries = {
         resent: 'Уведомление поставлено в очередь на повторную отправку.'
       }
     },
+
+    errorLogs: {
+      pageTitle: 'Логи ошибок',
+      pageSubtitle: 'Ошибки фронтенда и бэкенда за последние 7 дней.',
+      accessDenied: 'Только owner может просматривать логи ошибок.',
+      empty: 'Логи ошибок не найдены.',
+      columns: {
+        createdAt: 'Создано',
+        source: 'Источник',
+        path: 'Путь',
+        message: 'Сообщение',
+        accountId: 'Аккаунт'
+      },
+      errors: {
+        load: 'Не удалось загрузить логи ошибок.'
+      }
+    },
     appointments: {
       pageTitle: 'Записи',
       pageSubtitle: 'Календарный вид с расписанием по дням и времени.',
@@ -605,6 +641,7 @@ export type TranslationKey =
   | 'common.specialists'
   | 'common.users'
   | 'common.notificationLogs'
+  | 'common.errorLogs'
   | 'common.profileMenuAria'
   | 'common.appearancePaletteAria'
   | 'common.themeToggleAria'
@@ -831,6 +868,16 @@ export type TranslationKey =
   | 'notificationLogs.errors.load'
   | 'notificationLogs.errors.resend'
   | 'notificationLogs.success.resent'
+  | 'errorLogs.pageTitle'
+  | 'errorLogs.pageSubtitle'
+  | 'errorLogs.accessDenied'
+  | 'errorLogs.empty'
+  | 'errorLogs.columns.createdAt'
+  | 'errorLogs.columns.source'
+  | 'errorLogs.columns.path'
+  | 'errorLogs.columns.message'
+  | 'errorLogs.columns.accountId'
+  | 'errorLogs.errors.load'
   | 'appointments.fields.notes';
 
 export const DEFAULT_LOCALE: Locale = 'ru';

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -213,3 +213,21 @@ export type NotificationLogItem = {
 export type NotificationLogsResponse = {
   items: NotificationLogItem[];
 };
+
+export type ErrorLogItem = {
+  id: number;
+  accountId: number | null;
+  webUserId: number | null;
+  source: 'web' | 'server';
+  level: string;
+  method: string | null;
+  path: string | null;
+  message: string;
+  stack: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+};
+
+export type ErrorLogsResponse = {
+  items: ErrorLogItem[];
+};

--- a/web/src/shared/ui/AppIcons.tsx
+++ b/web/src/shared/ui/AppIcons.tsx
@@ -3,6 +3,7 @@ import DarkModeRounded from '@mui/icons-material/DarkModeRounded';
 import DeleteRounded from '@mui/icons-material/DeleteRounded';
 import EditRounded from '@mui/icons-material/EditRounded';
 import EventRounded from '@mui/icons-material/EventRounded';
+import ErrorOutlineRounded from '@mui/icons-material/ErrorOutlineRounded';
 import GroupRounded from '@mui/icons-material/GroupRounded';
 import LightModeRounded from '@mui/icons-material/LightModeRounded';
 import LoginRounded from '@mui/icons-material/LoginRounded';
@@ -20,6 +21,7 @@ export const AppIcons = {
   delete: DeleteRounded,
   edit: EditRounded,
   calendar: EventRounded,
+  errors: ErrorOutlineRounded,
   specialists: GroupRounded,
   lightMode: LightModeRounded,
   login: LoginRounded,


### PR DESCRIPTION
### Motivation
- Provide centralized error tracking for both frontend (`web`) and backend (`server`) so owners can inspect runtime and 5xx issues without flooding primary tables. 
- Keep storage bounded by retaining logs only for 7 days to avoid growth and simplify initial rollout.

### Description
- Added DB migration to create a new `error_logs` table with `source` check (`web` | `server`) and indexes for `created_at` and `(source, created_at)`; migration file: `server/src/db/migrations/20260427123000_create_error_logs.ts`.
- Implemented `errorLogRepository` with `insertErrorLog`, `listErrorLogs`, and `purgeExpiredErrorLogs(7)` for retention; file: `server/src/repositories/errorLogRepository.ts`.
- Implemented `errorTrackingService` to accept web/server errors, map/normalize fields, run cleanup (7-day retention) and restrict listing to owners; file: `server/src/services/errorTrackingService.ts`.
- Exposed API routes: `POST /api/error-logs/web` to ingest frontend errors and `GET /api/error-logs` to list logs (owner-only); file: `server/src/routes/errorLogRoutes.ts` and mounted at `/api/error-logs` in `server/src/app.ts`.
- Added middleware to capture server `5xx` responses and persist minimal server error entries via `trackServerError`; change in `server/src/app.ts`.
- Frontend: added `WebErrorTracker` that listens to `window.error` and `unhandledrejection` and posts to `/api/error-logs/web` for authenticated users, plus an owner-only `/error-logs` page and menu item to view logs; files: `web/src/app/WebErrorTracker.tsx`, `web/src/containers/ErrorLogsContainer.tsx`, `web/src/pages/ErrorLogsPage.tsx`, `web/src/app/router.tsx`, `web/src/components/layout/MainLayout.tsx`.
- Updated web API typings and i18n dictionaries (ru/en) for new UI strings and server i18n keys for error-log errors; files: `web/src/shared/types/api.ts`, `web/src/shared/i18n/dictionaries.ts`, `server/src/i18n/dictionaries.ts`.
- Updated root `README.md` to mention the new feature and 7-day retention.

### Testing
- Ran TypeScript build for server with `npm run -w @scheduletm/server build`, which succeeded after adjusting schema validation types.
- Built the web bundle with `npm run -w @scheduletm/web build` (TypeScript + `vite build`), which completed successfully.
- No additional automated unit tests were added; CI-style smoke was limited to local `build` validation and both builds passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef739f3c948333b57bd4bf95b12b81)