### PR TITLE
Improve registration UX and 4-digit OTP autoflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ scheduletm/
 
 ### Web + Server
 
-- Auth: register/login/refresh/logout + OTP email verification by unique code (with resend) + invite onboarding page `/verify-email` for creating account from invitation.
+- Auth: register/login/refresh/logout + 4-digit OTP email verification (with resend and auto-confirm UX) + invite onboarding page `/verify-email` for creating account from invitation.
 - Роли: `owner` / `admin` / `specialist` / `client` (RBAC policy централизована в server).
 - Settings: system + account + user settings, plus user integrations. `Default meeting duration` in system/account settings is selected from dropdown options 30–90 minutes (step 10).
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.

--- a/server/README.md
+++ b/server/README.md
@@ -6,7 +6,9 @@ Node.js/Express API для web-клиента и интеграций.
 
 - Auth: register/login/refresh/logout + verify-email.
   При self-registration пользователю создаётся отдельный `account_id`, присваивается роль `admin`,
-  и отправляется письмо с OTP-кодом подтверждения email.
+  и отправляется письмо с 4-значным OTP-кодом подтверждения email.
+  Для `POST /api/auth/register` обязательны `firstName`, `lastName`, `email`, `phone`, `password`,
+  опционален `telegramUsername`.
   Для приглашённых пользователей поддерживается flow принятия приглашения `POST /api/auth/accept-invite`
   (одноразовый invite-токен в ссылке, срок жизни 24 часа, пароль задаёт сам пользователь).
   Поддерживаются `POST /api/auth/verify-email` и `POST /api/auth/resend-verification-code`.

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -31,6 +31,10 @@ export const registrationSchema = z.object({
     .max(254, v.emailTooLong),
   password: passwordSchema,
   timezone: timezoneSchema.optional(),
+  firstName: z.string().trim().min(1, v.managedUserFirstNameRequired).max(120, v.managedUserFirstNameTooLong),
+  lastName: z.string().trim().min(1, v.managedUserLastNameRequired).max(120, v.managedUserLastNameTooLong),
+  phone: z.string().trim().min(1, v.registrationPhoneRequired).max(50, v.managedUserPhoneTooLong),
+  telegramUsername: z.string().trim().max(255, v.managedUserTelegramTooLong).optional().or(z.literal('')),
 });
 
 export const loginSchema = z.object({
@@ -50,8 +54,7 @@ export const verifyEmailSchema = z.object({
   code: z
     .string()
     .trim()
-    .min(8, v.emailVerificationCodeInvalid)
-    .max(128, v.emailVerificationCodeInvalid),
+    .regex(/^\d{4}$/, v.emailVerificationCodeInvalid),
 });
 
 

--- a/server/src/i18n/dictionaries.ts
+++ b/server/src/i18n/dictionaries.ts
@@ -195,6 +195,7 @@ export const schemaValidationDictionary = {
   managedUserFirstNameTooLong: 'Имя слишком длинное',
   managedUserLastNameRequired: 'Укажите фамилию',
   managedUserLastNameTooLong: 'Фамилия слишком длинная',
+  registrationPhoneRequired: 'Укажите номер телефона',
   managedUserPhoneTooLong: 'Телефон слишком длинный',
   managedUserTelegramTooLong: 'Telegram аккаунт слишком длинный',
   specialistUserIdRequired: 'Выберите пользователя специалиста',

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -92,7 +92,15 @@ authRoutes.post('/register', async (req, res) => {
   }
 
   try {
-    const user = await registerUser(parsed.data.email, parsed.data.password, parsed.data.timezone);
+    const user = await registerUser(
+      parsed.data.email,
+      parsed.data.password,
+      parsed.data.timezone,
+      parsed.data.firstName,
+      parsed.data.lastName,
+      parsed.data.phone,
+      parsed.data.telegramUsername,
+    );
     if (!user) {
       return res.status(409).json({
         message: t(req, 'userAlreadyRegistered'),

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -24,7 +24,7 @@ import {
 import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 import { canManageSpecialists } from '../policies/rolePermissions.js';
-import { createToken, hashPassword, sanitizeEmail, verifyPassword } from '../utils/crypto.js';
+import { createOtpCode, createToken, hashPassword, sanitizeEmail, verifyPassword } from '../utils/crypto.js';
 import { csrfCookieName } from '../utils/cookies.js';
 import { sendEmailVerificationEmail, sendRegistrationSuccessEmail } from './emailDeliveryService.js';
 
@@ -121,6 +121,10 @@ export const registerUser = async (
   emailRaw: string,
   password: string,
   timezone?: string,
+  firstName?: string,
+  lastName?: string,
+  phone?: string,
+  telegramUsername?: string,
 ): Promise<User | null> => {
   const email = sanitizeEmail(emailRaw);
   const existing = await findWebUserByEmailAnyAccount(email);
@@ -131,10 +135,18 @@ export const registerUser = async (
 
     const salt = crypto.randomBytes(16).toString('hex');
     const passwordHash = hashPassword(password, salt);
-    const verificationCode = createToken();
+    const verificationCode = createOtpCode();
     const verificationCodeHash = hashPassword(verificationCode, salt);
 
     await updateWebUserCredentials(existing.account_id, existing.id, passwordHash, salt);
+    await updateWebUserProfile({
+      accountId: existing.account_id,
+      id: existing.id,
+      firstName: firstName?.trim() ?? '',
+      lastName: lastName?.trim() ?? '',
+      phone: phone?.trim() ?? '',
+      telegramUsername: telegramUsername?.trim() ?? '',
+    });
     await updateWebUserAuthState({
       accountId: existing.account_id,
       id: existing.id,
@@ -168,13 +180,17 @@ export const registerUser = async (
 
   const salt = crypto.randomBytes(16).toString('hex');
   const passwordHash = hashPassword(password, salt);
-  const verificationCode = createToken();
+  const verificationCode = createOtpCode();
   const verificationCodeHash = hashPassword(verificationCode, salt);
 
   const webUser = await createWebUser({
     accountId,
     email,
     role: WebUserRole.Admin,
+    firstName: firstName?.trim() ?? '',
+    lastName: lastName?.trim() ?? '',
+    phone: phone?.trim() ?? '',
+    telegramUsername: telegramUsername?.trim() ?? '',
     passwordHash,
     passwordSalt: salt,
     timezone,
@@ -211,7 +227,7 @@ export const resendUserEmailVerificationCode = async (emailRaw: string): Promise
     return true;
   }
 
-  const verificationCode = createToken();
+  const verificationCode = createOtpCode();
   const verificationCodeHash = hashPassword(verificationCode, user.password_salt);
 
   await updateWebUserAuthState({

--- a/server/src/utils/crypto.ts
+++ b/server/src/utils/crypto.ts
@@ -6,6 +6,7 @@ export const hashPassword = (password: string, salt: string) =>
   crypto.pbkdf2Sync(password, salt, 310000, 32, 'sha256').toString('hex');
 
 export const createToken = () => crypto.randomBytes(32).toString('hex');
+export const createOtpCode = () => crypto.randomInt(0, 10_000).toString().padStart(4, '0');
 
 export const verifyPassword = (password: string, salt: string, hash: string) =>
   crypto.timingSafeEqual(Buffer.from(hashPassword(password, salt), 'hex'), Buffer.from(hash, 'hex'));

--- a/web/README.md
+++ b/web/README.md
@@ -5,6 +5,8 @@ React SPA для owner/admin/specialist/client.
 ## Что умеет
 
 - Auth: `/login`, `/register`, `/invite/accept`, `/verify-email`.
+  - `register`: required fields `firstName`, `lastName`, `email`, `phone`, optional `telegramUsername`.
+  - `verify-email`: 4-digit OTP with auto-confirm when all digits are entered.
 - Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`, `/notification-logs`.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.

--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -4,11 +4,16 @@ import { Controller, useForm } from 'react-hook-form';
 import logoText from '../static/images/logo_text.svg';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
+import { AppRhfPhoneField, isValidPhoneValue } from '../shared/ui/AppRhfPhoneField';
 import { AppRhfPasswordField } from '../shared/ui/AppRhfPasswordField';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type AuthFormValues = {
+  firstName: string;
+  lastName: string;
   email: string;
+  phone: string;
+  telegramUsername: string;
   password: string;
 };
 
@@ -16,10 +21,18 @@ type AuthCardProps = {
   title: string;
   submitText: string;
   switchText: string;
+  isLogin: boolean;
+  firstNameLabel: string;
+  lastNameLabel: string;
   emailLabel: string;
+  phoneLabel: string;
+  telegramLabel: string;
   passwordLabel: string;
   isSubmitting?: boolean;
   fieldErrors?: Partial<Record<keyof AuthFormValues, string>>;
+  requiredMessage: string;
+  phoneInvalidMessage: string;
+  passwordMinLengthMessage: string;
   onSubmit: (values: AuthFormValues) => Promise<void> | void;
   onSwitch: () => void;
 };
@@ -28,16 +41,28 @@ export function AuthCard({
   title,
   submitText,
   switchText,
+  isLogin,
+  firstNameLabel,
+  lastNameLabel,
   emailLabel,
+  phoneLabel,
+  telegramLabel,
   passwordLabel,
   isSubmitting = false,
   fieldErrors,
+  requiredMessage,
+  phoneInvalidMessage,
+  passwordMinLengthMessage,
   onSubmit,
   onSwitch
 }: AuthCardProps) {
   const { control, handleSubmit, setError, clearErrors } = useForm<AuthFormValues>({
     defaultValues: {
+      firstName: '',
+      lastName: '',
       email: '',
+      phone: '',
+      telegramUsername: '',
       password: ''
     }
   });
@@ -49,6 +74,18 @@ export function AuthCard({
 
     if (fieldErrors.email) {
       setError('email', { type: 'server', message: fieldErrors.email });
+    }
+    if (fieldErrors.firstName) {
+      setError('firstName', { type: 'server', message: fieldErrors.firstName });
+    }
+    if (fieldErrors.lastName) {
+      setError('lastName', { type: 'server', message: fieldErrors.lastName });
+    }
+    if (fieldErrors.phone) {
+      setError('phone', { type: 'server', message: fieldErrors.phone });
+    }
+    if (fieldErrors.telegramUsername) {
+      setError('telegramUsername', { type: 'server', message: fieldErrors.telegramUsername });
     }
 
     if (fieldErrors.password) {
@@ -84,12 +121,44 @@ export function AuthCard({
           </Typography>
         </Stack>
 
+        {!isLogin && (
+          <>
+            <Controller
+              name="firstName"
+              control={control}
+              rules={{ required: requiredMessage }}
+              render={({ field, fieldState }: any) => (
+                <AppRhfTextField
+                  field={field}
+                  label={firstNameLabel}
+                  onValueChange={() => clearErrors('firstName')}
+                  error={Boolean(fieldState.error)}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="lastName"
+              control={control}
+              rules={{ required: requiredMessage }}
+              render={({ field, fieldState }: any) => (
+                <AppRhfTextField
+                  field={field}
+                  label={lastNameLabel}
+                  onValueChange={() => clearErrors('lastName')}
+                  error={Boolean(fieldState.error)}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+          </>
+        )}
+
         <Controller
           name="email"
           control={control}
-          rules={{
-            required: 'Email is required'
-          }}
+          rules={{ required: requiredMessage }}
           render={({ field, fieldState }: any) => (
             <AppRhfTextField
               field={field}
@@ -102,14 +171,50 @@ export function AuthCard({
           )}
         />
 
+        {!isLogin && (
+          <>
+            <Controller
+              name="phone"
+              control={control}
+              rules={{
+                required: requiredMessage,
+                validate: (value) => isValidPhoneValue(value) || phoneInvalidMessage
+              }}
+              render={({ field, fieldState }: any) => (
+                <AppRhfPhoneField
+                  field={field}
+                  label={phoneLabel}
+                  onChange={() => clearErrors('phone')}
+                  error={Boolean(fieldState.error)}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="telegramUsername"
+              control={control}
+              render={({ field, fieldState }: any) => (
+                <AppRhfTextField
+                  field={field}
+                  label={telegramLabel}
+                  onValueChange={() => clearErrors('telegramUsername')}
+                  error={Boolean(fieldState.error)}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+          </>
+        )}
+
         <Controller
           name="password"
           control={control}
           rules={{
-            required: 'Password is required',
+            required: requiredMessage,
             minLength: {
               value: 10,
-              message: 'Password must be at least 10 characters'
+              message: passwordMinLengthMessage
             }
           }}
           render={({ field, fieldState }: any) => (

--- a/web/src/containers/AuthContainer.tsx
+++ b/web/src/containers/AuthContainer.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Divider, Link, Stack, Typography } from '@mui/material';
+import { Alert, Box, Divider, Link, Stack, TextField, Typography } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -11,7 +11,6 @@ import { useI18n } from '../shared/i18n/I18nContext';
 import type { AuthResponse, RegisterResponse, VerifyEmailResponse } from '../shared/types/api';
 import { AppButton } from '../shared/ui/AppButton';
 import { AppForm } from '../shared/ui/AppForm';
-import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 
 type AuthMode = 'login' | 'register';
 
@@ -21,6 +20,15 @@ type AuthContainerProps = {
 
 type VerifyEmailFormValues = {
   code: string;
+};
+
+type AuthCredentialsFormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  telegramUsername: string;
+  password: string;
 };
 
 type RegisterStep = 'credentials' | 'otp';
@@ -49,11 +57,13 @@ export function AuthContainer({ mode }: AuthContainerProps) {
     handleSubmit: handleVerifyEmailSubmit,
     setError: setVerifyEmailFormError,
     clearErrors: clearVerifyEmailErrors,
+    setValue: setVerifyEmailValue,
   } = useForm<VerifyEmailFormValues>({
     defaultValues: {
       code: '',
     },
   });
+  const [otpDigits, setOtpDigits] = useState(['', '', '', '']);
 
   useEffect(() => {
     if (isLogin) {
@@ -81,7 +91,7 @@ export function AuthContainer({ mode }: AuthContainerProps) {
     });
   }, [fieldErrors.code, setVerifyEmailFormError]);
 
-  const submitCredentials = async ({ email, password }: { email: string; password: string }) => {
+  const submitCredentials = async ({ email, password, firstName, lastName, phone, telegramUsername }: AuthCredentialsFormValues) => {
     setIsSubmitting(true);
 
     try {
@@ -98,7 +108,15 @@ export function AuthContainer({ mode }: AuthContainerProps) {
         return;
       }
 
-      const response = await apiClient.post<RegisterResponse>(endpoint, { email, password, timezone });
+      const response = await apiClient.post<RegisterResponse>(endpoint, {
+        email,
+        password,
+        timezone,
+        firstName,
+        lastName,
+        phone,
+        telegramUsername,
+      });
       setError('');
       setFieldErrors({});
       setPendingEmail(response.data.user.email);
@@ -152,6 +170,11 @@ export function AuthContainer({ mode }: AuthContainerProps) {
     }
   };
 
+  const submitOtpCode = (code: string) => {
+    setVerifyEmailValue('code', code, { shouldValidate: true });
+    return handleVerifyEmailSubmit(submitOtp)();
+  };
+
   const resendCode = async () => {
     if (!pendingEmail) {
       return;
@@ -184,6 +207,18 @@ export function AuthContainer({ mode }: AuthContainerProps) {
     clearVerifyEmailErrors();
     window.sessionStorage.removeItem(REGISTER_PENDING_EMAIL_KEY);
     setPendingEmail('');
+    setOtpDigits(['', '', '', '']);
+  };
+
+  const handleOtpDigitChange = (index: number, rawValue: string) => {
+    const nextDigit = rawValue.replace(/\D/g, '').slice(-1);
+    const nextDigits = otpDigits.map((digit, digitIndex) => (digitIndex === index ? nextDigit : digit));
+    setOtpDigits(nextDigits);
+    const nextCode = nextDigits.join('');
+    setVerifyEmailValue('code', nextCode, { shouldValidate: true });
+    if (nextCode.length === 4 && nextDigits.every(Boolean) && !isSubmitting) {
+      void submitOtpCode(nextCode);
+    }
   };
 
   const authCardTitle = useMemo(() => (isLogin ? t('auth.formLoginTitle') : t('auth.formRegisterTitle')), [isLogin, t]);
@@ -259,23 +294,42 @@ export function AuthContainer({ mode }: AuthContainerProps) {
                 control={verifyEmailControl}
                 rules={{
                   required: t('auth.verifyCodeRequired'),
-                  minLength: {
-                    value: 8,
+                  pattern: {
+                    value: /^\d{4}$/,
                     message: t('auth.verifyCodeInvalid')
                   }
                 }}
-                render={({ field, fieldState }: any) => (
-                  <AppRhfTextField
-                    field={field}
-                    label={t('auth.verifyCodeLabel')}
-                    type="text"
-                    onValueChange={() => {
-                      clearVerifyEmailErrors('code');
-                      setFieldErrors((prev) => ({ ...prev, code: '' }));
-                    }}
-                    error={Boolean(fieldState.error)}
-                    helperText={fieldState.error?.message}
-                  />
+                render={({ fieldState }: any) => (
+                  <Stack spacing={1}>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('auth.verifyCodeLabel')}
+                    </Typography>
+                    <Stack direction="row" spacing={1.5}>
+                      {otpDigits.map((digit, index) => (
+                        <TextField
+                          key={`otp-${index}`}
+                          value={digit}
+                          onChange={(event) => {
+                            clearVerifyEmailErrors('code');
+                            setFieldErrors((prev) => ({ ...prev, code: '' }));
+                            handleOtpDigitChange(index, event.target.value);
+                          }}
+                          inputProps={{
+                            inputMode: 'numeric',
+                            maxLength: 1,
+                            style: { textAlign: 'center', fontSize: 24, fontWeight: 700 }
+                          }}
+                          sx={{ width: 64 }}
+                          error={Boolean(fieldState.error)}
+                        />
+                      ))}
+                    </Stack>
+                    {fieldState.error?.message ? (
+                      <Typography variant="caption" color="error">
+                        {fieldState.error.message}
+                      </Typography>
+                    ) : null}
+                  </Stack>
                 )}
               />
 
@@ -286,7 +340,13 @@ export function AuthContainer({ mode }: AuthContainerProps) {
                 <AppButton type="button" variant="text" onClick={resendCode} isLoading={isResending} fullWidth>
                   {t('auth.verifyResend')}
                 </AppButton>
-                <AppButton type="submit" variant="contained" isLoading={isSubmitting} fullWidth>
+                <AppButton
+                  type="button"
+                  variant="contained"
+                  isLoading={isSubmitting}
+                  onClick={() => void submitOtpCode(otpDigits.join(''))}
+                  fullWidth
+                >
                   {t('auth.verifySubmit')}
                 </AppButton>
               </Stack>
@@ -305,12 +365,27 @@ export function AuthContainer({ mode }: AuthContainerProps) {
         ) : (
           <AuthCard
             title={authCardTitle}
+            isLogin={isLogin}
+            firstNameLabel={t('auth.firstNameLabel')}
+            lastNameLabel={t('auth.lastNameLabel')}
             emailLabel={t('common.email')}
+            phoneLabel={t('auth.phoneLabel')}
+            telegramLabel={t('auth.telegramLabel')}
             passwordLabel={t('common.password')}
             submitText={isLogin ? t('auth.submitLogin') : t('auth.submitRegister')}
             switchText={isLogin ? t('auth.switchToRegister') : t('auth.switchToLogin')}
             isSubmitting={isSubmitting}
-            fieldErrors={{ email: fieldErrors.email, password: fieldErrors.password }}
+            fieldErrors={{
+              firstName: fieldErrors.firstName,
+              lastName: fieldErrors.lastName,
+              email: fieldErrors.email,
+              phone: fieldErrors.phone,
+              telegramUsername: fieldErrors.telegramUsername,
+              password: fieldErrors.password
+            }}
+            requiredMessage={t('auth.requiredField')}
+            phoneInvalidMessage={t('auth.phoneInvalid')}
+            passwordMinLengthMessage={t('auth.passwordMinLength')}
             onSubmit={submitCredentials}
             onSwitch={() => navigate(isLogin ? '/register' : '/login')}
           />

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -31,9 +31,16 @@ export const dictionaries = {
       registerSubtitle: 'Create an account and start setup.',
       formLoginTitle: 'Login',
       formRegisterTitle: 'Register',
+      firstNameLabel: 'First name',
+      lastNameLabel: 'Last name',
+      phoneLabel: 'Phone number',
+      telegramLabel: 'Telegram username',
+      requiredField: 'This field is required',
+      phoneInvalid: 'Enter a valid phone number',
+      passwordMinLength: 'Password must be at least 10 characters',
       verifyTitle: 'Verify email',
-      verifySubtitle: 'Enter the OTP code from email for {email}.',
-      verifyCodeLabel: 'OTP code',
+      verifySubtitle: 'Enter the 4-digit OTP code from email for {email}.',
+      verifyCodeLabel: 'OTP code (4 digits)',
       verifyCodeRequired: 'Enter verification code',
       verifyCodeInvalid: 'Invalid verification code',
       verifySubmit: 'Confirm email',
@@ -360,9 +367,16 @@ export const dictionaries = {
       registerSubtitle: 'Создайте аккаунт и начните настройки.',
       formLoginTitle: 'Вход',
       formRegisterTitle: 'Регистрация',
+      firstNameLabel: 'Имя',
+      lastNameLabel: 'Фамилия',
+      phoneLabel: 'Номер телефона',
+      telegramLabel: 'Telegram username',
+      requiredField: 'Поле обязательно',
+      phoneInvalid: 'Введите корректный номер телефона',
+      passwordMinLength: 'Пароль должен быть не короче 10 символов',
       verifyTitle: 'Подтверждение email',
-      verifySubtitle: 'Введите OTP-код из письма для {email}.',
-      verifyCodeLabel: 'OTP-код',
+      verifySubtitle: 'Введите 4-значный OTP-код из письма для {email}.',
+      verifyCodeLabel: 'OTP-код (4 цифры)',
       verifyCodeRequired: 'Введите код подтверждения',
       verifyCodeInvalid: 'Некорректный код подтверждения',
       verifySubmit: 'Подтвердить email',
@@ -688,6 +702,13 @@ export type TranslationKey =
   | 'auth.registerSubtitle'
   | 'auth.formLoginTitle'
   | 'auth.formRegisterTitle'
+  | 'auth.firstNameLabel'
+  | 'auth.lastNameLabel'
+  | 'auth.phoneLabel'
+  | 'auth.telegramLabel'
+  | 'auth.requiredField'
+  | 'auth.phoneInvalid'
+  | 'auth.passwordMinLength'
   | 'auth.verifyTitle'
   | 'auth.verifySubtitle'
   | 'auth.verifyCodeLabel'


### PR DESCRIPTION
### Motivation
- Собрать больше данных при саморегистрации (имя, фамилия, телефон, опционально Telegram) и использовать удобный 4‑значный OTP с автоподтверждением для быстрой верификации email.
- Обеспечить валидацию телефона через существующий `AppRhfPhoneField` и добавить локализованные сообщения для новых полей.

### Description
- Backend: `registrationSchema` расширен новыми полями `firstName`, `lastName`, `phone`, `telegramUsername`, а `verifyEmailSchema` теперь требует ровно 4 цифры; `/api/auth/register` прокидывает новые поля в `registerUser`, который сохраняет профиль и генерирует 4‑значный код через `createOtpCode` (в `server/src/utils/crypto.ts`). (изменены: `server/src/config/schemas.ts`, `server/src/routes/authRoutes.ts`, `server/src/services/authService.ts`, `server/src/utils/crypto.ts`, `server/src/i18n/dictionaries.ts`)
- Frontend: форма аутентификации (`AuthCard`) стала mode‑aware и отображает регистрационные поля (`firstName`, `lastName`, `phone` с `AppRhfPhoneField`, `telegramUsername`) при регистрации; `AuthContainer` отправляет расширённый payload и реализует экран верификации с четырьмя отдельными инпутами, авто‑отправкой при вводе всех 4 цифр и ручной кнопкой подтверждения. (изменены: `web/src/components/AuthCard.tsx`, `web/src/containers/AuthContainer.tsx`, `web/src/shared/i18n/dictionaries.ts`)
- Документация: обновлены `README.md`, `web/README.md`, `server/README.md` с описанием новых обязательных полей и 4‑значного OTP UX.

### Testing
- Запущен smoke тест авторизации сервера: `npm run -w @scheduletm/server test -- auth.routes.smoke.test.ts` — пройдено успешно.
- Собрана серверная часть: `npm run -w @scheduletm/server build` — успешно.
- Попытка линта/сборки web: `npm run -w @scheduletm/web lint` и `npm run -w @scheduletm/web build` не завершились из‑за отсутствующей dev‑зависимости `@eslint/js` в окружении, поэтому фронтенд линт/сборка не выполнены в CI здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d9a1622483338502eda1ab001a78)