### PR TITLE
fix(web): replace react-hook-form watch with useWatch

### DIFF
--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -14,7 +14,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import type { AppointmentItem, AppointmentStatus, ClientItem, SpecialistItem } from '../../shared/types/api';
 import { AppButton } from '../../shared/ui/AppButton';
 import { AppRhfPhoneField } from '../../shared/ui/AppRhfPhoneField';
@@ -173,7 +173,7 @@ export function AppointmentFormDialog({
     } satisfies AppointmentFormState;
   }, [editingItem, initialScheduledAtIso, selectedSlotStepMin, selectedSpecialistId, specialists]);
 
-  const { control, handleSubmit, reset, watch, setValue } = useForm<AppointmentFormState>({
+  const { control, handleSubmit, reset, setValue } = useForm<AppointmentFormState>({
     defaultValues: EMPTY_FORM,
   });
 
@@ -187,7 +187,7 @@ export function AppointmentFormDialog({
     setShowTimezoneSelect(false);
   }, [initialValues, open, reset]);
 
-  const selectedClientId = watch('clientId');
+  const selectedClientId = useWatch({ control, name: 'clientId' });
 
   useEffect(() => {
     const selectedClient = clients.find((item) => String(item.id) === selectedClientId);
@@ -202,8 +202,8 @@ export function AppointmentFormDialog({
     setValue('email', selectedClient.email, { shouldDirty: true });
   }, [clients, selectedClientId, setValue]);
 
-  const startDateValue = watch('startDate');
-  const startTimeValue = watch('startTime');
+  const startDateValue = useWatch({ control, name: 'startDate' });
+  const startTimeValue = useWatch({ control, name: 'startTime' });
 
   useEffect(() => {
     if (!open || editingItem || !startDateValue || !startTimeValue) {

--- a/web/src/components/users/UserFormDialog.tsx
+++ b/web/src/components/users/UserFormDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import type { ManagedUserItem } from '../../shared/types/api';
 import { AppButton } from '../../shared/ui/AppButton';
 import { AppRhfPhoneField } from '../../shared/ui/AppRhfPhoneField';
@@ -82,7 +82,7 @@ export function UserFormDialog({
     telegramUsername?: string;
   } | null>(null);
 
-  const { control, handleSubmit, reset, watch } = useForm<UserFormState>({
+  const { control, handleSubmit, reset } = useForm<UserFormState>({
     defaultValues: EMPTY_FORM
   });
 
@@ -105,7 +105,7 @@ export function UserFormDialog({
     });
   }, [editingUser, open, reset]);
 
-  const [email, firstName, lastName] = watch(['email', 'firstName', 'lastName']);
+  const [email, firstName, lastName] = useWatch({ control, name: ['email', 'firstName', 'lastName'] });
   const isValid = Boolean(email?.trim() && firstName?.trim() && lastName?.trim());
 
   const submitForm = handleSubmit(async (form) => {

--- a/web/src/containers/InviteAcceptContainer.tsx
+++ b/web/src/containers/InviteAcceptContainer.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
 import logoText from '../static/images/logo_text.svg';
 import { apiClient } from '../shared/api/client';
@@ -62,7 +62,6 @@ export function InviteAcceptContainer() {
     control,
     handleSubmit,
     formState: { isValid, errors },
-    watch,
   } = useForm<InviteAcceptFormValues>({
     mode: 'onChange',
     defaultValues: {
@@ -74,7 +73,7 @@ export function InviteAcceptContainer() {
     },
   });
 
-  const passwordValue = watch('password');
+  const passwordValue = useWatch({ control, name: 'password' });
 
   useEffect(() => {
     let isDisposed = false;


### PR DESCRIPTION
### Motivation
- Remove React Compiler / `react-hooks/incompatible-library` warnings caused by using `watch` returned from `useForm()` by switching to a safe subscription API.
- Change is minimal and targets only the files that subscribe to form values.
- Files inspected/edited: `web/src/components/appointments/AppointmentFormDialog.tsx`, `web/src/components/users/UserFormDialog.tsx`, and `web/src/containers/InviteAcceptContainer.tsx`.

### Description
- Import `useWatch` from `react-hook-form` and remove `watch` from `useForm` destructuring where no longer needed.
- Replace `watch('field')` / `watch(['a','b'])` usages with `useWatch({ control, name: 'field' })` or `useWatch({ control, name: ['a','b'] })` in the three files.
- Keep existing `setValue`, `reset`, and form behavior unchanged while making subscriptions compatible with React Compiler.

### Testing
- Ran ESLint on the modified files with `cd web && npx eslint src/components/appointments/AppointmentFormDialog.tsx src/components/users/UserFormDialog.tsx src/containers/InviteAcceptContainer.tsx`, which removed the `react-hooks/incompatible-library` warnings for these locations.
- The lint run reported unrelated pre-existing errors `react-hooks/set-state-in-effect` in `AppointmentFormDialog.tsx` and `InviteAcceptContainer.tsx`, which were not introduced by this change.
- No automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c21e9e04833381a42ecc5fd6cab3)