### PR TITLE
feat(web): switch default meeting duration to dropdown (30-90, step 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ scheduletm/
 
 - Auth: register/login/refresh/logout + OTP email verification by unique code (with resend) + invite onboarding page `/verify-email` for creating account from invitation.
 - Роли: `owner` / `admin` / `specialist` / `client` (RBAC policy централизована в server).
-- Settings: system + account + user settings, plus user integrations.
+- Settings: system + account + user settings, plus user integrations. `Default meeting duration` in system/account settings is selected from dropdown options 30–90 minutes (step 10).
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
 - Notifications: appointment notify flow with channel fallback (Telegram -> Email) + retry/backoff pipeline in scheduler (`pending/retry/processing/sent/failed`, `next_retry_at`, `max_attempts`, idempotent key per `appointment_id + type + channel`).
 - Notification logs page (`/notification-logs`) with role-aware access (`owner/admin/specialist`), filters and human-readable fields (specialist/client names, message, Telegram, email), including manual resend for failed deliveries.

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -121,6 +121,7 @@ export function SettingsCard({
     ].map(h => `${h}h`)
   ];
   const selectableChannels: NotificationChannel[] = ['email', 'telegram', 'viber', 'sms', 'whatsapp'];
+  const meetingDurationOptions = Array.from({ length: 7 }, (_, i) => 30 + i * 10);
   const [tab, setTab] = useState(canManageSystemSettings ? 0 : canManageAccountSettings ? 1 : canManageSpecialistBookingPolicy ? 2 : 4);
 
   const { control: systemControl, handleSubmit: handleSystemSubmit, reset: resetSystem } = useForm<SystemSettings>({
@@ -213,13 +214,19 @@ export function SettingsCard({
             name="defaultMeetingDuration"
             control={systemControl}
             render={({ field }: any) => (
-              <AppRhfTextField
-                field={field}
-                label={copy.defaultMeetingDuration}
-                type="number"
-                slotProps={{ htmlInput: { min: 15, max: 180 } }}
-                parseValue={(value) => Number(value)}
-              />
+              <FormControl fullWidth margin="normal">
+                <InputLabel id="system-default-meeting-duration-label">{copy.defaultMeetingDuration}</InputLabel>
+                <Select
+                  labelId="system-default-meeting-duration-label"
+                  value={String(field.value)}
+                  label={copy.defaultMeetingDuration}
+                  onChange={(event) => field.onChange(Number(event.target.value))}
+                >
+                  {meetingDurationOptions.map((duration) => (
+                    <MenuItem key={duration} value={String(duration)}>{duration}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
             )}
           />
 
@@ -302,13 +309,19 @@ export function SettingsCard({
             name="defaultMeetingDuration"
             control={accountControl}
             render={({ field }: any) => (
-              <AppRhfTextField
-                field={field}
-                label={copy.defaultMeetingDuration}
-                type="number"
-                slotProps={{ htmlInput: { min: 15, max: 180 } }}
-                parseValue={(value) => Number(value)}
-              />
+              <FormControl fullWidth margin="normal">
+                <InputLabel id="account-default-meeting-duration-label">{copy.defaultMeetingDuration}</InputLabel>
+                <Select
+                  labelId="account-default-meeting-duration-label"
+                  value={String(field.value)}
+                  label={copy.defaultMeetingDuration}
+                  onChange={(event) => field.onChange(Number(event.target.value))}
+                >
+                  {meetingDurationOptions.map((duration) => (
+                    <MenuItem key={duration} value={String(duration)}>{duration}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
             )}
           />
 


### PR DESCRIPTION
### Motivation
- Constrain and simplify the `Default meeting duration` input so users pick from a fixed, supported set of durations instead of free numeric input.
- Apply the change consistently to both system and account settings to avoid invalid values and improve UX.

### Description
- Added `meetingDurationOptions` in `web/src/components/SettingsCard.tsx` as `Array.from({ length: 7 }, (_, i) => 30 + i * 10)` to produce options `30,40,...,90`.
- Replaced the `defaultMeetingDuration` numeric `AppRhfTextField` with a MUI `Select` (wrapped in `FormControl`/`InputLabel`) in both System and Account tabs and convert selected values to numbers on change.
- Updated `README.md` to document that `Default meeting duration` in system/account settings is now a dropdown with options 30–90 minutes (step 10).
- Kept value shape unchanged so selected values are still stored/sent as numbers.

### Testing
- Ran type checking with `npm --prefix web run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05b52b9088333803489bde708bb14)