### PR TITLE
Fix Playwright login selector strictness for password input

### DIFF
--- a/web/tests/e2e/ui/web.ui.e2e.spec.mjs
+++ b/web/tests/e2e/ui/web.ui.e2e.spec.mjs
@@ -14,7 +14,7 @@ async function login(page, { email, password }) {
 
   await page.goto('/login');
   await page.getByLabel('Email').fill(email);
-  await page.getByLabel('Password').fill(password);
+  await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByRole('button', { name: 'Sign in' }).click();
   await expect(page).toHaveURL(/\/settings$/);
 }


### PR DESCRIPTION
### Motivation
- Fix a Playwright strict-mode failure in the UI E2E login helper where `getByLabel('Password')` resolved to multiple elements (the password input and the "Toggle password visibility" button), causing `locator.fill` to throw.

### Description
- Update `web/tests/e2e/ui/web.ui.e2e.spec.mjs` to use `getByLabel('Password', { exact: true })` in the `login(...)` helper so the password input is targeted unambiguously.

### Testing
- Ran `node --check web/tests/e2e/ui/web.ui.e2e.spec.mjs` which succeeded, and attempted `npm run test:e2e:ui` but the full E2E run could not complete in this environment due to package registry access (`403 Forbidden`) and missing local `.env` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08be7ee388333bbebf2e9d45cafe5)