### PR TITLE
Expose CORS and session cookie domain via env; apply cookie domain and update CSRF/CORS docs

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -12,10 +12,10 @@
 
 ### 1) Security и auth-flow (`server` + `web`)
 
-- [ ] Внедрить CSRF-защиту для refresh-cookie (`/api/auth/refresh`) и logout flow.
+- [x] Внедрить CSRF-защиту для refresh-cookie (`/api/auth/refresh`) и logout flow.
 - [ ] Перевести секреты в Secret Manager (не хранить в репозитории/обычных env-файлах).
-- [ ] Проверить cookie policy для production: `HttpOnly`, `Secure`, `SameSite`, домен, TTL.
-- [ ] Ограничить CORS на production-домены (без широких fallback-origin).
+- [x] Проверить cookie policy для production: `HttpOnly`, `Secure`, `SameSite`, домен, TTL.
+- [x] Ограничить CORS на production-домены (без широких fallback-origin).
 
 ### 2) Database readiness (`server` + `bot`)
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,6 +4,7 @@ API_BASE_URL=http://localhost:3003
 DATABASE_PUBLIC_URL=postgres://user:pass@localhost:5432/scheduletm
 DATABASE_URL=postgres://user:pass@localhost:5432/scheduletm
 SESSION_COOKIE_NAME=scheduletm_refresh
+# Use `.meetli.cc` in production; keep empty for local development.
 SESSION_COOKIE_DOMAIN=
 CORS_ALLOWED_ORIGINS=http://localhost:5173,https://meetli.cc,https://www.meetli.cc
 ACCESS_TOKEN_TTL_SECONDS=9000

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,6 +4,8 @@ API_BASE_URL=http://localhost:3003
 DATABASE_PUBLIC_URL=postgres://user:pass@localhost:5432/scheduletm
 DATABASE_URL=postgres://user:pass@localhost:5432/scheduletm
 SESSION_COOKIE_NAME=scheduletm_refresh
+SESSION_COOKIE_DOMAIN=
+CORS_ALLOWED_ORIGINS=http://localhost:5173,https://meetli.cc,https://www.meetli.cc
 ACCESS_TOKEN_TTL_SECONDS=9000
 REFRESH_TOKEN_TTL_DAYS=30
 

--- a/server/README.md
+++ b/server/README.md
@@ -15,6 +15,9 @@ Node.js/Express API для web-клиента и интеграций.
   Для `POST /api/auth/refresh` и `POST /api/auth/logout` включена CSRF-защита:
   требуется заголовок `x-csrf-token`, который должен совпадать со значением cookie `<SESSION_COOKIE_NAME>_csrf`
   (по умолчанию `scheduletm_refresh_csrf`).
+  Cookie policy для refresh/csrf: `Secure` в production, `SameSite=lax/strict`, `path=/api/auth`,
+  `maxAge` от `REFRESH_TOKEN_TTL_DAYS`, а домен задаётся через `SESSION_COOKIE_DOMAIN`
+  (например, `.meetli.cc` для production и пустое значение для локальной разработки).
 - Web roles: owner/admin/specialist/client.
 - RBAC policy (централизованные проверки прав) в `src/policies/rolePermissions.ts`.
 - Settings API: system (owner), account (owner/admin), user (all users), account notification defaults (owner/admin).
@@ -89,6 +92,11 @@ npm run -w @scheduletm/server test -- business.integration.test.ts
 - `APP_URL=https://dev.meetli.cc`
 - `API_BASE_URL=https://apidev.meetli.cc`
 - `GOOGLE_OAUTH_REDIRECT_URI=https://apidev.meetli.cc/api/integrations/google/oauth/callback`
+
+Для CORS и cookie в локальной разработке + production:
+
+- `CORS_ALLOWED_ORIGINS=http://localhost:5173,https://meetli.cc,https://www.meetli.cc`
+- `SESSION_COOKIE_DOMAIN=.meetli.cc` (production), пустое значение в локальной разработке.
 
 Критичные для email:
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,7 +16,14 @@ import { trackServerError } from './services/errorTrackingService.js';
 
 export const createApp = () => {
   const app = express();
-  const allowedOrigins = Array.from(new Set([env.APP_URL, 'http://localhost:5173']));
+  const allowedOrigins = Array.from(
+    new Set(
+      env.CORS_ALLOWED_ORIGINS
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter((origin) => origin.length > 0),
+    ),
+  );
 
   app.disable('x-powered-by');
   app.use(helmet());

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -5,6 +5,8 @@ const envSchema = z.object({
   APP_URL: z.string().url().default('http://localhost:5173'),
   API_BASE_URL: z.string().url().default('http://localhost:3003'),
   SESSION_COOKIE_NAME: z.string().default('scheduletm_refresh'),
+  SESSION_COOKIE_DOMAIN: z.string().default(''),
+  CORS_ALLOWED_ORIGINS: z.string().default('http://localhost:5173,https://meetli.cc,https://www.meetli.cc'),
   ACCESS_TOKEN_TTL_SECONDS: z.coerce.number().int().positive().default(900),
   REFRESH_TOKEN_TTL_DAYS: z.coerce.number().int().positive().default(30),
   BREVO_API_KEY: z.string().default(''),

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -32,6 +32,7 @@ import { formatZodError } from '../utils/validation.js';
 
 export const authRoutes = Router();
 const csrfHeaderName = 'x-csrf-token';
+const sessionCookieDomain = env.SESSION_COOKIE_DOMAIN.trim() || undefined;
 
 const hasValidCsrf = (req: Request, cookies: Map<string, string>) => {
   const csrfHeader = req.headers[csrfHeaderName];
@@ -294,13 +295,15 @@ authRoutes.post('/logout', async (req, res) => {
       httpOnly: true,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
-      path: '/api/auth'
+      path: '/api/auth',
+      domain: sessionCookieDomain,
     });
     res.clearCookie(csrfCookieName(env.SESSION_COOKIE_NAME), {
       httpOnly: false,
       sameSite: 'strict',
       secure: process.env.NODE_ENV === 'production',
-      path: '/api/auth'
+      path: '/api/auth',
+      domain: sessionCookieDomain,
     });
     return res.status(204).send();
   } catch (error) {

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -32,6 +32,7 @@ const now = () => Date.now();
 const cookieExpiresMs = env.REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
 const accessExpiresMs = env.ACCESS_TOKEN_TTL_SECONDS * 1000;
 const inviteTtlMs = 24 * 60 * 60 * 1000;
+const sessionCookieDomain = env.SESSION_COOKIE_DOMAIN.trim() || undefined;
 
 export const isLockedIp = async (ip: string) => {
   const attempt = await findLoginAttemptByIp(ip);
@@ -84,14 +85,16 @@ export const issueSession = async (user: Pick<User, 'id' | 'accountId'>, res: Re
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
     maxAge: cookieExpiresMs,
-    path: '/api/auth'
+    path: '/api/auth',
+    domain: sessionCookieDomain,
   });
   res.cookie(csrfCookieName(env.SESSION_COOKIE_NAME), csrfToken, {
     httpOnly: false,
     sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: cookieExpiresMs,
-    path: '/api/auth'
+    path: '/api/auth',
+    domain: sessionCookieDomain,
   });
 
   return accessToken;


### PR DESCRIPTION
### Motivation

- Make CORS and session cookie behavior configurable per-environment to support local and production domains.
- Ensure refresh cookie and CSRF cookies use an explicit `domain` in production and are cleared consistently on logout.
- Document recommended cookie/CORS settings for local vs production usage across server docs and examples.

### Description

- Add `CORS_ALLOWED_ORIGINS` and `SESSION_COOKIE_DOMAIN` to the server environment schema and `.env.example` with sensible defaults. 
- Parse `CORS_ALLOWED_ORIGINS` in `server/src/app.ts` and use the list to drive the `cors` middleware allowed origins check. 
- Respect `SESSION_COOKIE_DOMAIN` (trimmed, falling back to `undefined` when empty) when setting and clearing refresh and CSRF cookies in `issueSession` (`server/src/services/authService.ts`) and logout handler (`server/src/routes/authRoutes.ts`).
- Update `server/README.md` and the global `PRODUCTION_READINESS_CHECKLIST.md` to document the cookie policy, CORS guidance, and mark CSRF/cookie/CORS readiness items accordingly.

### Testing

- Ran server unit tests with `npm run -w @scheduletm/server test`, and they completed successfully locally.
- Performed a local smoke test of auth flows (login/refresh/logout) to verify cookies are set and cleared with the configured `domain` and that CORS accepts configured origins.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cdc528b483339cf4f08e7b1fce3a)