### PR TITLE
Use i18n context and translate hardcoded UI strings

### DIFF
--- a/web/src/app/AppErrorBoundary.tsx
+++ b/web/src/app/AppErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Alert, Box, Button, Stack, Typography } from '@mui/material';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { I18nContext } from '../shared/i18n/I18nContext';
 
 type AppErrorBoundaryProps = {
   children: ReactNode;
@@ -10,6 +11,8 @@ type AppErrorBoundaryState = {
 };
 
 export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  public static contextType = I18nContext;
+  declare context: React.ContextType<typeof I18nContext>;
   public state: AppErrorBoundaryState = {
     hasError: false
   };
@@ -28,6 +31,8 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
 
   public render() {
     if (this.state.hasError) {
+      const t = this.context?.t;
+
       return (
         <Box
           sx={{
@@ -39,13 +44,13 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
           }}
         >
           <Stack spacing={2} sx={{ maxWidth: 560, width: '100%' }}>
-            <Typography variant="h4">Что-то пошло не так</Typography>
+            <Typography variant="h4">{t?.('common.appErrorTitle')}</Typography>
             <Typography color="text.secondary">
-              Произошла непредвиденная ошибка интерфейса. Попробуйте перезагрузить страницу.
+              {t?.('common.appErrorDescription')}
             </Typography>
-            <Alert severity="error">Если проблема повторяется, обратитесь к администратору.</Alert>
+            <Alert severity="error">{t?.('common.appErrorSupport')}</Alert>
             <Button variant="contained" onClick={this.handleReload}>
-              Перезагрузить страницу
+              {t?.('common.appErrorReload')}
             </Button>
           </Stack>
         </Box>

--- a/web/src/components/AuthCard.tsx
+++ b/web/src/components/AuthCard.tsx
@@ -241,7 +241,7 @@ export function AuthCard({
         </AppButton>
 
         <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
-          By continuing, you agree to our <Link underline="hover">terms</Link> and <Link underline="hover">privacy policy</Link>.
+          {t('auth.legalPrefix')} <Link underline="hover">{t('auth.termsLabel')}</Link> {t('auth.legalJoin')} <Link underline="hover">{t('auth.privacyPolicyLabel')}</Link>{t('auth.legalSuffix')}
         </Typography>
       </AppForm>
     </Box>

--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -252,18 +252,18 @@ export function AppointmentFormDialog({
               onClick={() => setShowTimezoneSelect((prev) => !prev)}
               sx={{ alignSelf: { xs: 'flex-start', sm: 'center' } }}
             >
-              {showTimezoneSelect ? 'Hide custom timezone' : 'Use custom timezone'}
+              {showTimezoneSelect ? t('appointments.hideCustomTimezone') : t('appointments.useCustomTimezone')}
             </Button>
             <Typography variant="body2" color="text.secondary" sx={{ alignSelf: 'center' }}>
-              {`Current timezone: ${formTimeZone}`}
+              {t('appointments.currentTimezone').replace('{timezone}', formTimeZone)}
             </Typography>
           </Stack>
           <Collapse in={showTimezoneSelect}>
             <FormControl fullWidth>
-              <InputLabel id="appointment-timezone-label">Timezone</InputLabel>
+              <InputLabel id="appointment-timezone-label">{t('appointments.timezone')}</InputLabel>
               <Select
                 labelId="appointment-timezone-label"
-                label="Timezone"
+                label={t('appointments.timezone')}
                 value={formTimeZone}
                 onChange={(event) => setFormTimeZone(String(event.target.value))}
               >
@@ -299,14 +299,14 @@ export function AppointmentFormDialog({
               control={control}
               render={({ field }: any) => (
                 <FormControl fullWidth>
-                  <InputLabel id="client-label">Client</InputLabel>
+                  <InputLabel id="client-label">{t('appointments.client')}</InputLabel>
                   <Select
                     labelId="client-label"
-                    label="Client"
+                    label={t('appointments.client')}
                     value={field.value}
                     onChange={(event) => field.onChange(String(event.target.value))}
                   >
-                    <MenuItem value="">New client</MenuItem>
+                    <MenuItem value="">{t('appointments.newClient')}</MenuItem>
                     {clients.map((client) => (
                       <MenuItem key={client.id} value={String(client.id)}>{`${client.firstName} ${client.lastName}`.trim()}</MenuItem>
                     ))}

--- a/web/src/components/appointments/AppointmentsCalendar.tsx
+++ b/web/src/components/appointments/AppointmentsCalendar.tsx
@@ -193,7 +193,7 @@ export function AppointmentsCalendar({
                                   {formatLocalTime(item.scheduledAt)}
                                 </Typography>
                                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                  {statusLabel(item.status)} · {item.durationMin}m
+                                  {`${statusLabel(item.status)} · ${t('appointments.durationMinutesShort').replace('{minutes}', String(item.durationMin))}`}
                                 </Typography>
                               </Box>
                             ))
@@ -400,7 +400,7 @@ export function AppointmentsCalendar({
                                     {formatLocalTime(item.scheduledAt)}
                                   </Typography>
                                   <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                    {statusLabel(item.status)} · {item.durationMin}m
+                                    {`${statusLabel(item.status)} · ${t('appointments.durationMinutesShort').replace('{minutes}', String(item.durationMin))}`}
                                   </Typography>
                                 </Box>
                               ))}

--- a/web/src/components/users/UserFormDialog.tsx
+++ b/web/src/components/users/UserFormDialog.tsx
@@ -143,9 +143,9 @@ export function UserFormDialog({
             <FormControl margin="dense" fullWidth>
               <InputLabel id="managed-user-role-label">{roleLabel}</InputLabel>
               <Select labelId="managed-user-role-label" label={roleLabel} value={field.value} onChange={(event) => field.onChange(event.target.value as 'admin' | 'specialist' | 'client')}>
-                <MenuItem value="admin">admin</MenuItem>
-                <MenuItem value="specialist">specialist</MenuItem>
-                <MenuItem value="client">client</MenuItem>
+                <MenuItem value="admin">{t('appointments.roleAdmin')}</MenuItem>
+                <MenuItem value="specialist">{t('appointments.roleSpecialist')}</MenuItem>
+                <MenuItem value="client">{t('appointments.roleClient')}</MenuItem>
               </Select>
             </FormControl>
           )}

--- a/web/src/containers/AuthContainer.tsx
+++ b/web/src/containers/AuthContainer.tsx
@@ -450,7 +450,7 @@ export function AuthContainer({ mode }: AuthContainerProps) {
               </AppButton>
 
               <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
-                By continuing, you agree to our <Link underline="hover">terms</Link> and <Link underline="hover">privacy policy</Link>.
+                {t('auth.legalPrefix')} <Link underline="hover">{t('auth.termsLabel')}</Link> {t('auth.legalJoin')} <Link underline="hover">{t('auth.privacyPolicyLabel')}</Link>{t('auth.legalSuffix')}
               </Typography>
             </AppForm>
           </Box>

--- a/web/src/shared/i18n/I18nContext.tsx
+++ b/web/src/shared/i18n/I18nContext.tsx
@@ -12,7 +12,7 @@ type I18nContextValue = {
   t: (key: TranslationKey) => string;
 };
 
-const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+export const I18nContext = createContext<I18nContextValue | undefined>(undefined);
 
 const STORAGE_KEY = 'ui-locale';
 

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -23,7 +23,11 @@ export const dictionaries = {
       languageAria: 'Select language',
       errors: {
         network: 'Network connection issue. Please check your internet and try again.'
-      }
+      },
+      appErrorTitle: 'Something went wrong',
+      appErrorDescription: 'An unexpected UI error occurred. Try reloading the page.',
+      appErrorSupport: 'If the issue persists, contact your administrator.',
+      appErrorReload: 'Reload page'
     },
     auth: {
       loginTitle: 'Sign in to your account',
@@ -76,6 +80,11 @@ export const dictionaries = {
       submitRegister: 'Create account',
       switchToRegister: "Don't have an account? Register",
       switchToLogin: 'Already have an account? Sign in',
+      termsLabel: 'terms',
+      privacyPolicyLabel: 'privacy policy',
+      legalPrefix: 'By continuing, you agree to our',
+      legalJoin: 'and',
+      legalSuffix: '.',
       errors: {
         loginFailed: 'Unable to sign in. Check your email and password.',
         registerFailed: 'Unable to register.',
@@ -314,6 +323,16 @@ export const dictionaries = {
       cancelPolicyNoRefund: 'Cancellation policy: late cancellation without refund.',
       markPaidAction: 'Mark as paid',
       notifyAction: 'Notify client',
+      hideCustomTimezone: 'Hide custom timezone',
+      useCustomTimezone: 'Use custom timezone',
+      currentTimezone: 'Current timezone: {timezone}',
+      timezone: 'Timezone',
+      client: 'Client',
+      newClient: 'New client',
+      durationMinutesShort: '{minutes}m',
+      roleAdmin: 'admin',
+      roleSpecialist: 'specialist',
+      roleClient: 'client',
       paymentStatusPaid: 'Paid',
       paymentStatusUnpaid: 'Unpaid',
       auditTitle: 'Activity',
@@ -362,7 +381,11 @@ export const dictionaries = {
       languageAria: 'Выбрать язык',
       errors: {
         network: 'Проблема с подключением к сети. Проверьте интернет и попробуйте снова.'
-      }
+      },
+      appErrorTitle: 'Что-то пошло не так',
+      appErrorDescription: 'Произошла непредвиденная ошибка интерфейса. Попробуйте перезагрузить страницу.',
+      appErrorSupport: 'Если проблема повторяется, обратитесь к администратору.',
+      appErrorReload: 'Перезагрузить страницу'
     },
     auth: {
       loginTitle: 'Вход в аккаунт',
@@ -415,6 +438,11 @@ export const dictionaries = {
       submitRegister: 'Зарегистрироваться',
       switchToRegister: 'Нет аккаунта? Зарегистрироваться',
       switchToLogin: 'Уже есть аккаунт? Войти',
+      termsLabel: 'условиями',
+      privacyPolicyLabel: 'политикой конфиденциальности',
+      legalPrefix: 'Продолжая, вы соглашаетесь с нашими',
+      legalJoin: 'и',
+      legalSuffix: '.',
       errors: {
         loginFailed: 'Не удалось войти. Проверьте email и пароль.',
         registerFailed: 'Не удалось зарегистрироваться.',
@@ -653,6 +681,16 @@ export const dictionaries = {
       cancelPolicyNoRefund: 'Правило отмены: поздняя отмена без возврата оплаты.',
       markPaidAction: 'Подтвердить оплату',
       notifyAction: 'Уведомить клиента',
+      hideCustomTimezone: 'Скрыть выбор часового пояса',
+      useCustomTimezone: 'Использовать другой часовой пояс',
+      currentTimezone: 'Текущий часовой пояс: {timezone}',
+      timezone: 'Часовой пояс',
+      client: 'Клиент',
+      newClient: 'Новый клиент',
+      durationMinutesShort: '{minutes}м',
+      roleAdmin: 'admin',
+      roleSpecialist: 'specialist',
+      roleClient: 'client',
       paymentStatusPaid: 'Оплачено',
       paymentStatusUnpaid: 'Не оплачено',
       auditTitle: 'История действий',


### PR DESCRIPTION
### Motivation
- Introduce application-level translations and remove hardcoded UI text so the interface can be localized.
- Make the global error UI translatable and unify legal/appointment/user-related labels through the i18n system.

### Description
- Exported `I18nContext` and used it in `AppErrorBoundary` to render translatable error title, description, support text, and reload button via `t`.
- Replaced multiple hardcoded strings with translation lookups (`t('...')`) in `AuthCard`, `AuthContainer`, `AppointmentFormDialog`, `AppointmentsCalendar`, and `UserFormDialog`.
- Added new translation keys and values to `shared/i18n/dictionaries.ts` for both `en` and `ru`, covering app error messages, legal text (terms/privacy), appointment labels, timezone text, role labels, and duration formatting.

### Testing
- Ran TypeScript type check and project build with `yarn build`, which completed successfully.
- Ran unit tests with `yarn test`, and all tests passed.
- Ran linting with `yarn lint`, and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bd288e288333a41c5cdb8fce3ee2)