### PR TITLE
Add workspace `verify` scripts and QA commands; document dev-domain envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,35 @@ npm run -w bot dev
 
 > Точные переменные окружения и команды для production — в README каждого модуля.
 
+### Рекомендуемый setup для отдельного dev-домена
+
+Если frontend доступен с `https://dev.meetli.cc`, а API с `https://apidev.meetli.cc`, держите переменные по средам раздельно:
+
+- `web/.env.development`:
+  - `VITE_API_URL=https://apidev.meetli.cc`
+- `server/.env.development`:
+  - `APP_URL=https://dev.meetli.cc`
+  - `API_BASE_URL=https://apidev.meetli.cc`
+  - `GOOGLE_OAUTH_REDIRECT_URI=https://apidev.meetli.cc/api/integrations/google/oauth/callback`
+- OAuth-секреты (`GOOGLE_OAUTH_CLIENT_SECRET`) и другие секреты — только в server env, не в web.
+
+Для локальной разработки оставляйте `localhost` значения в `.env.local`/`.env` и не смешивайте их с доменными dev-значениями.
+
+### Одна команда для миграций + тестов по каждому модулю
+
+```bash
+# web (no-op миграции + тесты)
+npm run qa:web
+
+# server (migrate:latest + тесты)
+npm run qa:server
+
+# bot (no-op миграции + тесты)
+npm run qa:bot
+```
+
+Для `qa:server` убедитесь, что в `server/.env` (или переменных окружения CI) заполнены `DATABASE_PUBLIC_URL` или `DATABASE_URL`.
+
 ---
 
 ## 2) Архитектура

--- a/bot/README.md
+++ b/bot/README.md
@@ -20,6 +20,7 @@ npm run -w bot dev
 npm run -w bot build
 npm run -w bot start
 npm run -w bot test
+npm run -w bot verify
 ```
 
 ## Переменные окружения

--- a/bot/package.json
+++ b/bot/package.json
@@ -8,7 +8,9 @@
     "start": "node dist/app.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "migrate:latest": "node -e \"console.log('bot: migrations are not required')\"",
+    "verify": "npm run migrate:latest && npm run test"
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.9.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "lint": "npm run -ws lint --if-present",
     "typecheck": "npm run -ws typecheck --if-present",
     "test": "npm run -ws test --if-present",
-    "build": "npm run -ws build --if-present"
+    "build": "npm run -ws build --if-present",
+    "qa:web": "npm run -w @scheduletm/web verify",
+    "qa:server": "npm run -w @scheduletm/server verify",
+    "qa:bot": "npm run -w @scheduletm/bot verify"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,8 @@
 PORT=3003
 APP_URL=http://localhost:5173
 API_BASE_URL=http://localhost:3003
+DATABASE_PUBLIC_URL=postgres://user:pass@localhost:5432/scheduletm
+DATABASE_URL=postgres://user:pass@localhost:5432/scheduletm
 SESSION_COOKIE_NAME=scheduletm_refresh
 ACCESS_TOKEN_TTL_SECONDS=9000
 REFRESH_TOKEN_TTL_DAYS=30

--- a/server/README.md
+++ b/server/README.md
@@ -53,6 +53,7 @@ Node.js/Express API для web-клиента и интеграций.
 npm run -w @scheduletm/server dev
 npm run -w @scheduletm/server build
 npm run -w @scheduletm/server test
+npm run -w @scheduletm/server verify
 # только интеграционные бизнес-кейсы
 npm run -w @scheduletm/server test -- business.integration.test.ts
 ```
@@ -66,12 +67,23 @@ npm run -w @scheduletm/server test -- business.integration.test.ts
 
 Смотри `server/.env.example`.
 
+Минимум для новой БД:
+
+- `DATABASE_PUBLIC_URL` (или `DATABASE_URL`)
+- затем `npm run -w @scheduletm/server verify` для последовательного запуска миграций и тестов.
+
 Критичные для OAuth:
 
 - `GOOGLE_OAUTH_CLIENT_ID`
 - `GOOGLE_OAUTH_CLIENT_SECRET`
 - `GOOGLE_OAUTH_REDIRECT_URI`
 - `GOOGLE_OAUTH_SCOPES` (optional)
+
+Для dev-домена рекомендуется:
+
+- `APP_URL=https://dev.meetli.cc`
+- `API_BASE_URL=https://apidev.meetli.cc`
+- `GOOGLE_OAUTH_REDIRECT_URI=https://apidev.meetli.cc/api/integrations/google/oauth/callback`
 
 Критичные для email:
 

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "migrate:make": "npm run knex -- migrate:make",
     "migrate:latest": "npm run knex -- migrate:latest",
     "migrate:rollback": "npm run knex -- migrate:rollback",
-    "test": "cross-env DATABASE_PUBLIC_URL=postgresql://postgres:IxXKRzhJVpqQwUdyNHUMQfGPfiQtFZcs@nozomi.proxy.rlwy.net:41768/railway vitest run --config vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts",
+    "verify": "npm run migrate:latest && npm run test"
   },
   "dependencies": {
     "@types/cors": "^2.8.19",

--- a/web/README.md
+++ b/web/README.md
@@ -18,6 +18,7 @@ React SPA для owner/admin/specialist/client.
 npm run -w @scheduletm/web dev
 npm run -w @scheduletm/web build
 npm run -w @scheduletm/web test
+npm run -w @scheduletm/web verify
 ```
 
 ## Переменные окружения
@@ -28,6 +29,12 @@ npm run -w @scheduletm/web test
 
 ```bash
 VITE_API_URL=https://api.example.com
+```
+
+Для отдельного dev-домена:
+
+```bash
+VITE_API_URL=https://apidev.meetli.cc
 ```
 
 ## Документация

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,9 @@
     "start": "serve -s dist -l tcp://0.0.0.0:$PORT",
     "typecheck": "tsc --noEmit",
     "test": "node --test tests/e2e/smoke.e2e.test.mjs",
-    "test:e2e": "node --test tests/e2e/smoke.e2e.test.mjs"
+    "test:e2e": "node --test tests/e2e/smoke.e2e.test.mjs",
+    "migrate:latest": "node -e \"console.log('web: migrations are not required')\"",
+    "verify": "npm run migrate:latest && npm run test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
### Motivation

- Provide a single, consistent developer command to run migrations and tests across workspaces and to make CI/QA flows simpler.
- Document recommended environment variable setup for separate dev domains to avoid mixing localhost and domain values.

### Description

- Added `verify` scripts to `web/package.json`, `server/package.json`, and `bot/package.json` which run `migrate:latest` followed by `test`, and added no-op `migrate:latest` in `web` and `bot` so the command is uniform across workspaces.
- Introduced root QA helper scripts in `package.json`: `qa:web`, `qa:server`, and `qa:bot` that invoke the workspace `verify` tasks.
- Updated `server/.env.example` to include `DATABASE_PUBLIC_URL` and `DATABASE_URL` placeholders and updated `server/package.json` test script to a generic `vitest run` invocation.
- Expanded documentation in `README.md`, `web/README.md`, `server/README.md`, and `bot/README.md` to describe the `verify` command, recommended dev-domain environment variable values, and the one-line QA migration+test workflow.

### Testing

- No automated tests were executed as part of this change; the PR only adds/updates npm scripts and documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06e5f73fc8333ba6b1a8f560d4d50)