### PR TITLE
Show registration success message on login after email verification

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -7,6 +7,7 @@ React SPA для owner/admin/specialist/client.
 - Auth: `/login`, `/register`, `/invite/accept`, `/verify-email`.
   - `register`: required fields `firstName`, `lastName`, `email`, `phone`, optional `telegramUsername`.
   - `verify-email`: 4-digit OTP with auto-confirm when all digits are entered, auto-focus between inputs, full-code paste support, and resend cooldown timer.
+  - after successful email verification on registration, user is redirected to `/login` with a success message.
 - Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`, `/notification-logs`.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.

--- a/web/src/containers/AuthContainer.tsx
+++ b/web/src/containers/AuthContainer.tsx
@@ -1,7 +1,7 @@
 import { Alert, Box, Divider, Link, Stack, TextField, Typography } from '@mui/material';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { AuthCard } from '../components/AuthCard';
 import logoText from '../static/images/logo_text.svg';
 import { apiClient } from '../shared/api/client';
@@ -39,6 +39,7 @@ const RESEND_COOLDOWN_SECONDS = 30;
 
 export function AuthContainer({ mode }: AuthContainerProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { setAuthSession } = useAuth();
   const { t } = useI18n();
 
@@ -80,6 +81,24 @@ export function AuthContainer({ mode }: AuthContainerProps) {
 
     return () => window.clearInterval(timerId);
   }, [resendCooldown]);
+
+
+  useEffect(() => {
+    if (!isLogin) {
+      return;
+    }
+
+    const successMessage = location.state && typeof location.state === 'object' && 'successMessage' in location.state
+      ? location.state.successMessage
+      : '';
+
+    if (typeof successMessage !== 'string' || !successMessage) {
+      return;
+    }
+
+    setInfo(successMessage);
+    navigate(location.pathname, { replace: true, state: null });
+  }, [isLogin, location.pathname, location.state, navigate]);
 
   useEffect(() => {
     if (isLogin) {
@@ -172,7 +191,7 @@ export function AuthContainer({ mode }: AuthContainerProps) {
       setFieldErrors({});
       setInfo(response.data.message);
       window.sessionStorage.removeItem(REGISTER_PENDING_EMAIL_KEY);
-      navigate('/login');
+      navigate('/login', { state: { successMessage: t('auth.registerSuccessLoginHint') } });
     } catch (err) {
       const resolvedError = resolveApiError(err, {
         fallbackMessage: t('auth.errors.verifyFailed'),

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -70,6 +70,7 @@ export const dictionaries = {
       inviteAcceptedSuccess: 'Invitation accepted. You can now sign in.',
       registerOtpSentHint: 'Verification code sent to {email}.',
       registerOtpRestoreHint: 'Continue verification for {email}.',
+      registerSuccessLoginHint: 'Registration successful. You can now sign in.',
       submitLogin: 'Sign in',
       submitRegister: 'Create account',
       switchToRegister: "Don't have an account? Register",
@@ -407,6 +408,7 @@ export const dictionaries = {
       inviteAcceptedSuccess: 'Приглашение принято. Теперь можно войти.',
       registerOtpSentHint: 'Код подтверждения отправлен на {email}.',
       registerOtpRestoreHint: 'Продолжите подтверждение для {email}.',
+      registerSuccessLoginHint: 'Регистрация прошла успешно. Теперь можно войти.',
       submitLogin: 'Войти',
       submitRegister: 'Зарегистрироваться',
       switchToRegister: 'Нет аккаунта? Зарегистрироваться',
@@ -744,6 +746,7 @@ export type TranslationKey =
   | 'auth.inviteAcceptedSuccess'
   | 'auth.registerOtpSentHint'
   | 'auth.registerOtpRestoreHint'
+  | 'auth.registerSuccessLoginHint'
   | 'auth.submitLogin'
   | 'auth.submitRegister'
   | 'auth.switchToRegister'


### PR DESCRIPTION
### Motivation
- Provide clear feedback to users after they complete email verification during registration by redirecting them to the login page with a success message and ensuring the login view displays it.
- Add the corresponding i18n strings and documentation so the new behavior is translatable and described in the README.

### Description
- In `AuthContainer`, added `useLocation` and an effect that reads `location.state.successMessage` when on the login route, sets the `info` banner, and clears the navigation state with `navigate(..., { replace: true, state: null })`.
- Modified the OTP submit path to navigate to `/login` with `state: { successMessage: t('auth.registerSuccessLoginHint') }` after successful verification.
- Added `auth.registerSuccessLoginHint` translations for English and Russian and extended the `TranslationKey` union.
- Updated `web/README.md` to document that users are redirected to `/login` with a success message after email verification on registration.

### Testing
- Ran the package test suite with `npm run -w @scheduletm/web test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b17f59508333933647f6f636d9a4)