### PR TITLE
Improve OTP UX on registration verify step

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -6,7 +6,7 @@ React SPA для owner/admin/specialist/client.
 
 - Auth: `/login`, `/register`, `/invite/accept`, `/verify-email`.
   - `register`: required fields `firstName`, `lastName`, `email`, `phone`, optional `telegramUsername`.
-  - `verify-email`: 4-digit OTP with auto-confirm when all digits are entered.
+  - `verify-email`: 4-digit OTP with auto-confirm when all digits are entered, auto-focus between inputs, full-code paste support, and resend cooldown timer.
 - Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`, `/notification-logs`.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.

--- a/web/src/containers/AuthContainer.tsx
+++ b/web/src/containers/AuthContainer.tsx
@@ -1,5 +1,5 @@
 import { Alert, Box, Divider, Link, Stack, TextField, Typography } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { AuthCard } from '../components/AuthCard';
@@ -34,6 +34,8 @@ type AuthCredentialsFormValues = {
 type RegisterStep = 'credentials' | 'otp';
 
 const REGISTER_PENDING_EMAIL_KEY = 'meetli_register_pending_email';
+const OTP_LENGTH = 4;
+const RESEND_COOLDOWN_SECONDS = 30;
 
 export function AuthContainer({ mode }: AuthContainerProps) {
   const navigate = useNavigate();
@@ -51,6 +53,8 @@ export function AuthContainer({ mode }: AuthContainerProps) {
   const [isResending, setIsResending] = useState(false);
   const [registerStep, setRegisterStep] = useState<RegisterStep>('credentials');
   const [pendingEmail, setPendingEmail] = useState('');
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const otpInputRefs = useRef<Array<HTMLInputElement | null>>([]);
 
   const {
     control: verifyEmailControl,
@@ -63,7 +67,19 @@ export function AuthContainer({ mode }: AuthContainerProps) {
       code: '',
     },
   });
-  const [otpDigits, setOtpDigits] = useState(['', '', '', '']);
+  const [otpDigits, setOtpDigits] = useState(Array.from({ length: OTP_LENGTH }, () => ''));
+
+  useEffect(() => {
+    if (resendCooldown <= 0) {
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setResendCooldown((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+
+    return () => window.clearInterval(timerId);
+  }, [resendCooldown]);
 
   useEffect(() => {
     if (isLogin) {
@@ -176,7 +192,7 @@ export function AuthContainer({ mode }: AuthContainerProps) {
   };
 
   const resendCode = async () => {
-    if (!pendingEmail) {
+    if (!pendingEmail || resendCooldown > 0) {
       return;
     }
 
@@ -188,6 +204,7 @@ export function AuthContainer({ mode }: AuthContainerProps) {
       });
       setError('');
       setInfo(response.data.message);
+      setResendCooldown(RESEND_COOLDOWN_SECONDS);
     } catch (err) {
       const resolvedError = resolveApiError(err, {
         fallbackMessage: t('auth.errors.verifyResendFailed'),
@@ -207,17 +224,48 @@ export function AuthContainer({ mode }: AuthContainerProps) {
     clearVerifyEmailErrors();
     window.sessionStorage.removeItem(REGISTER_PENDING_EMAIL_KEY);
     setPendingEmail('');
-    setOtpDigits(['', '', '', '']);
+    setOtpDigits(Array.from({ length: OTP_LENGTH }, () => ''));
   };
 
   const handleOtpDigitChange = (index: number, rawValue: string) => {
-    const nextDigit = rawValue.replace(/\D/g, '').slice(-1);
+    const digitsOnly = rawValue.replace(/\D/g, '');
+    const nextDigit = digitsOnly.slice(-1);
     const nextDigits = otpDigits.map((digit, digitIndex) => (digitIndex === index ? nextDigit : digit));
     setOtpDigits(nextDigits);
     const nextCode = nextDigits.join('');
     setVerifyEmailValue('code', nextCode, { shouldValidate: true });
-    if (nextCode.length === 4 && nextDigits.every(Boolean) && !isSubmitting) {
+    if (nextDigit && index < OTP_LENGTH - 1) {
+      otpInputRefs.current[index + 1]?.focus();
+    }
+    if (nextCode.length === OTP_LENGTH && nextDigits.every(Boolean) && !isSubmitting) {
       void submitOtpCode(nextCode);
+    }
+  };
+
+  const handleOtpPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    const pastedDigits = event.clipboardData.getData('text').replace(/\D/g, '').slice(0, OTP_LENGTH);
+    if (!pastedDigits) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const nextDigits = Array.from({ length: OTP_LENGTH }, (_, index) => pastedDigits[index] ?? '');
+    setOtpDigits(nextDigits);
+    const nextCode = nextDigits.join('');
+    setVerifyEmailValue('code', nextCode, { shouldValidate: true });
+
+    const focusIndex = Math.min(pastedDigits.length, OTP_LENGTH - 1);
+    otpInputRefs.current[focusIndex]?.focus();
+
+    if (pastedDigits.length === OTP_LENGTH && !isSubmitting) {
+      void submitOtpCode(nextCode);
+    }
+  };
+
+  const handleOtpKeyDown = (index: number, event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Backspace' && !otpDigits[index] && index > 0) {
+      otpInputRefs.current[index - 1]?.focus();
     }
   };
 
@@ -314,12 +362,26 @@ export function AuthContainer({ mode }: AuthContainerProps) {
                             setFieldErrors((prev) => ({ ...prev, code: '' }));
                             handleOtpDigitChange(index, event.target.value);
                           }}
+                          inputRef={(element) => {
+                            otpInputRefs.current[index] = element;
+                          }}
+                          onKeyDown={(event) => handleOtpKeyDown(index, event)}
+                          onPaste={handleOtpPaste}
                           inputProps={{
                             inputMode: 'numeric',
                             maxLength: 1,
-                            style: { textAlign: 'center', fontSize: 24, fontWeight: 700 }
+                            style: { textAlign: 'center', fontSize: 24, fontWeight: 700, padding: 0, lineHeight: '64px' }
                           }}
-                          sx={{ width: 64 }}
+                          sx={{
+                            width: 64,
+                            '& .MuiInputBase-input': {
+                              height: 64,
+                              textAlign: 'center',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center'
+                            }
+                          }}
                           error={Boolean(fieldState.error)}
                         />
                       ))}
@@ -337,8 +399,8 @@ export function AuthContainer({ mode }: AuthContainerProps) {
                 <AppButton type="button" variant="outlined" onClick={backToRegister} fullWidth>
                   {t('auth.verifyBack')}
                 </AppButton>
-                <AppButton type="button" variant="text" onClick={resendCode} isLoading={isResending} fullWidth>
-                  {t('auth.verifyResend')}
+                <AppButton type="button" variant="text" onClick={resendCode} isLoading={isResending} disabled={resendCooldown > 0} fullWidth>
+                  {resendCooldown > 0 ? `${t('auth.verifyResendCooldown')} ${resendCooldown}s` : t('auth.verifyResend')}
                 </AppButton>
                 <AppButton
                   type="button"

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -45,6 +45,7 @@ export const dictionaries = {
       verifyCodeInvalid: 'Invalid verification code',
       verifySubmit: 'Confirm email',
       verifyResend: 'Resend code',
+      verifyResendCooldown: 'Resend in',
       verifyBack: 'Back',
       inviteAcceptTitle: 'Accept invitation',
       inviteAcceptSubtitle: 'Set your password to activate access.',
@@ -381,6 +382,7 @@ export const dictionaries = {
       verifyCodeInvalid: 'Некорректный код подтверждения',
       verifySubmit: 'Подтвердить email',
       verifyResend: 'Отправить код снова',
+      verifyResendCooldown: 'Повторная отправка через',
       verifyBack: 'Назад',
       inviteAcceptTitle: 'Принять приглашение',
       inviteAcceptSubtitle: 'Задайте пароль, чтобы активировать доступ.',
@@ -716,6 +718,7 @@ export type TranslationKey =
   | 'auth.verifyCodeInvalid'
   | 'auth.verifySubmit'
   | 'auth.verifyResend'
+  | 'auth.verifyResendCooldown'
   | 'auth.verifyBack'
   | 'auth.inviteAcceptTitle'
   | 'auth.inviteAcceptSubtitle'


### PR DESCRIPTION
### Motivation
- Improve the email verification (OTP) UX on the register/verify-email step by adding a resend cooldown, making digits visually centered, supporting paste of the whole code, and enabling automatic focus movement when typing/deleting digits.

### Description
- Added OTP constants and state (`OTP_LENGTH`, `RESEND_COOLDOWN_SECONDS`, `resendCooldown`) and input refs (`otpInputRefs`) in `web/src/containers/AuthContainer.tsx` to manage focus and cooldown behavior.
- Implemented auto-focus to next input on digit entry, backspace focus-back behavior, and full-code paste handling with `handleOtpPaste` and `handleOtpKeyDown`, and preserved existing auto-submit when all digits are present in `AuthContainer`.
- Centered digits inside OTP boxes by adjusting `TextField` `inputProps` and `sx` styling and unified `otpDigits` initialization to use `OTP_LENGTH`.
- Disabled resend button during cooldown and display cooldown text using a new i18n key; added `auth.verifyResendCooldown` in both `en` and `ru` in `web/src/shared/i18n/dictionaries.ts` and updated the translation key union.
- Updated `web/README.md` to document the enhanced OTP behavior; changed files: `web/src/containers/AuthContainer.tsx`, `web/src/shared/i18n/dictionaries.ts`, `web/README.md`.

### Testing
- Ran linter with `npm run -w @scheduletm/web lint` which exited with errors; the reported issues are pre-existing in unrelated files and this change does not introduce new OTP-related lint errors.
- No additional automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1aea2469883339a77b545fec71c8e)