### PR TITLE
Add web e2e test harness: contract tests + Playwright UI suite and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .idea
 .env
+playwright-report
+test-results

--- a/TODO.md
+++ b/TODO.md
@@ -9,11 +9,26 @@
 - [x] Добавить базовый integration-набор ключевой бизнес-логики в `server/tests/business.integration.test.ts` (DB-backed, без моков доменных сервисов).
 - [ ] Зафиксировать политику миграций и backup/restore для production БД.
 
+### P0 — Next для автотестов web (UI e2e + интеграция с dev БД)
+
+- [ ] Подготовить выделенный e2e-account seed для dev БД (owner/admin/specialist/client) и reset-скрипт тестовых данных между прогонами.
+- [ ] Подключить запуск `web test:e2e:ui` в CI на nightly/scheduled pipeline c `E2E_BASE_URL` и роль-специфичными `E2E_*` credentials.
+- [ ] Добавить UI e2e: appointments lifecycle для owner/admin/specialist/client (create/edit/reschedule/cancel).
+- [ ] Добавить UI e2e: поздняя отмена appointment с проверкой grace period + refund/no-refund текстов подтверждения.
+- [ ] Добавить UI e2e: users management (create/edit/deactivate + resend invite).
+- [ ] Добавить UI e2e: role permissions matrix (Owner/Admin/Specialist/Client) по доступу к меню, страницам и критичным действиям.
+
 ## Приоритет P1
 
 - [x] Закрыть CSRF protection в refresh-cookie потоке (`server`).
 - [x] Добавить error tracking для `web` и `server`.
 - [ ] Довести audit/events для appointments (фильтрация, retention, actor context).
+
+### P1 — Next для стабилизации тестов
+
+- [ ] Устранить flaky-risk в UI e2e: фиксировать timezone/locale, добавить deterministic test data naming и cleanup hooks.
+- [ ] Добавить smoke-набор для notification logs и error logs с role-aware проверками видимости страниц.
+- [ ] Добавить негативные UI e2e сценарии: 401/403, network-failure fallback, validation errors в ключевых формах.
 
 ## Приоритет P2
 

--- a/web/README.md
+++ b/web/README.md
@@ -17,7 +17,10 @@ React SPA для owner/admin/specialist/client.
 ```bash
 npm run -w @scheduletm/web dev
 npm run -w @scheduletm/web build
-npm run -w @scheduletm/web test
+npm run -w @scheduletm/web test                 # быстрые e2e contract checks
+npm run -w @scheduletm/web test:e2e:contracts   # contract-level checks (node:test)
+npm run -w @scheduletm/web test:e2e:ui          # реальный UI e2e (Playwright, клики)
+npm run -w @scheduletm/web test:e2e             # contracts + UI
 npm run -w @scheduletm/web verify
 ```
 
@@ -51,3 +54,30 @@ VITE_API_URL=https://apidev.meetli.cc
 - создание аккаунта с полями: имя, фамилия, пароль, повтор пароля, Telegram;
 - inline-ошибки (слабый пароль/несовпадение паролей) и fallback серверной ошибки;
 - запрос нового приглашения для истекших ссылок.
+
+
+## Покрытие e2e contract-тестами (быстрый слой)
+
+`web/tests/e2e/*.test.mjs` проверяют web-контракты без браузерного раннера:
+- жизненный цикл appointments: create/edit/cancel/reschedule;
+- late-cancel UX по specialist booking policy (grace period + refund/no-refund тексты подтверждения/предупреждения);
+- users CRUD: create/edit/delete;
+- role-aware ограничения для owner/admin/specialist/client на уровне web-контейнеров и меню.
+
+
+## UI e2e (Playwright) для dev-стенда
+
+Тесты в `web/tests/e2e/ui/*.spec.mjs` — это **настоящие end-to-end UI-тесты**:
+- открывают браузерный контекст;
+- делают реальные клики/ввод в интерфейсе;
+- проверяют поведение web-приложения при интеграции с backend/dev БД.
+
+### Переменные окружения для UI e2e
+
+- `E2E_BASE_URL` — URL web-приложения (например, `https://dev.meetli.cc` или локальный `http://127.0.0.1:5173`).
+- `E2E_OWNER_EMAIL` / `E2E_OWNER_PASSWORD`
+- `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD`
+- `E2E_SPECIALIST_EMAIL` / `E2E_SPECIALIST_PASSWORD`
+- `E2E_CLIENT_EMAIL` / `E2E_CLIENT_PASSWORD`
+
+Если часть ролей не задана, соответствующие проверки будут пропущены (skip), чтобы можно было запускать suite постепенно.

--- a/web/package.json
+++ b/web/package.json
@@ -8,8 +8,10 @@
     "build": "tsc -p tsconfig.json && vite build",
     "start": "serve -s dist -l tcp://0.0.0.0:$PORT",
     "typecheck": "tsc --noEmit",
-    "test": "node --test tests/e2e/smoke.e2e.test.mjs",
-    "test:e2e": "node --test tests/e2e/smoke.e2e.test.mjs",
+    "test": "npm run test:e2e:contracts",
+    "test:e2e:contracts": "node --test tests/e2e/*.test.mjs",
+    "test:e2e:ui": "npx -y playwright@1.53.0 test --config=playwright.config.mjs",
+    "test:e2e": "npm run test:e2e:contracts && npm run test:e2e:ui",
     "migrate:latest": "node -e \"console.log('web: migrations are not required')\"",
     "verify": "npm run migrate:latest && npm run test"
   },

--- a/web/playwright.config.mjs
+++ b/web/playwright.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from 'playwright/test';
+
+const baseURL = process.env.E2E_BASE_URL || 'http://127.0.0.1:5173';
+
+export default defineConfig({
+  testDir: './tests/e2e/ui',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+});

--- a/web/tests/e2e/ui/web.ui.e2e.spec.mjs
+++ b/web/tests/e2e/ui/web.ui.e2e.spec.mjs
@@ -1,0 +1,108 @@
+import { test, expect } from 'playwright/test';
+
+function creds(prefix) {
+  return {
+    email: process.env[`${prefix}_EMAIL`] ?? '',
+    password: process.env[`${prefix}_PASSWORD`] ?? '',
+  };
+}
+
+async function login(page, { email, password }) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('ui-locale', 'en');
+  });
+
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL(/\/settings$/);
+}
+
+test.describe('web ui e2e (real clicks)', () => {
+  test('owner can create/edit/deactivate user via UI', async ({ page }) => {
+    const owner = creds('E2E_OWNER');
+    test.skip(!owner.email || !owner.password, 'Set E2E_OWNER_EMAIL and E2E_OWNER_PASSWORD for UI e2e.');
+
+    await login(page, owner);
+
+    await page.getByRole('link', { name: 'Users' }).click();
+    await expect(page).toHaveURL(/\/users$/);
+
+    const randomSuffix = `${Date.now()}${Math.floor(Math.random() * 1000)}`;
+    const email = `e2e-client-${randomSuffix}@example.com`;
+
+    await page.getByRole('button', { name: 'Add user' }).click();
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Role').click();
+    await page.getByRole('option', { name: 'client' }).click();
+    await page.getByLabel('First name').fill('E2E');
+    await page.getByLabel('Last name').fill('Client');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    const row = page.locator('tr', { hasText: email });
+    await expect(row).toBeVisible();
+
+    await row.getByRole('button', { name: 'Edit user' }).click();
+    await page.getByLabel('Last name').fill('Client Updated');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.locator('tr', { hasText: 'Client Updated' })).toBeVisible();
+
+    await row.getByRole('button', { name: 'Deactivate user' }).click();
+    await expect(row).toBeVisible();
+  });
+
+  test('role-aware menu visibility for owner/admin/specialist/client', async ({ browser }) => {
+    const scenarios = [
+      {
+        label: 'owner',
+        creds: creds('E2E_OWNER'),
+        visible: ['Appointments', 'Specialists', 'Users', 'Notification logs', 'Error logs', 'Settings'],
+      },
+      {
+        label: 'admin',
+        creds: creds('E2E_ADMIN'),
+        visible: ['Appointments', 'Specialists', 'Users', 'Notification logs', 'Settings'],
+        hidden: ['Error logs'],
+      },
+      {
+        label: 'specialist',
+        creds: creds('E2E_SPECIALIST'),
+        visible: ['Appointments', 'Users', 'Notification logs', 'Settings'],
+        hidden: ['Specialists', 'Error logs'],
+      },
+      {
+        label: 'client',
+        creds: creds('E2E_CLIENT'),
+        visible: ['Appointments', 'Settings'],
+        hidden: ['Specialists', 'Users', 'Notification logs', 'Error logs'],
+      },
+    ];
+
+
+    const hasAnyScenario = scenarios.some((scenario) => scenario.creds.email && scenario.creds.password);
+    test.skip(!hasAnyScenario, 'Set at least one E2E_*_EMAIL/PASSWORD pair for role menu checks.');
+
+    for (const scenario of scenarios) {
+      if (!scenario.creds.email || !scenario.creds.password) {
+        continue;
+      }
+
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      await login(page, scenario.creds);
+
+      for (const item of scenario.visible) {
+        await expect(page.getByRole('link', { name: item })).toBeVisible();
+      }
+
+      for (const item of scenario.hidden ?? []) {
+        await expect(page.getByRole('link', { name: item })).toHaveCount(0);
+      }
+
+      await context.close();
+    }
+
+  });
+});

--- a/web/tests/e2e/web.integration.e2e.test.mjs
+++ b/web/tests/e2e/web.integration.e2e.test.mjs
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+async function read(relativePath) {
+  return readFile(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('web integration contracts: appointments lifecycle + users CRUD + RBAC', () => {
+  it('covers appointments create/edit/cancel/reschedule API contracts', async () => {
+    const appointmentsContainer = await read('src/containers/AppointmentsContainer.tsx');
+
+    assert.match(appointmentsContainer, /await apiClient\.post\('\/api\/appointments'/);
+    assert.match(appointmentsContainer, /await apiClient\.patch\(`\/api\/appointments\/\$\{editingItem\.id\}`/);
+    assert.match(appointmentsContainer, /await apiClient\.post\(`\/api\/appointments\/\$\{editingItem\.id\}\/cancel`/);
+    assert.match(appointmentsContainer, /await apiClient\.post\(`\/api\/appointments\/\$\{appointmentId\}\/reschedule`/);
+  });
+
+  it('covers late-cancel grace period and refund/no-refund UX contracts', async () => {
+    const appointmentsContainer = await read('src/containers/AppointmentsContainer.tsx');
+
+    assert.match(appointmentsContainer, /policy\.cancelGracePeriodHours/);
+    assert.match(appointmentsContainer, /policy\.refundOnLateCancel/);
+    assert.match(appointmentsContainer, /return isLateCancel && !policy\.refundOnLateCancel \? 'no_refund' : 'refund'/);
+    assert.match(appointmentsContainer, /\? t\('appointments\.cancelConfirmNoRefund'\)/);
+    assert.match(appointmentsContainer, /: t\('appointments\.cancelConfirmRefund'\)/);
+    assert.match(appointmentsContainer, /\? t\('appointments\.cancelPolicyNoRefund'\)/);
+    assert.match(appointmentsContainer, /: t\('appointments\.cancelPolicyRefund'\)/);
+  });
+
+  it('covers users create/edit/delete contracts', async () => {
+    const usersContainer = await read('src/containers/UsersContainer.tsx');
+
+    assert.match(usersContainer, /await apiClient\.post<ManagedUserItem>\('\/api\/users', payload/);
+    assert.match(usersContainer, /await apiClient\.patch<ManagedUserItem>\(`\/api\/users\/\$\{editingUser\.id\}`, payload/);
+    assert.match(usersContainer, /await apiClient\.delete<ManagedUserItem>\(`\/api\/users\/\$\{item\.id\}`/);
+  });
+
+  it('covers owner/admin/specialist/client RBAC gates in web UI containers', async () => {
+    const roles = await read('src/shared/types/roles.ts');
+    const mainLayout = await read('src/components/layout/MainLayout.tsx');
+    const usersContainer = await read('src/containers/UsersContainer.tsx');
+    const specialistsContainer = await read('src/containers/SpecialistsContainer.tsx');
+    const appointmentsContainer = await read('src/containers/AppointmentsContainer.tsx');
+
+    assert.match(roles, /Owner = 'owner'/);
+    assert.match(roles, /Admin = 'admin'/);
+    assert.match(roles, /Specialist = 'specialist'/);
+    assert.match(roles, /Client = 'client'/);
+
+    assert.match(mainLayout, /user\?\.role === 'owner' \|\| user\?\.role === 'admin'/);
+    assert.match(mainLayout, /user\?\.role === 'owner' \|\| user\?\.role === 'admin' \|\| user\?\.role === 'specialist'/);
+    assert.match(mainLayout, /user\?\.role === 'owner'[\s\S]*?\{ to: '\/error-logs'/);
+
+    assert.match(usersContainer, /const canManageUsers = user\?\.role === 'owner' \|\| user\?\.role === 'admin' \|\| user\?\.role === 'specialist'/);
+    assert.match(specialistsContainer, /const canManageSpecialists = user\?\.role === 'owner' \|\| user\?\.role === 'admin'/);
+    assert.match(appointmentsContainer, /const canManageAll = user\?\.role === WebUserRole\.Owner \|\| user\?\.role === WebUserRole\.Admin/);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a lightweight contract layer and a full UI end-to-end layer for the web module so core flows and RBAC are continuously validated.
- Surface run scripts and configuration so CI/nightly pipelines can execute both fast contract checks and real-browser Playwright tests.
- Document e2e requirements and next priorities for stabilizing UI tests in the global TODO and module README.

### Description

- Added Playwright configuration in `web/playwright.config.mjs` with `E2E_BASE_URL` support, retries on CI, and failure artifacts enabled.
- Introduced UI e2e tests in `web/tests/e2e/ui/web.ui.e2e.spec.mjs` that exercise login, users CRUD and role-aware menu visibility using role-specific env credentials.
- Added fast contract integration tests in `web/tests/e2e/web.integration.e2e.test.mjs` that assert API contract usages and RBAC gates via `node:test` static reads of UI containers.
- Updated `web/package.json` scripts to run contract checks (`test:e2e:contracts`) and Playwright UI tests (`test:e2e:ui`) and made `test` point to the contracts suite, plus updated `web/README.md` and top-level `TODO.md` to document e2e plans; updated `.gitignore` to ignore Playwright artifacts.

### Testing

- Ran the contract suite with `npm run -w @scheduletm/web test:e2e:contracts` (`node --test tests/e2e/*.test.mjs`) and the tests completed successfully.
- The Playwright UI suite is configured to run with `npm run -w @scheduletm/web test:e2e:ui` and was not executed in this rollout because it requires `E2E_*` credentials and a reachable `E2E_BASE_URL` (tests will be skipped when credentials are missing).
- Playwright config sets `retries` on CI and produces traces/screenshots/videos on failures to aid flake investigation; no CI Playwright run was included in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0763d30e88333be78b9301e7adb96)