### PR TITLE
Add encrypted Telegram error-alerts for server error tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ scheduletm/
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
 - Notifications: appointment notify flow with channel fallback (Telegram -> Email) + retry/backoff pipeline in scheduler (`pending/retry/processing/sent/failed`, `next_retry_at`, `max_attempts`, idempotent key per `appointment_id + type + channel`).
 - Notification logs page (`/notification-logs`) with role-aware access (`owner/admin/specialist`), filters and human-readable fields (specialist/client names, message, Telegram, email), including manual resend for failed deliveries.
-- Error tracking for `web` + `server`: frontend runtime errors and backend `5xx` responses are persisted in `error_logs`; UI page `/error-logs` is available only for `owner`; retention is 7 days.
+- Error tracking for `web` + `server`: frontend runtime errors and backend `5xx` responses are persisted in `error_logs`; UI page `/error-logs` is available only for `owner`; retention is 7 days; optional Telegram alerts can be sent via a dedicated bot token + chat id configured in `system_settings` (encrypted at rest, without email costs).
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
 - Late cancellation UX (web + bot): before cancel confirmation the user sees refund/no-refund outcome according to specialist booking policy (`cancel_grace_period_hours`, `refund_on_late_cancel`), and after cancellation bot sends final refund status.
 - Scheduler: auto-cancel unpaid appointments by specialist booking policy (`auto_cancel_unpaid_enabled`, `unpaid_auto_cancel_after_hours`) with audit reason `auto_cancel_unpaid`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -17,3 +17,6 @@ GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
 GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3003/api/integrations/google/oauth/callback
 # Optional (space-separated scopes). Leave empty to use defaults.
 GOOGLE_OAUTH_SCOPES=
+
+# Required for encryption of sensitive values stored in DB (for example system-level Telegram alert credentials).
+APP_ENCRYPTION_KEY=replace_with_long_random_secret

--- a/server/README.md
+++ b/server/README.md
@@ -35,6 +35,7 @@ Node.js/Express API для web-клиента и интеграций.
   - дедупликация через таблицу `notifications` по ключу `appointment_id + type + channel`;
   - retry/backoff и управление состояниями отправки: `pending -> processing -> sent` или `retry/failed` с `next_retry_at`, `attempts`, `max_attempts`.
 - Локализованные API-сообщения (`ru/en`).
+- Error tracking (`web` + `server`) с хранением в `error_logs` и optional Telegram alerts через отдельного бота (без email); bot token/chat id хранятся в `system_settings` в зашифрованном виде.
 
 ## Команды
 
@@ -61,6 +62,16 @@ npm run -w @scheduletm/server test
 - `EMAIL_FROM_ADDRESS` (default: `no-reply@meetli.cc`)
 - `EMAIL_FROM_NAME`
 - `EMAIL_VERIFY_BASE_URL` (ссылка для frontend-экрана подтверждения email)
+
+Опционально для Telegram-алертов по ошибкам:
+
+- `APP_ENCRYPTION_KEY` (обязателен для шифрования/дешифрования чувствительных значений в БД)
+
+Настройка Telegram-алертов делается через `PUT /api/settings/system` (owner only):
+
+- `errorAlertsTelegramBotToken` — токен отдельного бота для ошибок;
+- `errorAlertsTelegramChatId` — chat id (личный/групповой);
+- в `GET /api/settings/system` возвращается только флаг `errorAlertsTelegramEnabled`, сами секреты не отдаются.
 
 ## Документация
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -14,7 +14,8 @@ const envSchema = z.object({
   GOOGLE_OAUTH_CLIENT_ID: z.string().default(''),
   GOOGLE_OAUTH_CLIENT_SECRET: z.string().default(''),
   GOOGLE_OAUTH_REDIRECT_URI: z.string().url().default('http://localhost:3003/api/integrations/google/oauth/callback'),
-  GOOGLE_OAUTH_SCOPES: z.string().default('')
+  GOOGLE_OAUTH_SCOPES: z.string().default(''),
+  APP_ENCRYPTION_KEY: z.string().default(''),
 });
 
 export const env = envSchema.parse(process.env);

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -101,6 +101,8 @@ export const systemSettingsSchema = z.object({
   refreshTokenTtlDays: z.coerce.number().int().min(1).max(365),
   accessTokenTtlSeconds: z.coerce.number().int().min(60).max(86400),
   sessionCookieName: z.string().trim().min(1).max(128),
+  errorAlertsTelegramBotToken: z.string().trim().max(512).optional().or(z.literal('')),
+  errorAlertsTelegramChatId: z.string().trim().max(255).optional().or(z.literal('')),
 }).partial();
 
 export const accountSettingsSchema = z.object({

--- a/server/src/db/migrations/20260427150000_add_encrypted_error_alert_settings_to_system_settings.ts
+++ b/server/src/db/migrations/20260427150000_add_encrypted_error_alert_settings_to_system_settings.ts
@@ -1,0 +1,53 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'system_settings';
+const BOT_TOKEN_COLUMN = 'error_alerts_telegram_bot_token_encrypted';
+const CHAT_ID_COLUMN = 'error_alerts_telegram_chat_id_encrypted';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasBotTokenColumn = await knex.schema.hasColumn(TABLE, BOT_TOKEN_COLUMN);
+  const hasChatIdColumn = await knex.schema.hasColumn(TABLE, CHAT_ID_COLUMN);
+
+  if (hasBotTokenColumn && hasChatIdColumn) {
+    return;
+  }
+
+  await knex.schema.alterTable(TABLE, (table) => {
+    if (!hasBotTokenColumn) {
+      table.text(BOT_TOKEN_COLUMN).nullable();
+    }
+
+    if (!hasChatIdColumn) {
+      table.text(CHAT_ID_COLUMN).nullable();
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TABLE);
+  if (!hasTable) {
+    return;
+  }
+
+  const hasBotTokenColumn = await knex.schema.hasColumn(TABLE, BOT_TOKEN_COLUMN);
+  const hasChatIdColumn = await knex.schema.hasColumn(TABLE, CHAT_ID_COLUMN);
+
+  if (!hasBotTokenColumn && !hasChatIdColumn) {
+    return;
+  }
+
+  await knex.schema.alterTable(TABLE, (table) => {
+    if (hasBotTokenColumn) {
+      table.dropColumn(BOT_TOKEN_COLUMN);
+    }
+
+    if (hasChatIdColumn) {
+      table.dropColumn(CHAT_ID_COLUMN);
+    }
+  });
+}

--- a/server/src/repositories/systemSettingsRepository.ts
+++ b/server/src/repositories/systemSettingsRepository.ts
@@ -8,6 +8,8 @@ export type SystemSettingsRecord = {
   refresh_token_ttl_days: number;
   access_token_ttl_seconds: number;
   session_cookie_name: string;
+  error_alerts_telegram_bot_token_encrypted: string | null;
+  error_alerts_telegram_chat_id_encrypted: string | null;
 };
 
 export type UpdateSystemSettingsInput = {
@@ -17,6 +19,8 @@ export type UpdateSystemSettingsInput = {
   refreshTokenTtlDays?: number;
   accessTokenTtlSeconds?: number;
   sessionCookieName?: string;
+  errorAlertsTelegramBotTokenEncrypted?: string | null;
+  errorAlertsTelegramChatIdEncrypted?: string | null;
 };
 
 export async function getSystemSettingsRecord(): Promise<SystemSettingsRecord | null> {
@@ -51,6 +55,14 @@ export async function updateSystemSettingsRecord(input: UpdateSystemSettingsInpu
 
   if (input.sessionCookieName !== undefined) {
     patch.session_cookie_name = input.sessionCookieName;
+  }
+
+  if (input.errorAlertsTelegramBotTokenEncrypted !== undefined) {
+    patch.error_alerts_telegram_bot_token_encrypted = input.errorAlertsTelegramBotTokenEncrypted;
+  }
+
+  if (input.errorAlertsTelegramChatIdEncrypted !== undefined) {
+    patch.error_alerts_telegram_chat_id_encrypted = input.errorAlertsTelegramChatIdEncrypted;
   }
 
 

--- a/server/src/services/errorTrackingService.ts
+++ b/server/src/services/errorTrackingService.ts
@@ -1,5 +1,9 @@
 import { canManageSystemSettings } from '../policies/rolePermissions.js';
 import { insertErrorLog, listErrorLogs, purgeExpiredErrorLogs, type ErrorLogRecord } from '../repositories/errorLogRepository.js';
+import { getSystemSettingsRecord } from '../repositories/systemSettingsRepository.js';
+import { env } from '../config/env.js';
+import { decryptText } from '../utils/crypto.js';
+import { sendTelegramBotMessage } from './telegramService.js';
 import type { User } from '../types/domain.js';
 
 const ERROR_MESSAGE_MAX = 2000;
@@ -47,6 +51,52 @@ async function cleanupExpiredLogs(): Promise<void> {
   await purgeExpiredErrorLogs(7);
 }
 
+function normalizeInline(value: string | null | undefined, max = 120): string {
+  if (!value) {
+    return '-';
+  }
+
+  return value.replace(/\s+/g, ' ').trim().slice(0, max);
+}
+
+async function notifyErrorToTelegram(input: {
+  source: 'web' | 'server';
+  message: string;
+  method?: string | null;
+  path?: string | null;
+  accountId?: number | null;
+  webUserId?: number | null;
+}): Promise<void> {
+  const encryptionKey = env.APP_ENCRYPTION_KEY.trim();
+  if (!encryptionKey) {
+    return;
+  }
+
+  const systemSettings = await getSystemSettingsRecord();
+  const botToken = systemSettings?.error_alerts_telegram_bot_token_encrypted
+    ? (decryptText(systemSettings.error_alerts_telegram_bot_token_encrypted, encryptionKey) ?? '').trim()
+    : '';
+  const chatId = systemSettings?.error_alerts_telegram_chat_id_encrypted
+    ? (decryptText(systemSettings.error_alerts_telegram_chat_id_encrypted, encryptionKey) ?? '').trim()
+    : '';
+
+  if (!botToken || !chatId) {
+    return;
+  }
+
+  const lines = [
+    '🚨 Error log',
+    `source: ${input.source}`,
+    `message: ${normalizeInline(input.message, 300)}`,
+    `method: ${normalizeInline(input.method)}`,
+    `path: ${normalizeInline(input.path, 180)}`,
+    `accountId: ${input.accountId ?? '-'}`,
+    `webUserId: ${input.webUserId ?? '-'}`,
+  ];
+
+  await sendTelegramBotMessage(botToken, chatId, lines.join('\n'));
+}
+
 export async function trackWebError(input: {
   actor: User;
   message: unknown;
@@ -71,6 +121,14 @@ export async function trackWebError(input: {
       : null,
   });
 
+  await notifyErrorToTelegram({
+    source: 'web',
+    message,
+    path: normalizeText(input.path, 255) || null,
+    accountId: input.actor.accountId,
+    webUserId: Number(input.actor.id),
+  });
+
   await cleanupExpiredLogs();
 }
 
@@ -89,6 +147,15 @@ export async function trackServerError(input: {
     path: input.path?.slice(0, 255) ?? null,
     message: normalizeText(error.message) || 'Server error',
     stack: normalizeText(error.stack, ERROR_STACK_MAX) || null,
+  });
+
+  await notifyErrorToTelegram({
+    source: 'server',
+    message: normalizeText(error.message) || 'Server error',
+    method: input.method?.slice(0, 16) ?? null,
+    path: input.path?.slice(0, 255) ?? null,
+    accountId: input.actor?.accountId ?? null,
+    webUserId: input.actor ? Number(input.actor.id) : null,
   });
 
   await cleanupExpiredLogs();

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -19,6 +19,8 @@ import {
   systemSettingsSchema,
   userSettingsSchema,
 } from '../config/schemas.js';
+import { env } from '../config/env.js';
+import { decryptText, encryptText } from '../utils/crypto.js';
 import { verifyTelegramBotToken } from './telegramService.js';
 import { canManageAccountSettings, canManageSystemSettings } from '../policies/rolePermissions.js';
 export { canManageAccountSettings, canManageSystemSettings } from '../policies/rolePermissions.js';
@@ -42,6 +44,7 @@ export type SystemSettings = {
   refreshTokenTtlDays: number;
   accessTokenTtlSeconds: number;
   sessionCookieName: string;
+  errorAlertsTelegramEnabled: boolean;
 };
 
 export type AccountSettings = {
@@ -78,6 +81,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   refreshTokenTtlDays: 30,
   accessTokenTtlSeconds: 900,
   sessionCookieName: 'meetli_refresh_token',
+  errorAlertsTelegramEnabled: false,
 };
 
 const mapSystemSettings = async (): Promise<SystemSettings> => {
@@ -86,6 +90,14 @@ const mapSystemSettings = async (): Promise<SystemSettings> => {
     return DEFAULT_SYSTEM_SETTINGS;
   }
 
+  const hasEncryptionKey = Boolean(env.APP_ENCRYPTION_KEY.trim());
+  const decryptedBotToken = hasEncryptionKey && row.error_alerts_telegram_bot_token_encrypted
+    ? decryptText(row.error_alerts_telegram_bot_token_encrypted, env.APP_ENCRYPTION_KEY)
+    : null;
+  const decryptedChatId = hasEncryptionKey && row.error_alerts_telegram_chat_id_encrypted
+    ? decryptText(row.error_alerts_telegram_chat_id_encrypted, env.APP_ENCRYPTION_KEY)
+    : null;
+
   return {
     dailyDigestEnabled: row.daily_digest_enabled,
     defaultMeetingDuration: row.default_meeting_duration,
@@ -93,6 +105,7 @@ const mapSystemSettings = async (): Promise<SystemSettings> => {
     refreshTokenTtlDays: row.refresh_token_ttl_days,
     accessTokenTtlSeconds: row.access_token_ttl_seconds,
     sessionCookieName: row.session_cookie_name,
+    errorAlertsTelegramEnabled: Boolean(decryptedBotToken && decryptedChatId),
   };
 };
 
@@ -137,6 +150,13 @@ export const updateSystemSettings = async (payload: unknown): Promise<SystemSett
     return null;
   }
 
+  const wantsEncryptedTelegramSettings = Boolean(
+    parsed.data.errorAlertsTelegramBotToken?.trim() || parsed.data.errorAlertsTelegramChatId?.trim(),
+  );
+  if (wantsEncryptedTelegramSettings && !env.APP_ENCRYPTION_KEY.trim()) {
+    return null;
+  }
+
   await updateSystemSettingsRecord({
     dailyDigestEnabled: parsed.data.dailyDigestEnabled,
     defaultMeetingDuration: parsed.data.defaultMeetingDuration,
@@ -144,6 +164,20 @@ export const updateSystemSettings = async (payload: unknown): Promise<SystemSett
     refreshTokenTtlDays: parsed.data.refreshTokenTtlDays,
     accessTokenTtlSeconds: parsed.data.accessTokenTtlSeconds,
     sessionCookieName: parsed.data.sessionCookieName,
+    errorAlertsTelegramBotTokenEncrypted: parsed.data.errorAlertsTelegramBotToken === undefined
+      ? undefined
+      : (!parsed.data.errorAlertsTelegramBotToken.trim()
+        ? null
+        : (env.APP_ENCRYPTION_KEY.trim()
+          ? encryptText(parsed.data.errorAlertsTelegramBotToken.trim(), env.APP_ENCRYPTION_KEY)
+          : null)),
+    errorAlertsTelegramChatIdEncrypted: parsed.data.errorAlertsTelegramChatId === undefined
+      ? undefined
+      : (!parsed.data.errorAlertsTelegramChatId.trim()
+        ? null
+        : (env.APP_ENCRYPTION_KEY.trim()
+          ? encryptText(parsed.data.errorAlertsTelegramChatId.trim(), env.APP_ENCRYPTION_KEY)
+          : null)),
   });
 
   return mapSystemSettings();

--- a/server/src/utils/crypto.ts
+++ b/server/src/utils/crypto.ts
@@ -14,3 +14,35 @@ export const generateTemporaryPassword = (length = 14) => {
   const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%';
   return Array.from(crypto.randomBytes(length), (value) => alphabet[value % alphabet.length]).join('');
 };
+
+function buildEncryptionKey(secret: string): Buffer {
+  return crypto.createHash('sha256').update(secret).digest();
+}
+
+export function encryptText(value: string, secret: string): string {
+  const iv = crypto.randomBytes(12);
+  const key = buildEncryptionKey(secret);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+export function decryptText(value: string, secret: string): string | null {
+  const parts = value.split(':');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  try {
+    const iv = Buffer.from(parts[0], 'hex');
+    const tag = Buffer.from(parts[1], 'hex');
+    const encrypted = Buffer.from(parts[2], 'hex');
+    const key = buildEncryptionKey(secret);
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide optional real-time error alerts via Telegram for existing error tracking without exposing secrets in plaintext.
- Store Telegram bot token and chat id encrypted in `system_settings` and require an application-level encryption key to decrypt them.
- Allow owners to configure alerts through system settings while keeping secrets hidden from API responses.

### Description

- Introduced `APP_ENCRYPTION_KEY` env var in `server/.env.example` and added it to runtime `env` parsing in `server/src/config/env.ts`.
- Added two nullable encrypted columns to `system_settings` via a new migration `20260427150000_add_encrypted_error_alert_settings_to_system_settings.ts` (`error_alerts_telegram_bot_token_encrypted`, `error_alerts_telegram_chat_id_encrypted`).
- Extended Zod `systemSettingsSchema` to accept `errorAlertsTelegramBotToken` and `errorAlertsTelegramChatId` and updated `server/README.md` with configuration notes for Telegram alerts.
- Updated `systemSettingsRepository` to include the new encrypted columns and allow updating them in `updateSystemSettingsRecord`.
- Added `encryptText` and `decryptText` utilities (AES-256-GCM) in `server/src/utils/crypto.ts` and used them to encrypt/decrypt Telegram settings in `settingsService` and to gate enabling when `APP_ENCRYPTION_KEY` is missing.
- Implemented Telegram notification flow in `errorTrackingService`: decrypts credentials, formats a compact alert, and sends it using existing `sendTelegramBotMessage`; also added inline normalization and wiring to `trackWebError` and `trackServerError`.

### Testing

- Ran a TypeScript build via `npm run -w @scheduletm/server build`, which completed successfully.
- Executed server unit tests via `npm run -w @scheduletm/server test`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef76a66c6883338e77b8c336578e87)