### PR TITLE
Hide inaccessible settings tabs for non-owner roles

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -102,7 +102,7 @@ VITE_API_URL=http://localhost:3003
 - делают реальные клики/ввод в интерфейсе;
 - проверяют поведение web-приложения при интеграции с backend/dev БД;
 - покрывают owner-flow для `Users` (create/edit/deactivate), переход owner в `/error-logs`, logout из profile menu;
-- проверяют role-aware доступность пунктов меню и доступность табов `System settings`/`Account settings` на странице настроек;
+- проверяют role-aware доступность пунктов меню и видимость табов `System settings`/`Account settings` на странице настроек;
 - проверяют доступ к страницам по прямому URL и access denied состояния (owner/admin/client) для `/specialists`, `/notification-logs`, `/error-logs`.
 
 Структура UI e2e разнесена по файлам: `users.ui.e2e.spec.mjs`, `navigation.ui.e2e.spec.mjs`, `settings.ui.e2e.spec.mjs`, `session.ui.e2e.spec.mjs`, `access-control.ui.e2e.spec.mjs`; общие auth-хелперы вынесены в `ui/helpers/auth.mjs`.

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -112,6 +112,14 @@ export function SettingsCard({
   onConnectGoogle,
   onDisconnectGoogle
 }: SettingsCardProps) {
+  const tabs = [
+    ...(canManageSystemSettings ? [{ key: 'system', label: copy.systemTab }] : []),
+    ...(canManageAccountSettings ? [{ key: 'account', label: copy.accountTab }] : []),
+    ...(canManageSpecialistBookingPolicy ? [{ key: 'specialistPolicy', label: copy.specialistPolicyTab }] : []),
+    ...(canManageAccountSettings ? [{ key: 'notifications', label: copy.notificationsTab }] : []),
+    { key: 'user', label: copy.userTab }
+  ] as const;
+  const initialTab = tabs[0]?.key ?? 'user';
   const timingOptions = [
     'disabled',
     ...[
@@ -122,7 +130,13 @@ export function SettingsCard({
   ];
   const selectableChannels: NotificationChannel[] = ['email', 'telegram', 'viber', 'sms', 'whatsapp'];
   const meetingDurationOptions = Array.from({ length: 7 }, (_, i) => 30 + i * 10);
-  const [tab, setTab] = useState(canManageSystemSettings ? 0 : canManageAccountSettings ? 1 : canManageSpecialistBookingPolicy ? 2 : 4);
+  const [tab, setTab] = useState<string>(initialTab);
+
+  useEffect(() => {
+    if (!tabs.some((item) => item.key === tab)) {
+      setTab(initialTab);
+    }
+  }, [initialTab, tab, tabs]);
 
   const { control: systemControl, handleSubmit: handleSystemSubmit, reset: resetSystem } = useForm<SystemSettings>({
     defaultValues: systemSettings
@@ -198,15 +212,17 @@ export function SettingsCard({
 
   return (
     <Box>
-      <AppTabs value={tab} onChange={(_, next) => setTab(next)} sx={{ mb: 2 }}>
-        <AppTab label={copy.systemTab} disabled={!canManageSystemSettings} />
-        <AppTab label={copy.accountTab} disabled={!canManageAccountSettings} />
-        <AppTab label={copy.specialistPolicyTab} disabled={!canManageSpecialistBookingPolicy} />
-        <AppTab label={copy.notificationsTab} disabled={!canManageAccountSettings} />
-        <AppTab label={copy.userTab} />
+      <AppTabs
+        value={tabs.findIndex((item) => item.key === tab)}
+        onChange={(_, next) => setTab(tabs[next]?.key ?? initialTab)}
+        sx={{ mb: 2 }}
+      >
+        {tabs.map((item) => (
+          <AppTab key={item.key} label={item.label} />
+        ))}
       </AppTabs>
 
-      {tab === 0 && canManageSystemSettings && (
+      {tab === 'system' && (
         <AppForm component="form" onSubmit={handleSystemSubmit(onSaveSystem)}>
           <Typography variant="h5">{copy.systemTitle}</Typography>
 
@@ -293,7 +309,7 @@ export function SettingsCard({
         </AppForm>
       )}
 
-      {tab === 1 && canManageAccountSettings && (
+      {tab === 'account' && (
         <AppForm component="form" onSubmit={handleAccountSubmit(onSaveAccount)}>
           <Typography variant="h5">{copy.accountTitle}</Typography>
 
@@ -353,7 +369,7 @@ export function SettingsCard({
         </AppForm>
       )}
 
-      {tab === 2 && canManageSpecialistBookingPolicy && (
+      {tab === 'specialistPolicy' && (
         <AppForm component="form" onSubmit={handleSpecialistPolicySubmit(onSaveSpecialistBookingPolicy)}>
           <Typography variant="h5">{copy.specialistPolicyTitle}</Typography>
 
@@ -413,7 +429,7 @@ export function SettingsCard({
         </AppForm>
       )}
 
-      {tab === 3 && canManageAccountSettings && (
+      {tab === 'notifications' && (
         <AppForm
           component="form"
           onSubmit={handleNotificationDefaultsSubmit((values) => {
@@ -536,7 +552,7 @@ export function SettingsCard({
         </AppForm>
       )}
 
-      {tab === 4 && (
+      {tab === 'user' && (
         <AppForm component="form" onSubmit={handleUserSubmit(onSaveUser)}>
           <Typography variant="h5">{copy.userTitle}</Typography>
 

--- a/web/tests/e2e/ui/settings.ui.e2e.spec.mjs
+++ b/web/tests/e2e/ui/settings.ui.e2e.spec.mjs
@@ -2,12 +2,12 @@ import { test, expect } from '@playwright/test';
 import { creds, loggedInRole, login } from './helpers/auth.mjs';
 
 test.describe('web ui e2e: settings', () => {
-  test('settings tabs are enabled according to role', async ({ browser }) => {
+  test('settings tabs are visible according to role', async ({ browser }) => {
     const scenarios = [
-      { label: 'owner', expectedRole: 'owner', creds: creds('E2E_OWNER'), systemTabEnabled: true, accountTabEnabled: true },
-      { label: 'admin', expectedRole: 'admin', creds: creds('E2E_ADMIN'), systemTabEnabled: false, accountTabEnabled: true },
-      { label: 'specialist', expectedRole: 'specialist', creds: creds('E2E_SPECIALIST'), systemTabEnabled: false, accountTabEnabled: false },
-      { label: 'client', expectedRole: 'client', creds: creds('E2E_CLIENT'), systemTabEnabled: false, accountTabEnabled: false },
+      { label: 'owner', expectedRole: 'owner', creds: creds('E2E_OWNER'), systemTabVisible: true, accountTabVisible: true },
+      { label: 'admin', expectedRole: 'admin', creds: creds('E2E_ADMIN'), systemTabVisible: false, accountTabVisible: true },
+      { label: 'specialist', expectedRole: 'specialist', creds: creds('E2E_SPECIALIST'), systemTabVisible: false, accountTabVisible: false },
+      { label: 'client', expectedRole: 'client', creds: creds('E2E_CLIENT'), systemTabVisible: false, accountTabVisible: false },
     ];
 
     const hasAnyScenario = scenarios.some((scenario) => scenario.creds.email && scenario.creds.password);
@@ -38,16 +38,16 @@ test.describe('web ui e2e: settings', () => {
       const systemTab = page.getByRole('tab', { name: 'System settings' });
       const accountTab = page.getByRole('tab', { name: 'Account settings' });
 
-      if (scenario.systemTabEnabled) {
-        await expect(systemTab, `${scenario.label}: system tab must be enabled`).toBeEnabled();
+      if (scenario.systemTabVisible) {
+        await expect(systemTab, `${scenario.label}: system tab must be visible`).toBeVisible();
       } else {
-        await expect(systemTab, `${scenario.label}: system tab must be disabled`).toBeDisabled();
+        await expect(systemTab, `${scenario.label}: system tab must be hidden`).toHaveCount(0);
       }
 
-      if (scenario.accountTabEnabled) {
-        await expect(accountTab, `${scenario.label}: account tab must be enabled`).toBeEnabled();
+      if (scenario.accountTabVisible) {
+        await expect(accountTab, `${scenario.label}: account tab must be visible`).toBeVisible();
       } else {
-        await expect(accountTab, `${scenario.label}: account tab must be disabled`).toBeDisabled();
+        await expect(accountTab, `${scenario.label}: account tab must be hidden`).toHaveCount(0);
       }
 
       await context.close();

--- a/web/tests/e2e/web.integration.e2e.test.mjs
+++ b/web/tests/e2e/web.integration.e2e.test.mjs
@@ -48,9 +48,9 @@ describe('web integration contracts: appointments lifecycle + users CRUD + RBAC'
     assert.match(roles, /Specialist = 'specialist'/);
     assert.match(roles, /Client = 'client'/);
 
-    assert.match(mainLayout, /user\?\.role === 'owner' \|\| user\?\.role === 'admin'/);
-    assert.match(mainLayout, /user\?\.role === 'owner' \|\| user\?\.role === 'admin' \|\| user\?\.role === 'specialist'/);
-    assert.match(mainLayout, /user\?\.role === 'owner'[\s\S]*?\{ to: '\/error-logs'/);
+    assert.match(mainLayout, /user\?\.role === WebUserRole\.Owner \|\| user\?\.role === WebUserRole\.Admin/);
+    assert.match(mainLayout, /user\?\.role === WebUserRole\.Owner \|\| user\?\.role === WebUserRole\.Admin \|\| user\?\.role === WebUserRole\.Specialist/);
+    assert.match(mainLayout, /user\?\.role === WebUserRole\.Owner[\s\S]*?\{ to: '\/error-logs'/);
 
     assert.match(usersContainer, /const canManageUsers = user\?\.role === 'owner' \|\| user\?\.role === 'admin' \|\| user\?\.role === 'specialist'/);
     assert.match(specialistsContainer, /const canManageSpecialists = user\?\.role === 'owner' \|\| user\?\.role === 'admin'/);


### PR DESCRIPTION
### Motivation
- Admin users saw the "System settings" tab (disabled) which clutters the UI and exposes inaccessible surface; the intent is to remove UI elements entirely when the role has no access. 

### Description
- Render settings tabs dynamically in `SettingsCard` using a `tabs` array and a key-based `tab` state so only role-permitted tabs are shown and indexes do not shift. 
- Switch tab content checks from numeric indices to string keys (`'system'|'account'|'specialistPolicy'|'notifications'|'user'`) and keep selection stable when available tabs change. 
- Update UI e2e test `web/tests/e2e/ui/settings.ui.e2e.spec.mjs` to assert tab visibility/hiddenness instead of enabled/disabled. 
- Adjust integration contract test regexes in `web/tests/e2e/web.integration.e2e.test.mjs` and update `web/README.md` wording to reflect visibility checks. 

### Testing
- Ran contract tests with `npm -w @scheduletm/web run test:e2e:contracts`, which passed. 
- Ran TypeScript checks with `npm -w @scheduletm/web run typecheck`, which passed. 
- `npm -w @scheduletm/web run lint` failed in this environment due to missing `@eslint/js` package resolution (environment issue), not changes introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d6d29fb08333950b18ec86b73507)