### PR TITLE
docs(todo): add Vladislav product backlog items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,25 @@
 - [x] Добавить error tracking для `web` и `server`.
 - [ ] Довести audit/events для appointments (фильтрация, retention, actor context).
 
+### P1 — Новые задачи продукта (из заметок Vladislav, 2026-04-27 — 2026-04-28)
+
+- [ ] Интеграции встреч: добавить Google/Outlook/iCal календари, Zoom, Телемост и другие meeting providers.
+- [ ] Регистрация: улучшить страницу регистрации и добавить дополнительные поля профиля.
+- [ ] OTP flow: отправлять 4-значный код подтверждения; после полного ввода OTP автоматически запускать `confirm` и валидацию токена.
+- [ ] RBAC/UI cleanup: для ролей без доступа полностью скрывать недоступные секции (не `disable`), в том числе `System settings` для `admin`; провести аудит остальных экранов.
+- [ ] Настройки локали/таймзоны: убрать дублирование между `Account settings` и `User settings`, оставить только в `User settings`.
+- [ ] Owner user management: дать owner возможность создавать пользователей в других `account_id`; добавить dropdown `account_id — account_name — company_name`.
+- [ ] Users list: починить удаление пользователя по иконке delete (запись должна исчезать из списка и в БД).
+- [ ] Verify email/create account: корректно подтягивать и предзаполнять `first_name`/`last_name`; не подставлять Telegram/email в неверные поля.
+- [ ] User settings: убрать поле `telegram bot token`, заменить на `telegram username`.
+- [ ] Client notifications: добавить отдельную страницу настроек уведомлений для клиента (вкл/выкл и каналы доставки).
+- [ ] Public appointment status: добавить страницу проверки статуса appointment для незарегистрированного пользователя по `appointment_id + specialist_last_name`.
+- [ ] Public booking by account slug: добавить страницу создания appointment без регистрации по ссылке вида `/[account_company_id]/login`.
+- [ ] Account slug management: добавить для admin/owner настройку `account_company_name` и уникального `account_company_id`; по умолчанию генерировать доступный slug.
+- [ ] Appointments recurrence: добавить `frequency` при создании appointment.
+- [ ] Account settings (admin): добавить поле имени компании.
+- [ ] Вынести настройку публичного URL/slug страницы в отдельный setup окружения.
+
 ### P1 — Next для стабилизации тестов
 
 - [ ] Устранить flaky-risk в UI e2e: фиксировать timezone/locale, добавить deterministic test data naming и cleanup hooks.


### PR DESCRIPTION
### Motivation
- Centralize product ideas from Vladislav into the project backlog so they are actionable and prioritized.
- Keep the existing TODO structure and priorities unchanged while surfacing new P1 product work.

### Description
- Added a new `P1 — Новые задачи продукта (из заметок Vladislav, 2026-04-27 — 2026-04-28)` section to `TODO.md` containing actionable items for calendar/meeting integrations, registration and OTP improvements, RBAC/UI visibility cleanup, locale/timezone and Telegram settings cleanup, owner/account management, user-deletion and verify-email fixes, client notification settings, public appointment status/booking flows, account slug/URL management, appointment recurrence (`frequency`), and related admin fields.
- This PR only modifies `TODO.md` and introduces no runtime code changes or new dependencies.

### Testing
- No automated tests were required for this documentation-only change and none were run.
- The updated `TODO.md` content and diff were inspected to confirm the new P1 section was added correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c1f883c48333978a90c04cea3993)