### PR TITLE
Enable ESLint for web: add config, scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 # API
 npm run -w @scheduletm/server dev
 
-# Web
+# Web (включает ESLint + typecheck перед стартом)
 npm run -w @scheduletm/web dev
 
 # Bot
@@ -50,6 +50,12 @@ npm run -w bot dev
 - OAuth-секреты (`GOOGLE_OAUTH_CLIENT_SECRET`) и другие секреты — только в server env, не в web.
 
 Для локальной разработки оставляйте `localhost` значения в `.env.local`/`.env` и не смешивайте их с доменными dev-значениями.
+
+### Линтинг web
+
+```bash
+npm run -w @scheduletm/web lint
+```
 
 ### Одна команда для миграций + тестов по каждому модулю
 

--- a/web/README.md
+++ b/web/README.md
@@ -22,14 +22,27 @@ React SPA для owner/admin/specialist/client.
 ## Команды
 
 ```bash
-npm run -w @scheduletm/web dev
-npm run -w @scheduletm/web build
+npm run -w @scheduletm/web lint                 # ESLint (best practices + i18n markup rules)
+npm run -w @scheduletm/web dev                  # lint + typecheck + vite
+npm run -w @scheduletm/web build                # lint + tsc + vite build
 npm run -w @scheduletm/web test                 # быстрые e2e contract checks
 npm run -w @scheduletm/web test:e2e:contracts   # contract-level checks (node:test)
 npm run -w @scheduletm/web test:e2e:ui          # реальный UI e2e (Playwright, клики)
 npm run -w @scheduletm/web test:e2e             # contracts + UI
 npm run -w @scheduletm/web verify
 ```
+
+
+## Линтинг
+
+В `web` подключен ESLint и он запускается автоматически в `dev` и `build`.
+
+Правила включают:
+- базовые recommended + TypeScript checks;
+- best practices (`curly`, `eqeqeq`, `no-var`, `prefer-const`);
+- `i18next/no-literal-string` в режиме `jsx-only` с исключениями для `className`, `data-testid`, `aria-*` атрибутов;
+- для test/spec файлов правило `i18next/no-literal-string` отключено;
+- строки логирования через `console.*` исключены из этого правила.
 
 ## Переменные окружения
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,0 +1,61 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import i18next from 'eslint-plugin-i18next';
+
+export default tseslint.config(
+  {
+    ignores: ['dist']
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser
+      }
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+      i18next
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+
+      // Best practices
+      'curly': ['error', 'all'],
+      'eqeqeq': ['error', 'always'],
+      'no-var': 'error',
+      'prefer-const': 'error',
+
+      'i18next/no-literal-string': [
+        'error',
+        {
+          mode: 'jsx-only',
+          'jsx-attributes': {
+            exclude: ['className', 'data-testid', 'aria-.*']
+          },
+          callees: {
+            exclude: ['^console\\.(log|warn|error|info|debug)$']
+          }
+        }
+      ]
+    }
+
+  },
+  {
+    files: ['**/*.{test,spec}.{ts,tsx,mts,cts,js,jsx,mjs,cjs}', '**/tests/**/*.{ts,tsx,js,jsx,mjs,cjs}'],
+    rules: {
+      'i18next/no-literal-string': 'off'
+    }
+  }
+);

--- a/web/package.json
+++ b/web/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "npm run typecheck && vite",
-    "build": "tsc -p tsconfig.json && vite build",
+    "dev": "npm run lint && npm run typecheck && vite",
+    "build": "npm run lint && tsc -p tsconfig.json && vite build",
     "start": "serve -s dist -l tcp://0.0.0.0:$PORT",
     "typecheck": "tsc --noEmit",
     "test": "npm run test:e2e:contracts",
@@ -13,7 +13,8 @@
     "test:e2e:ui": "node --env-file=.dev.env ../node_modules/@playwright/test/cli.js test --config=playwright.config.mjs",
     "test:e2e": "npm run test:e2e:contracts && npm run test:e2e:ui",
     "migrate:latest": "node -e \"console.log('web: migrations are not required')\"",
-    "verify": "npm run migrate:latest && npm run test"
+    "verify": "npm run migrate:latest && npm run test",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -39,6 +40,13 @@
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^5.1.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "eslint": "^9.39.1",
+    "@eslint/js": "^9.39.1",
+    "typescript-eslint": "^8.46.2",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "eslint-plugin-i18next": "^6.1.3",
+    "globals": "^16.4.0"
   }
 }


### PR DESCRIPTION
### Motivation

- Enforce consistent code quality and i18n-safe strings in the `@scheduletm/web` package by adding ESLint and integrating it into existing workflows. 
- Make linting discoverable and required for local dev and CI steps to prevent regressions and literal UI strings.

### Description

- Add `web/eslint.config.js` with TypeScript-aware configuration, `i18next` plugin and rules including `i18next/no-literal-string` (JSX-only with sensible exceptions) and basic best-practices (`curly`, `eqeqeq`, `no-var`, `prefer-const`).
- Update `web/package.json` to run `lint` in `dev` and `build`, add a `lint` script (`eslint .`) and include ESLint and related plugins as `devDependencies`.
- Update top-level `README.md` and `web/README.md` to document the new `lint` command and to describe the web linting rules and behavior.
- Ensure `dev`/`build` now perform lint + typecheck before starting or building the app.

### Testing

- Ran `npm run -w @scheduletm/web lint` against the updated web sources and the lint check passed.
- Started the dev flow with `npm run -w @scheduletm/web dev` to verify lint + typecheck integration and the dev server started successfully.
- Executed `npm run -w @scheduletm/web build` to validate the pre-build lint and typecheck steps and the build completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d33cfcac8333b06336a50899eab2)