### PR TITLE
Add process-level error tracking, job error handling, and graceful shutdown

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -44,6 +44,9 @@ Node.js/Express API для web-клиента и интеграций.
   - fallback на `email`;
   - дедупликация через таблицу `notifications` по ключу `appointment_id + type + channel`;
   - retry/backoff и управление состояниями отправки: `pending -> processing -> sent` или `retry/failed` с `next_retry_at`, `attempts`, `max_attempts`.
+  - ошибки фоновых job пишутся в `error_logs` (`source=server`, `method=JOB`) и не падают в `unhandledRejection`, чтобы не останавливать процесс API при временных проблемах сети/БД.
+  - process-level ошибки (`unhandledRejection`, `uncaughtException`, `listen error`) также трекаются в `error_logs` (`method=PROCESS`) best-effort.
+  - при `SIGTERM`/`SIGINT` сервер выполняет graceful shutdown: останавливает job-таймеры и закрывает HTTP listener.
 - Локализованные API-сообщения (`ru/en`).
 - Error tracking (`web` + `server`) с хранением в `error_logs` и optional Telegram alerts через отдельного бота (без email); bot token/chat id хранятся в `system_settings` в зашифрованном виде.
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,10 +9,75 @@ const [{ createApp }, { env }, { startNotificationDefaultsJob }, { startAppointm
   import('./jobs/appointmentNotifications.job.js'),
   import('./jobs/appointmentAutoCancelUnpaid.job.js'),
 ]);
+const { trackServerError } = await import('./services/errorTrackingService.js');
+const jobTimers: NodeJS.Timeout[] = [];
+let shuttingDown = false;
 
-createApp().listen(env.PORT, () => {
-  startNotificationDefaultsJob();
-  startAppointmentNotificationsJob();
-  startAppointmentAutoCancelUnpaidJob();
+const stopJobs = () => {
+  for (const timer of jobTimers) {
+    clearInterval(timer);
+  }
+  jobTimers.length = 0;
+};
+
+const shutdown = (signal: 'SIGINT' | 'SIGTERM') => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  console.log(`[process] received ${signal}, shutting down`);
+  stopJobs();
+  server.close((error) => {
+    if (error) {
+      console.error('[process] graceful shutdown failed', error);
+      void trackServerError({
+        method: 'PROCESS',
+        path: '/process/graceful-shutdown',
+        error,
+      });
+      process.exitCode = 1;
+      return;
+    }
+
+    process.exitCode = 0;
+  });
+};
+
+process.on('unhandledRejection', (reason) => {
+  const error = reason instanceof Error ? reason : new Error(String(reason));
+  console.error('[process] unhandledRejection', error);
+  void trackServerError({
+    method: 'PROCESS',
+    path: '/process/unhandled-rejection',
+    error,
+  });
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('[process] uncaughtException', error);
+  void trackServerError({
+    method: 'PROCESS',
+    path: '/process/uncaught-exception',
+    error,
+  });
+});
+
+const app = createApp();
+const server = app.listen(env.PORT, () => {
+  jobTimers.push(startNotificationDefaultsJob());
+  jobTimers.push(startAppointmentNotificationsJob());
+  jobTimers.push(startAppointmentAutoCancelUnpaidJob());
   console.log(`server listening on http://localhost:${env.PORT}`);
+});
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+server.on('error', (error) => {
+  console.error('[process] listen error', error);
+  void trackServerError({
+    method: 'PROCESS',
+    path: '/process/listen-error',
+    error,
+  });
 });

--- a/server/src/jobs/appointmentAutoCancelUnpaid.job.ts
+++ b/server/src/jobs/appointmentAutoCancelUnpaid.job.ts
@@ -4,6 +4,7 @@ import {
   listUnpaidActiveAppointmentsCreatedBeforeAllAccounts,
 } from '../repositories/appointmentRepository.js';
 import { findSpecialistBookingPolicy } from '../repositories/specialistBookingPolicyRepository.js';
+import { trackServerError } from '../services/errorTrackingService.js';
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
 const MIN_ELAPSED_MINUTES = 60;
@@ -19,7 +20,13 @@ function shouldAutoCancel(input: {
 
 export function startAppointmentAutoCancelUnpaidJob(intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timeout {
   return setInterval(() => {
-    void runAppointmentAutoCancelUnpaidJob();
+    void runAppointmentAutoCancelUnpaidJob().catch((error) => {
+      void trackServerError({
+        method: 'JOB',
+        path: '/jobs/appointment-auto-cancel-unpaid',
+        error,
+      });
+    });
   }, intervalMs);
 }
 

--- a/server/src/jobs/appointmentNotifications.job.ts
+++ b/server/src/jobs/appointmentNotifications.job.ts
@@ -9,6 +9,7 @@ import {
   upsertNotificationJob,
 } from '../repositories/notificationRepository.js';
 import { sendAppointmentNotificationByType } from '../services/appointmentNotificationService.js';
+import { trackServerError } from '../services/errorTrackingService.js';
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_WINDOW_MIN = 10;
@@ -88,7 +89,13 @@ async function deliverAndMark(input: {
 
 export function startAppointmentNotificationsJob(intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timeout {
   return setInterval(() => {
-    void runAppointmentNotificationsJob();
+    void runAppointmentNotificationsJob().catch((error) => {
+      void trackServerError({
+        method: 'JOB',
+        path: '/jobs/appointment-notifications',
+        error,
+      });
+    });
   }, intervalMs);
 }
 

--- a/server/src/jobs/notificationDefaults.job.ts
+++ b/server/src/jobs/notificationDefaults.job.ts
@@ -1,12 +1,19 @@
 import { listAccountIdsWithoutNotificationDefaults } from '../repositories/accountNotificationDefaultsRepository.js';
 import { buildDefaultAccountNotificationSettings, getAccountNotificationDefaults } from '../services/notificationSettingsService.js';
+import { trackServerError } from '../services/errorTrackingService.js';
 
 const DEFAULT_BATCH_SIZE = 50;
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
 
 export function startNotificationDefaultsJob(intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timeout {
   return setInterval(() => {
-    void runNotificationDefaultsJob();
+    void runNotificationDefaultsJob().catch((error) => {
+      void trackServerError({
+        method: 'JOB',
+        path: '/jobs/notification-defaults',
+        error,
+      });
+    });
   }, intervalMs);
 }
 

--- a/server/src/services/errorTrackingService.ts
+++ b/server/src/services/errorTrackingService.ts
@@ -139,26 +139,31 @@ export async function trackServerError(input: {
   error: unknown;
 }): Promise<void> {
   const error = input.error instanceof Error ? input.error : new Error('Unknown server error');
-  await insertErrorLog({
-    accountId: input.actor?.accountId ?? null,
-    webUserId: input.actor ? Number(input.actor.id) : null,
-    source: 'server',
-    method: input.method?.slice(0, 16) ?? null,
-    path: input.path?.slice(0, 255) ?? null,
-    message: normalizeText(error.message) || 'Server error',
-    stack: normalizeText(error.stack, ERROR_STACK_MAX) || null,
-  });
+  try {
+    await insertErrorLog({
+      accountId: input.actor?.accountId ?? null,
+      webUserId: input.actor ? Number(input.actor.id) : null,
+      source: 'server',
+      method: input.method?.slice(0, 16) ?? null,
+      path: input.path?.slice(0, 255) ?? null,
+      message: normalizeText(error.message) || 'Server error',
+      stack: normalizeText(error.stack, ERROR_STACK_MAX) || null,
+    });
 
-  await notifyErrorToTelegram({
-    source: 'server',
-    message: normalizeText(error.message) || 'Server error',
-    method: input.method?.slice(0, 16) ?? null,
-    path: input.path?.slice(0, 255) ?? null,
-    accountId: input.actor?.accountId ?? null,
-    webUserId: input.actor ? Number(input.actor.id) : null,
-  });
+    await notifyErrorToTelegram({
+      source: 'server',
+      message: normalizeText(error.message) || 'Server error',
+      method: input.method?.slice(0, 16) ?? null,
+      path: input.path?.slice(0, 255) ?? null,
+      accountId: input.actor?.accountId ?? null,
+      webUserId: input.actor ? Number(input.actor.id) : null,
+    });
 
-  await cleanupExpiredLogs();
+    await cleanupExpiredLogs();
+  } catch (trackingError) {
+    console.error('[error-tracking] trackServerError failed', trackingError);
+    console.error('[error-tracking] original server error', error);
+  }
 }
 
 export async function getErrorLogsForActor(


### PR DESCRIPTION
### Motivation
- Make background jobs and process-level failures observable in `error_logs` while avoiding process exit on transient errors.
- Ensure background job rejections and error-tracking failures do not cause `unhandledRejection` that would stop the API.
- Document new process-level behavior and shutdown semantics in the server README.

### Description
- Wrap job invocations in `start*Job` functions so rejected job promises are caught and reported via `trackServerError` (method=`JOB`).
- Add graceful shutdown logic with `jobTimers`, `stopJobs`, and `shutdown` to clear job timers and close the HTTP listener on `SIGINT`/`SIGTERM`.
- Register process handlers for `unhandledRejection`, `uncaughtException`, and server `listen` errors to call `trackServerError` (method=`PROCESS`) and log the issues.
- Make `trackServerError` fault-tolerant by wrapping its implementation in a `try/catch` to prevent tracking failures from bubbling up, and update `server/README.md` to describe error logging and shutdown behavior.

### Testing
- Ran the server test suite with `npm run -w @scheduletm/server test`, which includes the integration set `server/tests/business.integration.test.ts`, and the tests passed.
- Ran `npm run -w @scheduletm/server verify` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c415a14c8333b3ebf7680d27188a)