### PR TITLE
Use API-based login for UI e2e, add `E2E_API_URL` and document local `VITE_API_URL`

### DIFF
--- a/web/.dev.env
+++ b/web/.dev.env
@@ -2,7 +2,7 @@ PORT=3003
 APP_URL=http://localhost:5173
 SESSION_COOKIE_NAME=scheduletm_refresh
 WEBHOOK_SECRET=любой_длинный_секрет
-VITE_API_URL=https://apidev.meetli.cc
+VITE_API_URL=http://localhost:3003
 
 E2E_OWNER_EMAIL=vlad.s-92@yandex.ru
 E2E_OWNER_PASSWORD=Koibass555

--- a/web/README.md
+++ b/web/README.md
@@ -40,6 +40,16 @@ VITE_API_URL=https://api.example.com
 VITE_API_URL=https://apidev.meetli.cc
 ```
 
+
+Для локального UI e2e (`localhost`) используйте локальный API, например:
+
+```bash
+VITE_API_URL=http://localhost:3003
+```
+
+Если оставить удалённый `VITE_API_URL` (например `https://apidev.meetli.cc`) при локальном запуске, на странице `/login` может появляться `Network connection issue`, и login-шаг UI e2e не пройдет.
+
+
 ## Документация
 
 - Глобальный обзор: [`../README.md`](../README.md)
@@ -83,9 +93,15 @@ VITE_API_URL=https://apidev.meetli.cc
 ### Переменные окружения для UI e2e
 
 - `E2E_BASE_URL` — URL web-приложения (например, `https://dev.meetli.cc` или локальный `http://127.0.0.1:5173`).
+- `E2E_API_URL` — URL API для e2e auth-хелпера (по умолчанию: `VITE_API_URL`, затем origin web).
 - `E2E_OWNER_EMAIL` / `E2E_OWNER_PASSWORD`
 - `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD`
 - `E2E_SPECIALIST_EMAIL` / `E2E_SPECIALIST_PASSWORD`
 - `E2E_CLIENT_EMAIL` / `E2E_CLIENT_PASSWORD`
 
 Если часть ролей не задана, соответствующие проверки будут пропущены (skip), чтобы можно было запускать suite постепенно.
+
+`ui/helpers/auth.mjs` выполняет login через API и кладет auth-сессию в `localStorage`,
+поэтому UI e2e меньше зависят от CORS-ограничений браузера на странице `/login`.
+Важно, чтобы `E2E_API_URL` (или `VITE_API_URL`) был достижим из окружения, где запускается Playwright.
+

--- a/web/tests/e2e/ui/helpers/auth.mjs
+++ b/web/tests/e2e/ui/helpers/auth.mjs
@@ -1,6 +1,10 @@
 import { expect } from '@playwright/test';
 
 const APP_ORIGIN = new URL(process.env.E2E_BASE_URL || 'http://localhost:5173').origin;
+const E2E_API_URL = process.env.E2E_API_URL || process.env.VITE_API_URL || APP_ORIGIN;
+const AUTH_TOKEN_KEY = 'scheduletm_access_token';
+const AUTH_USER_KEY = 'scheduletm_auth_user';
+const AUTH_REDIRECT_RE = new RegExp('\/(appointments|settings)$');
 const authStateCache = new Map();
 
 export function creds(prefix) {
@@ -27,6 +31,41 @@ async function applyCachedState(page, state) {
   }, { entries: localStorageEntries });
 }
 
+async function loginViaApi(page, { email, password }) {
+  const endpoint = new URL('/api/auth/login', E2E_API_URL).toString();
+  const timezone = 'UTC';
+
+  const response = await page.request.post(endpoint, {
+    data: { email, password, timezone },
+    failOnStatusCode: false,
+  });
+
+  if (!response.ok()) {
+    const responseText = (await response.text()).slice(0, 300);
+    throw new Error(`E2E API login failed (${response.status()}) at ${endpoint}: ${responseText || 'empty response'}`);
+  }
+
+  const payload = await response.json();
+
+  if (!payload?.accessToken || !payload?.user) {
+    throw new Error(`E2E API login returned invalid payload at ${endpoint}`);
+  }
+
+  await page.addInitScript(({ token, user, tokenKey, userKey }) => {
+    window.localStorage.setItem('ui-locale', 'en');
+    window.localStorage.setItem(tokenKey, token);
+    window.localStorage.setItem(userKey, JSON.stringify(user));
+  }, {
+    token: payload.accessToken,
+    user: payload.user,
+    tokenKey: AUTH_TOKEN_KEY,
+    userKey: AUTH_USER_KEY,
+  });
+
+  await page.goto('/appointments');
+  await expect(page).toHaveURL(AUTH_REDIRECT_RE);
+}
+
 export async function login(page, { email, password }) {
   const cacheKey = `${email}:${password}`;
   const cachedState = authStateCache.get(cacheKey);
@@ -34,20 +73,11 @@ export async function login(page, { email, password }) {
   if (cachedState) {
     await applyCachedState(page, cachedState);
     await page.goto('/appointments');
-    await expect(page).toHaveURL(/\\/(appointments|settings)$/);
+    await expect(page).toHaveURL(AUTH_REDIRECT_RE);
 
     return;
   }
 
-  await page.addInitScript(() => {
-    window.localStorage.setItem('ui-locale', 'en');
-  });
-
-  await page.goto('/login');
-  await page.getByLabel('Email').fill(email);
-  await page.getByLabel('Password', { exact: true }).fill(password);
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await expect(page).toHaveURL(/\\/(appointments|settings)$/);
-
+  await loginViaApi(page, { email, password });
   authStateCache.set(cacheKey, await page.context().storageState());
 }


### PR DESCRIPTION
### Motivation

- Reduce UI e2e flakiness caused by browser CORS and remote API by performing auth via backend API instead of filling the login form in the browser.
- Allow tests to target a different API origin than the built web app via an explicit `E2E_API_URL` env var.
- Improve local developer experience by documenting and defaulting `VITE_API_URL` to a local API in the dev env.

### Description

- Added `E2E_API_URL` resolution in `web/tests/e2e/ui/helpers/auth.mjs` (falls back to `VITE_API_URL` and then the app origin) and introduced constants for storage keys and redirect detection.
- Implemented `loginViaApi` which performs a `POST` to `/api/auth/login` with `page.request`, validates the response, and injects `accessToken` and `user` into `localStorage` using `page.addInitScript` before navigating to `/appointments`.
- Reworked `login` to use cached storage state when available and to call `loginViaApi` when not cached, replacing the previous UI form-driven sign-in flow.
- Updated `web/README.md` to document `E2E_API_URL`, add guidance for using a local `VITE_API_URL` for local UI e2e runs, and explain why API-based login is used for tests.
- Adjusted `web/.dev.env` to set `VITE_API_URL=http://localhost:3003` to match local dev/test usage.

### Testing

- Ran quick contract checks with `npm run -w @scheduletm/web test` and `npm run -w @scheduletm/web test:e2e` and they completed successfully.
- Executed Playwright UI tests with `npm run -w @scheduletm/web test:e2e:ui` against a local API endpoint and they passed using the new API-login flow.
- Verified that cached auth state is stored and reused by the `login` helper during repeated test runs (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a2b8f0c883338c60a393dee75e1e)