### PR TITLE
test(web): add Playwright UI e2e checks for page access control

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -72,9 +72,10 @@ VITE_API_URL=https://apidev.meetli.cc
 - делают реальные клики/ввод в интерфейсе;
 - проверяют поведение web-приложения при интеграции с backend/dev БД;
 - покрывают owner-flow для `Users` (create/edit/deactivate), переход owner в `/error-logs`, logout из profile menu;
-- проверяют role-aware доступность пунктов меню и доступность табов `System settings`/`Account settings` на странице настроек.
+- проверяют role-aware доступность пунктов меню и доступность табов `System settings`/`Account settings` на странице настроек;
+- проверяют доступ к страницам по прямому URL и access denied состояния (owner/admin/client) для `/specialists`, `/notification-logs`, `/error-logs`.
 
-Структура UI e2e разнесена по файлам: `users.ui.e2e.spec.mjs`, `navigation.ui.e2e.spec.mjs`, `settings.ui.e2e.spec.mjs`, `session.ui.e2e.spec.mjs`; общие auth-хелперы вынесены в `ui/helpers/auth.mjs`.
+Структура UI e2e разнесена по файлам: `users.ui.e2e.spec.mjs`, `navigation.ui.e2e.spec.mjs`, `settings.ui.e2e.spec.mjs`, `session.ui.e2e.spec.mjs`, `access-control.ui.e2e.spec.mjs`; общие auth-хелперы вынесены в `ui/helpers/auth.mjs`.
 
 
 > Для запуска используется `@playwright/test` (единый раннер/DSL), чтобы избежать конфликтов вида `test.describe() called here` при смешивании разных Playwright пакетов.

--- a/web/tests/e2e/ui/access-control.ui.e2e.spec.mjs
+++ b/web/tests/e2e/ui/access-control.ui.e2e.spec.mjs
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { creds, login } from './helpers/auth.mjs';
+
+test.describe('web ui e2e: page access control', () => {
+  test('owner can open specialists and notification logs pages directly', async ({ page }) => {
+    const owner = creds('E2E_OWNER');
+    test.skip(!owner.email || !owner.password, 'Set E2E_OWNER_EMAIL and E2E_OWNER_PASSWORD for UI e2e.');
+
+    await login(page, owner);
+
+    await page.goto('/specialists');
+    await expect(page).toHaveURL(/\/specialists$/);
+    await expect(page.getByRole('heading', { name: 'Specialists' })).toBeVisible();
+
+    await page.goto('/notification-logs');
+    await expect(page).toHaveURL(/\/notification-logs$/);
+    await expect(page.getByRole('heading', { name: 'Notification logs' })).toBeVisible();
+  });
+
+  test('client sees access denied on specialists and notification logs', async ({ page }) => {
+    const client = creds('E2E_CLIENT');
+    test.skip(!client.email || !client.password, 'Set E2E_CLIENT_EMAIL and E2E_CLIENT_PASSWORD for UI e2e.');
+
+    await login(page, client);
+
+    await page.goto('/specialists');
+    await expect(page).toHaveURL(/\/specialists$/);
+    await expect(page.getByText('Only owner or admin can manage specialists.')).toBeVisible();
+
+    await page.goto('/notification-logs');
+    await expect(page).toHaveURL(/\/notification-logs$/);
+    await expect(page.getByText('You do not have access to notification logs.')).toBeVisible();
+  });
+
+  test('admin sees access denied on error logs page', async ({ page }) => {
+    const admin = creds('E2E_ADMIN');
+    test.skip(!admin.email || !admin.password, 'Set E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD for UI e2e.');
+
+    await login(page, admin);
+
+    await page.goto('/error-logs');
+    await expect(page).toHaveURL(/\/error-logs$/);
+    await expect(page.getByText('Only owner can view error logs.')).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Motivation
- Add missing UI e2e coverage for page-level access control and direct-URL access scenarios (owner/admin/client) to ensure pages enforce role gates and surface access-denied states.

### Description
- Added a new Playwright UI spec `web/tests/e2e/ui/access-control.ui.e2e.spec.mjs` which verifies direct access and access-denied messages for `/specialists`, `/notification-logs`, and `/error-logs`.
- Updated `web/README.md` to document the new access-control checks and include the new spec in the UI e2e coverage description.

### Testing
- Ran `npm run -w @scheduletm/web test:e2e:contracts` and the contract-level tests passed successfully (all checks green).
- Attempted `npm run -w @scheduletm/web test:e2e:ui` which failed in this environment due to a missing `web/.env` required by the runner (environment issue, not test logic failure).
- Performed a syntax check with `node --check web/tests/e2e/ui/access-control.ui.e2e.spec.mjs` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09254603c83338b2d462d1925dca7)