### PR TITLE
Appointments: add role-aware menu/subtitle and advanced top filters (client, status, service, date)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -9,6 +9,13 @@ React SPA для owner/admin/specialist/client.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
+- Appointments page includes role-based top filters:
+  - owner: `Account`, `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;
+  - admin: `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;
+  - specialist: `Client`, `Service`, `Status`, `From/To` dates;
+  - client: `Specialist`, `Service`, `Status`, `From/To` dates.
+- Appointments page subtitle is role-aware (`All appointments`, `Appointments in your account`, `Appointments with you`, `My appointments`).
+- Main menu item for `/appointments` uses the same role-aware labels as the Appointments page subtitle.
 - Client flow: клиент работает только со своим расписанием (без доступа к чужим записям).
 - Notification logs (`/notification-logs`): таблица истории отправки с фильтрами (`accountId`, `specialistId`, `userId`) и колонками для читаемых данных (`specialistName`, `clientName`, `message`, `recipientTelegram`, `recipientEmail`) + retry action для статусов `failed/retry/cancelled`.
 

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -45,10 +45,25 @@ export function MainLayout() {
 
     void sync();
   }, [accessToken, isAuthenticated, locale, mode, paletteVariantId]);
-  const appointmentsText = user?.role === WebUserRole.Specialist || user?.role === WebUserRole.Client;
+
+  const appointmentsMenuLabel = (() => {
+    if (user?.role === WebUserRole.Owner) {
+      return t('appointments.pageSubtitleOwner');
+    }
+    if (user?.role === WebUserRole.Admin) {
+      return t('appointments.pageSubtitleAdmin');
+    }
+    if (user?.role === WebUserRole.Specialist) {
+      return t('appointments.pageSubtitleSpecialist');
+    }
+    if (user?.role === WebUserRole.Client) {
+      return t('appointments.pageSubtitleClient');
+    }
+    return t('common.appointments');
+  })();
 
   const menuItems = [
-    { to: '/appointments', label: appointmentsText ? t('common.my_appointments') : t('common.appointments'), icon: 'calendar' as const },
+    { to: '/appointments', label: appointmentsMenuLabel, icon: 'calendar' as const },
     ...(user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin
       ? [
         { to: '/specialists', label: t('common.specialists'), icon: 'specialists' as const },

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -11,6 +11,7 @@ import {
   Snackbar,
   Skeleton,
   Stack,
+  TextField,
   Typography,
   alpha,
   useTheme,
@@ -59,6 +60,11 @@ export function AppointmentsContainer() {
   const [clients, setClients] = useState<ClientItem[]>([]);
   const [busySlots, setBusySlots] = useState<AppointmentListResponse['busySlots']>([]);
   const [selectedSpecialistId, setSelectedSpecialistId] = useState<number | 'all'>('all');
+  const [selectedClientId, setSelectedClientId] = useState<number | 'all'>('all');
+  const [selectedStatus, setSelectedStatus] = useState<AppointmentItem['status'] | 'all'>('all');
+  const [serviceQuery, setServiceQuery] = useState('');
+  const [fromDateFilter, setFromDateFilter] = useState('');
+  const [toDateFilter, setToDateFilter] = useState('');
   const displayTimeZone = BROWSER_TIMEZONE;
 
   const [focusDate, setFocusDate] = useState(() => startOfDay(getUtcNowByTimeZone(displayTimeZone)));
@@ -84,6 +90,10 @@ export function AppointmentsContainer() {
   };
 
   const canManageAll = user?.role === WebUserRole.Owner || user?.role === WebUserRole.Admin;
+  const isOwner = user?.role === WebUserRole.Owner;
+  const isAdmin = user?.role === WebUserRole.Admin;
+  const isSpecialist = user?.role === WebUserRole.Specialist;
+  const isClient = user?.role === WebUserRole.Client;
   const selectedSpecialist = selectedSpecialistId === 'all'
     ? null
     : specialists.find((item) => item.id === selectedSpecialistId) ?? null;
@@ -104,10 +114,44 @@ export function AppointmentsContainer() {
     return Array.from({ length: 7 }, (_, index) => addDays(start, index));
   }, [focusDate, viewMode]);
 
+  const filteredAppointments = useMemo(() => appointments.filter((item) => {
+    if (selectedClientId !== 'all' && item.client.id !== selectedClientId) {
+      return false;
+    }
+
+    if (selectedStatus !== 'all' && item.status !== selectedStatus) {
+      return false;
+    }
+
+    if (serviceQuery.trim()) {
+      const serviceText = item.notes.toLowerCase();
+      if (!serviceText.includes(serviceQuery.trim().toLowerCase())) {
+        return false;
+      }
+    }
+
+    const scheduledDate = new Date(item.scheduledAt);
+    if (fromDateFilter) {
+      const fromDate = new Date(`${fromDateFilter}T00:00:00`);
+      if (scheduledDate < fromDate) {
+        return false;
+      }
+    }
+
+    if (toDateFilter) {
+      const toDate = new Date(`${toDateFilter}T23:59:59`);
+      if (scheduledDate > toDate) {
+        return false;
+      }
+    }
+
+    return true;
+  }), [appointments, fromDateFilter, selectedClientId, selectedStatus, serviceQuery, toDateFilter]);
+
   const appointmentsByCell = useMemo(() => {
     const map = new Map<string, AppointmentItem[]>();
 
-    for (const item of appointments) {
+    for (const item of filteredAppointments) {
       const date = new Date(item.scheduledAt);
       const dayKey = toDateKeyInTimezone(date, displayTimeZone);
       const key = `${dayKey}:${toTimeKeyInTimezone(date, displayTimeZone)}`;
@@ -121,7 +165,7 @@ export function AppointmentsContainer() {
     });
 
     return map;
-  }, [appointments, displayTimeZone]);
+  }, [displayTimeZone, filteredAppointments]);
 
   const busySlotsByCell = useMemo(() => {
     const map = new Map<string, AppointmentListResponse['busySlots']>();
@@ -141,7 +185,7 @@ export function AppointmentsContainer() {
   const appointmentsByDay = useMemo(() => {
     const map = new Map<string, AppointmentItem[]>();
 
-    for (const item of appointments) {
+    for (const item of filteredAppointments) {
       const date = new Date(item.scheduledAt);
       const dayKey = toDateKeyInTimezone(date, displayTimeZone);
       const list = map.get(dayKey) ?? [];
@@ -154,7 +198,24 @@ export function AppointmentsContainer() {
     });
 
     return map;
-  }, [appointments, displayTimeZone]);
+  }, [displayTimeZone, filteredAppointments]);
+
+  const pageSubtitle = useMemo(() => {
+    if (isOwner) {
+      return t('appointments.pageSubtitleOwner');
+    }
+    if (isAdmin) {
+      return t('appointments.pageSubtitleAdmin');
+    }
+    if (isSpecialist) {
+      return t('appointments.pageSubtitleSpecialist');
+    }
+    if (isClient) {
+      return t('appointments.pageSubtitleClient');
+    }
+
+    return t('appointments.pageSubtitle');
+  }, [isAdmin, isClient, isOwner, isSpecialist, t]);
 
   function getGridDayKey(day: Date) {
     const noon = new Date(day);
@@ -494,7 +555,7 @@ export function AppointmentsContainer() {
   return (
     <AppPage
       title={t('appointments.pageTitle')}
-      subtitle={t('appointments.pageSubtitle')}
+      subtitle={pageSubtitle}
     >
       {error && (
         <Box sx={{ mb: 2 }}>
@@ -512,6 +573,19 @@ export function AppointmentsContainer() {
         >
           <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
             <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} sx={{ justifyContent: 'space-between', alignItems: { md: 'center' } }}>
+              {isOwner && (
+                <FormControl sx={{ width: { xs: '100%', sm: 240 } }} size="small" disabled>
+                  <InputLabel id="account-filter">{t('appointments.accountFilter')}</InputLabel>
+                  <Select
+                    labelId="account-filter"
+                    label={t('appointments.accountFilter')}
+                    value="current"
+                  >
+                    <MenuItem value="current">{t('appointments.currentAccount')}</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
+
               {canManageAll && (
                 <FormControl sx={{ width: { xs: '100%', sm: 360 } }} size="small">
                   <InputLabel id="specialist-filter">{t('appointments.specialistFilter')}</InputLabel>
@@ -531,6 +605,94 @@ export function AppointmentsContainer() {
                   </Select>
                 </FormControl>
               )}
+
+              {(isOwner || isAdmin || isSpecialist) && (
+                <FormControl sx={{ width: { xs: '100%', sm: 300 } }} size="small">
+                  <InputLabel id="client-filter">{t('appointments.clientFilter')}</InputLabel>
+                  <Select
+                    labelId="client-filter"
+                    label={t('appointments.clientFilter')}
+                    value={selectedClientId}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      setSelectedClientId(raw === 'all' ? 'all' : Number(raw));
+                    }}
+                  >
+                    <MenuItem value="all">{t('appointments.allClients')}</MenuItem>
+                    {clients.map((client) => (
+                      <MenuItem key={client.id} value={client.id}>
+                        {[client.firstName, client.lastName].filter(Boolean).join(' ').trim() || client.email}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+
+              {isClient && (
+                <FormControl sx={{ width: { xs: '100%', sm: 320 } }} size="small">
+                  <InputLabel id="specialist-filter-client">{t('appointments.specialistFilter')}</InputLabel>
+                  <Select
+                    labelId="specialist-filter-client"
+                    label={t('appointments.specialistFilter')}
+                    value={selectedSpecialistId}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      setSelectedSpecialistId(raw === 'all' ? 'all' : Number(raw));
+                    }}
+                  >
+                    <MenuItem value="all">{t('appointments.allSpecialists')}</MenuItem>
+                    {specialists.map((specialist) => (
+                      <MenuItem key={specialist.id} value={specialist.id}>{specialist.name}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+
+              <TextField
+                type="text"
+                label={t('appointments.serviceFilter')}
+                size="small"
+                value={serviceQuery}
+                onChange={(event) => setServiceQuery(event.target.value)}
+                sx={{ width: { xs: '100%', sm: 260 } }}
+              />
+
+              <FormControl sx={{ width: { xs: '100%', sm: 220 } }} size="small">
+                <InputLabel id="status-filter">{t('appointments.statusFilter')}</InputLabel>
+                <Select
+                  labelId="status-filter"
+                  label={t('appointments.statusFilter')}
+                  value={selectedStatus}
+                  onChange={(event) => {
+                    const raw = event.target.value as AppointmentItem['status'] | 'all';
+                    setSelectedStatus(raw);
+                  }}
+                >
+                  <MenuItem value="all">{t('appointments.allStatuses')}</MenuItem>
+                  <MenuItem value="new">{t('appointments.statusNew')}</MenuItem>
+                  <MenuItem value="confirmed">{t('appointments.statusConfirmed')}</MenuItem>
+                  <MenuItem value="cancelled">{t('appointments.statusCancelled')}</MenuItem>
+                </Select>
+              </FormControl>
+
+              <TextField
+                type="date"
+                label={t('appointments.fromDateFilter')}
+                size="small"
+                value={fromDateFilter}
+                onChange={(event) => setFromDateFilter(event.target.value)}
+                slotProps={{ inputLabel: { shrink: true } }}
+                sx={{ width: { xs: '100%', sm: 180 } }}
+              />
+              <TextField
+                type="date"
+                label={t('appointments.toDateFilter')}
+                size="small"
+                value={toDateFilter}
+                onChange={(event) => setToDateFilter(event.target.value)}
+                slotProps={{ inputLabel: { shrink: true } }}
+                sx={{ width: { xs: '100%', sm: 180 } }}
+              />
             </Stack>
           </CardContent>
         </Card>

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -266,8 +266,24 @@ export const dictionaries = {
     appointments: {
       pageTitle: 'Appointments',
       pageSubtitle: 'Calendar view with schedule by day and time.',
+      pageSubtitleOwner: 'All appointments',
+      pageSubtitleAdmin: 'Appointments in your account',
+      pageSubtitleSpecialist: 'Appointments with you',
+      pageSubtitleClient: 'My appointments',
+      accountFilter: 'Account',
+      currentAccount: 'Current account',
       specialistFilter: 'Specialist',
       allSpecialists: 'All specialists',
+      clientFilter: 'Client',
+      allClients: 'All clients',
+      serviceFilter: 'Service',
+      statusFilter: 'Status',
+      allStatuses: 'All statuses',
+      statusNew: 'New',
+      statusConfirmed: 'Confirmed',
+      statusCancelled: 'Cancelled',
+      fromDateFilter: 'From',
+      toDateFilter: 'To',
       create: 'Create',
       createTitle: 'Create appointment',
       editTitle: 'Edit appointment',
@@ -579,8 +595,24 @@ export const dictionaries = {
     appointments: {
       pageTitle: 'Записи',
       pageSubtitle: 'Календарный вид с расписанием по дням и времени.',
+      pageSubtitleOwner: 'Все записи',
+      pageSubtitleAdmin: 'Записи в вашем аккаунте',
+      pageSubtitleSpecialist: 'Записи с вами',
+      pageSubtitleClient: 'Мои записи',
+      accountFilter: 'Аккаунт',
+      currentAccount: 'Текущий аккаунт',
       specialistFilter: 'Специалист',
       allSpecialists: 'Все специалисты',
+      clientFilter: 'Клиент',
+      allClients: 'Все клиенты',
+      serviceFilter: 'Услуга',
+      statusFilter: 'Статус',
+      allStatuses: 'Все статусы',
+      statusNew: 'Новая',
+      statusConfirmed: 'Подтверждена',
+      statusCancelled: 'Отменена',
+      fromDateFilter: 'С',
+      toDateFilter: 'По',
       create: 'Создать',
       createTitle: 'Создать запись',
       editTitle: 'Редактировать запись',
@@ -640,6 +672,7 @@ export type TranslationKey =
   | 'common.register'
   | 'common.language'
   | 'common.appointments'
+  | 'common.my_appointments'
   | 'common.specialists'
   | 'common.users'
   | 'common.notificationLogs'
@@ -804,8 +837,24 @@ export type TranslationKey =
   | 'users.success.inviteResent'
   | 'appointments.pageTitle'
   | 'appointments.pageSubtitle'
+  | 'appointments.pageSubtitleOwner'
+  | 'appointments.pageSubtitleAdmin'
+  | 'appointments.pageSubtitleSpecialist'
+  | 'appointments.pageSubtitleClient'
+  | 'appointments.accountFilter'
+  | 'appointments.currentAccount'
   | 'appointments.specialistFilter'
   | 'appointments.allSpecialists'
+  | 'appointments.clientFilter'
+  | 'appointments.allClients'
+  | 'appointments.serviceFilter'
+  | 'appointments.statusFilter'
+  | 'appointments.allStatuses'
+  | 'appointments.statusNew'
+  | 'appointments.statusConfirmed'
+  | 'appointments.statusCancelled'
+  | 'appointments.fromDateFilter'
+  | 'appointments.toDateFilter'
   | 'appointments.create'
   | 'appointments.createTitle'
   | 'appointments.editTitle'


### PR DESCRIPTION
### Motivation

- Make the Appointments page and main menu more role-aware by using distinct subtitles/labels per user role and expose richer top-level filtering for different roles.
- Allow owners/admins/specialists/clients to narrow appointment lists by client, status, service text, and date range directly from the calendar UI.

### Description

- Main menu label for `/appointments` is now role-aware in `MainLayout.tsx` and uses new translation keys for owner/admin/specialist/client subtitles.
- `AppointmentsContainer.tsx` adds UI controls and state for account (owner-only placeholder), specialist, client, service text search, status, and from/to date filters, and shows/hides controls based on `WebUserRole`.
- Introduced `filteredAppointments` and applied it to `appointmentsByCell` and `appointmentsByDay` so the calendar reflects the active filters.
- Added role-aware `pageSubtitle` selection and extended i18n dictionaries in `shared/i18n/dictionaries.ts` with new keys and translations; updated `web/README.md` to document the role-based filters and subtitles.

### Testing

- Ran the package test suite with `npm run -w @scheduletm/web test` and the fast contract checks completed successfully.
- Verified contract-level checks with `npm run -w @scheduletm/web test:e2e:contracts` and they passed.
- No UI e2e changes were executed in this rollout; `npm run -w @scheduletm/web test:e2e:ui` was not run in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0cfc04bd4833394c32d7508b063e2)