### PR TITLE
Expose appointment audit events with actor context and add event filters to appointments API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ scheduletm/
 - Notification logs page (`/notification-logs`) with role-aware access (`owner/admin/specialist`), filters and human-readable fields (specialist/client names, message, Telegram, email), including manual resend for failed deliveries.
 - Error tracking for `web` + `server`: frontend runtime errors and backend `5xx` responses are persisted in `error_logs`; UI page `/error-logs` is available only for `owner`; retention is 7 days; optional Telegram alerts can be sent via a dedicated bot token + chat id configured in `system_settings` (encrypted at rest, without email costs).
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
+- Appointments audit/events: `GET /api/appointments` возвращает `events[]` c actor context и поддерживает event-фильтры (`eventAction`, `eventActorWebUserId`, `eventFrom`, `eventTo`).
 - Late cancellation UX (web + bot): before cancel confirmation the user sees refund/no-refund outcome according to specialist booking policy (`cancel_grace_period_hours`, `refund_on_late_cancel`), and after cancellation bot sends final refund status.
 - Scheduler: auto-cancel unpaid appointments by specialist booking policy (`auto_cancel_unpaid_enabled`, `unpaid_auto_cancel_after_hours`) with audit reason `auto_cancel_unpaid`.
 - Specialists и Users CRUD (с role-gates).

--- a/server/README.md
+++ b/server/README.md
@@ -20,6 +20,16 @@ Node.js/Express API для web-клиента и интеграций.
   - При создании пользователей owner/admin отправляется invite-link вместо временного пароля.
   - Приглашённый пользователь создаётся неактивным и активируется только после verify-email / accept-invite.
 - Appointments lifecycle: list/create/edit/reschedule/cancel/mark-paid/notify.
+  - В `GET /api/appointments` поддерживаются фильтры для audit events:
+    - `eventAction` (`cancel|reschedule|mark-paid|notify`, можно CSV),
+    - `eventActorWebUserId`,
+    - `eventFrom`,
+    - `eventTo`.
+  - В `appointments[].events[]` возвращается actor context:
+    - `actor.id`,
+    - `actor.role`,
+    - `actor.displayName`,
+    - `actor.email`.
 - Client self-service:
   - owner/admin/specialist могут создавать web users с ролью `client`;
   - `client` видит и управляет только собственными записями (edit/reschedule/cancel);

--- a/server/src/repositories/appointmentRepository.ts
+++ b/server/src/repositories/appointmentRepository.ts
@@ -32,6 +32,17 @@ export type AppointmentAuditEventRecord = {
   actor_web_user_id: number | null;
   metadata_json: string | null;
   created_at: Date;
+  actor_role?: string | null;
+  actor_first_name?: string | null;
+  actor_last_name?: string | null;
+  actor_email?: string | null;
+};
+
+type AppointmentEventsFilters = {
+  actions?: AppointmentAuditAction[];
+  actorWebUserId?: number;
+  from?: Date;
+  to?: Date;
 };
 
 type AppointmentListFilters = {
@@ -240,16 +251,49 @@ export async function createAppointmentAuditEvent(input: {
 export async function listAppointmentEventsByAppointmentIds(
   accountId: number,
   appointmentIds: number[],
+  filters?: AppointmentEventsFilters,
 ): Promise<AppointmentAuditEventRecord[]> {
   if (appointmentIds.length === 0) {
     return [];
   }
 
-  return db('appointment_events')
-    .where({ account_id: accountId })
-    .whereIn('appointment_id', appointmentIds)
-    .orderBy('created_at', 'desc')
-    .select<AppointmentAuditEventRecord[]>('*');
+  const query = db('appointment_events as ae')
+    .leftJoin('web_users as wu', function joinActors() {
+      this.on('wu.id', '=', 'ae.actor_web_user_id').andOn('wu.account_id', '=', 'ae.account_id');
+    })
+    .where({ 'ae.account_id': accountId })
+    .whereIn('ae.appointment_id', appointmentIds)
+    .orderBy('ae.created_at', 'desc');
+
+  if (filters?.actions?.length) {
+    query.whereIn('ae.action', filters.actions);
+  }
+
+  if (filters?.actorWebUserId) {
+    query.andWhere('ae.actor_web_user_id', filters.actorWebUserId);
+  }
+
+  if (filters?.from) {
+    query.andWhere('ae.created_at', '>=', filters.from);
+  }
+
+  if (filters?.to) {
+    query.andWhere('ae.created_at', '<=', filters.to);
+  }
+
+  return query.select<AppointmentAuditEventRecord[]>(
+    'ae.id',
+    'ae.account_id',
+    'ae.appointment_id',
+    'ae.action',
+    'ae.actor_web_user_id',
+    'ae.metadata_json',
+    'ae.created_at',
+    'wu.role as actor_role',
+    'wu.first_name as actor_first_name',
+    'wu.last_name as actor_last_name',
+    'wu.email as actor_email',
+  );
 }
 
 export async function ensureFallbackClientForAccount(accountId: number): Promise<number> {

--- a/server/src/routes/appointmentRoutes.ts
+++ b/server/src/routes/appointmentRoutes.ts
@@ -18,6 +18,8 @@ import {
 import { formatZodError } from '../utils/validation.js';
 
 export const appointmentRoutes = Router();
+type AppointmentAuditActionFilter = 'cancel' | 'reschedule' | 'mark-paid' | 'notify';
+const APPOINTMENT_AUDIT_ACTIONS = new Set<AppointmentAuditActionFilter>(['cancel', 'reschedule', 'mark-paid', 'notify']);
 
 appointmentRoutes.use(requireAccessToken);
 
@@ -28,11 +30,33 @@ appointmentRoutes.get('/', async (req, res) => {
     const specialistId = typeof req.query.specialistId === 'string'
       ? Number(req.query.specialistId)
       : undefined;
+    const parseEventActions = () => {
+      const raw = req.query.eventAction;
+      const values = Array.isArray(raw)
+        ? raw.flatMap((value) => String(value).split(','))
+        : typeof raw === 'string'
+          ? raw.split(',')
+          : [];
+
+      return values
+        .map((value) => value.trim())
+        .filter((value): value is AppointmentAuditActionFilter => APPOINTMENT_AUDIT_ACTIONS.has(value as AppointmentAuditActionFilter));
+    };
+    const eventActorWebUserIdRaw = typeof req.query.eventActorWebUserId === 'string'
+      ? Number(req.query.eventActorWebUserId)
+      : undefined;
+    const eventActions = parseEventActions();
 
     const data = await getAppointments(actor, {
       specialistId: Number.isFinite(specialistId) ? specialistId : undefined,
       from: typeof req.query.from === 'string' ? req.query.from : undefined,
       to: typeof req.query.to === 'string' ? req.query.to : undefined,
+      eventAction: eventActions.length ? eventActions : undefined,
+      eventActorWebUserId: Number.isFinite(eventActorWebUserIdRaw) && Number(eventActorWebUserIdRaw) > 0
+        ? Number(eventActorWebUserIdRaw)
+        : undefined,
+      eventFrom: typeof req.query.eventFrom === 'string' ? req.query.eventFrom : undefined,
+      eventTo: typeof req.query.eventTo === 'string' ? req.query.eventTo : undefined,
     });
 
     return res.json(data);

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -60,6 +60,12 @@ type AppointmentDto = {
 type AppointmentEventDto = {
   action: AppointmentAuditAction;
   createdAt: string;
+  actor: {
+    id: number | null;
+    role: string;
+    displayName: string;
+    email: string;
+  };
 };
 
 type AppointmentListResult = {
@@ -171,9 +177,18 @@ function mapEventsByAppointmentId(
 
   for (const row of rows) {
     const events = eventsById.get(row.appointment_id) ?? [];
+    const actorFirstName = row.actor_first_name?.trim() ?? '';
+    const actorLastName = row.actor_last_name?.trim() ?? '';
+    const actorDisplayName = [actorFirstName, actorLastName].filter(Boolean).join(' ').trim();
     events.push({
       action: row.action,
       createdAt: row.created_at.toISOString(),
+      actor: {
+        id: row.actor_web_user_id ?? null,
+        role: row.actor_role ?? '',
+        displayName: actorDisplayName || (row.actor_email ?? ''),
+        email: row.actor_email ?? '',
+      },
     });
     eventsById.set(row.appointment_id, events);
   }
@@ -323,7 +338,15 @@ async function resolveClientId(accountId: number, payload: AppointmentClientPayl
 
 export async function getAppointments(
   actor: User,
-  filters: { from?: string; to?: string; specialistId?: number },
+  filters: {
+    from?: string;
+    to?: string;
+    specialistId?: number;
+    eventAction?: AppointmentAuditAction[];
+    eventActorWebUserId?: number;
+    eventFrom?: string;
+    eventTo?: string;
+  },
 ): Promise<AppointmentListResult> {
   const accountId = await resolveAccountId(actor);
   const allowedSpecialistId = await resolveAllowedSpecialistId(actor, accountId);
@@ -377,6 +400,12 @@ export async function getAppointments(
     await listAppointmentEventsByAppointmentIds(
       accountId,
       appointmentsForUi.map((item) => item.id),
+      {
+        actions: filters.eventAction,
+        actorWebUserId: filters.eventActorWebUserId,
+        from: filters.eventFrom ? new Date(filters.eventFrom) : undefined,
+        to: filters.eventTo ? new Date(filters.eventTo) : undefined,
+      },
     ),
   );
 

--- a/server/tests/appointment-events.service.unit.test.ts
+++ b/server/tests/appointment-events.service.unit.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebUserRole } from '../src/types/webUserRole.js';
+import { getAppointments } from '../src/services/appointmentService.js';
+
+const listAppointmentsAllAccountsMock = vi.hoisted(() => vi.fn());
+const listAppointmentEventsByAppointmentIdsMock = vi.hoisted(() => vi.fn());
+const listSpecialistsAllAccountsMock = vi.hoisted(() => vi.fn());
+const listClientsByAccountMock = vi.hoisted(() => vi.fn());
+const listExternalBusySlotsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/repositories/appointmentRepository.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/repositories/appointmentRepository.js')>(
+    '../src/repositories/appointmentRepository.js',
+  );
+  return {
+    ...actual,
+    listAppointmentsAllAccounts: listAppointmentsAllAccountsMock,
+    listAppointmentEventsByAppointmentIds: listAppointmentEventsByAppointmentIdsMock,
+  };
+});
+
+vi.mock('../src/repositories/specialistRepository.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/repositories/specialistRepository.js')>(
+    '../src/repositories/specialistRepository.js',
+  );
+  return {
+    ...actual,
+    listSpecialistsAllAccounts: listSpecialistsAllAccountsMock,
+  };
+});
+
+vi.mock('../src/repositories/clientRepository.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/repositories/clientRepository.js')>(
+    '../src/repositories/clientRepository.js',
+  );
+  return {
+    ...actual,
+    listClientsByAccount: listClientsByAccountMock,
+  };
+});
+
+vi.mock('../src/services/calendarAvailabilityService.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/services/calendarAvailabilityService.js')>(
+    '../src/services/calendarAvailabilityService.js',
+  );
+  return {
+    ...actual,
+    listExternalBusySlots: listExternalBusySlotsMock,
+  };
+});
+
+describe('appointment events service unit', () => {
+  beforeEach(() => {
+    listAppointmentsAllAccountsMock.mockReset();
+    listAppointmentEventsByAppointmentIdsMock.mockReset();
+    listSpecialistsAllAccountsMock.mockReset();
+    listClientsByAccountMock.mockReset();
+    listExternalBusySlotsMock.mockReset();
+
+    listAppointmentsAllAccountsMock.mockResolvedValue([
+      {
+        id: 10,
+        account_id: 1,
+        specialist_id: 5,
+        appointment_at: new Date('2026-04-20T10:00:00.000Z'),
+        status: 'confirmed',
+        comment: null,
+        duration_min: 60,
+        is_paid: false,
+        user_id: 8,
+        service_id: 2,
+        created_at: new Date('2026-04-15T00:00:00.000Z'),
+        updated_at: new Date('2026-04-15T00:00:00.000Z'),
+        client_first_name: 'Ivan',
+        client_last_name: 'Petrov',
+        client_username: 'ivan',
+        client_phone: '+1000000',
+        client_email: 'ivan@example.com',
+      },
+    ]);
+    listSpecialistsAllAccountsMock.mockResolvedValue([{ id: 5, name: 'Spec', timezone: 'UTC', slot_step_min: 30 }]);
+    listClientsByAccountMock.mockResolvedValue([{ id: 8, username: 'ivan', first_name: 'Ivan', last_name: 'Petrov', phone: '+1000000', email: 'ivan@example.com' }]);
+    listExternalBusySlotsMock.mockResolvedValue([]);
+  });
+
+  it('maps actor context for appointment events and forwards event filters', async () => {
+    listAppointmentEventsByAppointmentIdsMock.mockResolvedValue([
+      {
+        id: 1,
+        account_id: 1,
+        appointment_id: 10,
+        action: 'notify',
+        actor_web_user_id: 101,
+        metadata_json: null,
+        created_at: new Date('2026-04-19T09:00:00.000Z'),
+        actor_role: 'owner',
+        actor_first_name: 'Owner',
+        actor_last_name: 'User',
+        actor_email: 'owner@example.com',
+      },
+    ]);
+
+    const data = await getAppointments(
+      {
+        id: '101',
+        accountId: 1,
+        email: 'owner@example.com',
+        role: WebUserRole.Owner,
+      } as any,
+      {
+        eventAction: ['notify'],
+        eventActorWebUserId: 101,
+        eventFrom: '2026-04-01T00:00:00.000Z',
+        eventTo: '2026-04-30T23:59:59.999Z',
+      },
+    );
+
+    expect(listAppointmentEventsByAppointmentIdsMock).toHaveBeenCalledWith(
+      1,
+      [10],
+      expect.objectContaining({
+        actions: ['notify'],
+        actorWebUserId: 101,
+      }),
+    );
+    expect(data.appointments[0].events[0]).toMatchObject({
+      action: 'notify',
+      actor: {
+        id: 101,
+        role: 'owner',
+        displayName: 'Owner User',
+        email: 'owner@example.com',
+      },
+    });
+  });
+
+  it('uses actor email fallback for displayName when first/last names are missing (edge case)', async () => {
+    listAppointmentEventsByAppointmentIdsMock.mockResolvedValue([
+      {
+        id: 2,
+        account_id: 1,
+        appointment_id: 10,
+        action: 'cancel',
+        actor_web_user_id: 102,
+        metadata_json: null,
+        created_at: new Date('2026-04-19T09:00:00.000Z'),
+        actor_role: 'admin',
+        actor_first_name: null,
+        actor_last_name: null,
+        actor_email: 'admin@example.com',
+      },
+    ]);
+
+    const data = await getAppointments(
+      {
+        id: '101',
+        accountId: 1,
+        email: 'owner@example.com',
+        role: WebUserRole.Owner,
+      } as any,
+      {},
+    );
+
+    expect(data.appointments[0].events[0].actor.displayName).toBe('admin@example.com');
+  });
+});

--- a/server/tests/appointments.routes.smoke.test.ts
+++ b/server/tests/appointments.routes.smoke.test.ts
@@ -4,6 +4,7 @@ import { createApp } from '../src/app.js';
 import { WebUserRole } from '../src/types/webUserRole.js';
 
 const resolveUserByAccessTokenMock = vi.hoisted(() => vi.fn());
+const getAppointmentsMock = vi.hoisted(() => vi.fn());
 const createAppointmentForActorMock = vi.hoisted(() => vi.fn());
 const rescheduleAppointmentForActorMock = vi.hoisted(() => vi.fn());
 const cancelAppointmentForActorMock = vi.hoisted(() => vi.fn());
@@ -15,7 +16,7 @@ vi.mock('../src/services/authService.js', () => ({
 }));
 
 vi.mock('../src/services/appointmentService.js', () => ({
-  getAppointments: vi.fn(),
+  getAppointments: getAppointmentsMock,
   updateAppointmentForActor: vi.fn(),
   createAppointmentForActor: createAppointmentForActorMock,
   rescheduleAppointmentForActor: rescheduleAppointmentForActorMock,
@@ -57,12 +58,60 @@ describe('appointments API route-smoke scenarios (mocked service layer)', () => 
   beforeEach(() => {
     resolveUserByAccessTokenMock.mockReset();
     createAppointmentForActorMock.mockReset();
+    getAppointmentsMock.mockReset();
     rescheduleAppointmentForActorMock.mockReset();
     cancelAppointmentForActorMock.mockReset();
     markPaidAppointmentForActorMock.mockReset();
     notifyAppointmentForActorMock.mockReset();
 
     resolveUserByAccessTokenMock.mockResolvedValue(authedUser);
+    getAppointmentsMock.mockResolvedValue({
+      appointments: [],
+      specialists: [],
+      clients: [],
+      busySlots: [],
+    });
+  });
+
+  it('list: forwards event filters to getAppointments', async () => {
+    const response = await fetch(`${baseUrl}/api/appointments?specialistId=8&from=2026-04-01T00:00:00.000Z&to=2026-04-30T23:59:59.999Z&eventAction=cancel,notify&eventActorWebUserId=101&eventFrom=2026-04-10T00:00:00.000Z&eventTo=2026-04-20T23:59:59.999Z`, {
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer smoke-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getAppointmentsMock).toHaveBeenCalledWith(
+      authedUser,
+      expect.objectContaining({
+        specialistId: 8,
+        from: '2026-04-01T00:00:00.000Z',
+        to: '2026-04-30T23:59:59.999Z',
+        eventAction: ['cancel', 'notify'],
+        eventActorWebUserId: 101,
+        eventFrom: '2026-04-10T00:00:00.000Z',
+        eventTo: '2026-04-20T23:59:59.999Z',
+      }),
+    );
+  });
+
+  it('list: ignores invalid event filters (edge case)', async () => {
+    const response = await fetch(`${baseUrl}/api/appointments?eventAction=cancel,unknown,event&eventActorWebUserId=abc`, {
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer smoke-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(getAppointmentsMock).toHaveBeenCalledWith(
+      authedUser,
+      expect.objectContaining({
+        eventAction: ['cancel'],
+        eventActorWebUserId: undefined,
+      }),
+    );
   });
 
   it('create: POST /api/appointments returns 201', async () => {


### PR DESCRIPTION
### Motivation
- Surface audit events for appointments in the appointments list so clients can show event history with actor context. 
- Allow filtering of appointment events by action, actor and date range at the API layer to avoid extra client-side filtering. 
- Propagate actor information (role, name, email) into the UI-friendly DTO for clearer event display. 

### Description
- Repository: extended `AppointmentAuditEventRecord` with actor fields and updated `listAppointmentEventsByAppointmentIds` to `LEFT JOIN web_users` and accept event filters (`actions`, `actorWebUserId`, `from`, `to`) in the query. 
- Service: updated `getAppointments` to accept event filter params and forward them to the repository, implemented `mapEventsByAppointmentId` to include an `actor` object (`id`, `role`, `displayName`, `email`) on each event. 
- Routes: enhanced `GET /api/appointments` to parse and validate `eventAction`, `eventActorWebUserId`, `eventFrom`, and `eventTo` query params and pass them into `getAppointments`. 
- Docs: updated `README.md` and `server/README.md` to document that `GET /api/appointments` returns `events[]` with actor context and supports event filters. 
- Tests: added `server/tests/appointment-events.service.unit.test.ts` and extended `server/tests/appointments.routes.smoke.test.ts` to cover mapping of actor context and forwarding/validation of event filters. 

### Testing
- Ran unit tests with `vitest` including the new `appointment-events.service.unit.test.ts`, and they passed. 
- Ran route smoke tests (`appointments.routes.smoke.test.ts`) against the app with mocked services, and they passed. 
- Executed the server test script via `npm run -w @scheduletm/server test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7cc1eaf88333a60d26379a557314)