### PR TITLE
fix(web): accept /settings redirect in UI E2E auth helper

### DIFF
--- a/web/tests/e2e/ui/helpers/auth.mjs
+++ b/web/tests/e2e/ui/helpers/auth.mjs
@@ -34,7 +34,7 @@ export async function login(page, { email, password }) {
   if (cachedState) {
     await applyCachedState(page, cachedState);
     await page.goto('/appointments');
-    await expect(page).toHaveURL(/\/appointments$/);
+    await expect(page).toHaveURL(/\\/(appointments|settings)$/);
 
     return;
   }
@@ -47,7 +47,7 @@ export async function login(page, { email, password }) {
   await page.getByLabel('Email').fill(email);
   await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByRole('button', { name: 'Sign in' }).click();
-  await expect(page).toHaveURL(/\/appointments$/);
+  await expect(page).toHaveURL(/\\/(appointments|settings)$/);
 
   authStateCache.set(cacheKey, await page.context().storageState());
 }


### PR DESCRIPTION
### Motivation
- The UI E2E login helper asserted only `/appointments` after sign-in while the app can redirect to `/settings`, causing flaky failures in several Playwright specs.

### Description
- Relaxed the post-login URL expectation in `web/tests/e2e/ui/helpers/auth.mjs` to accept either `/appointments` or `/settings` and applied it for both the cached-session and fresh-login code paths.

### Testing
- Attempted to run `npm run -w @scheduletm/web test:e2e:ui -- --grep "owner can open specialists and notification logs pages directly"` and direct Playwright CLI runs, but execution could not complete in this environment due to a missing `.env` file and the Playwright dependency layout, so no E2E tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a071841c833393c1e5abf1661278)