### PR TITLE
Add request rate limiting, safe request logging, and Google OAuth redirect validation; update i18n and readiness checklists

### DIFF
--- a/PRODUCTION_READINESS_CHECKLIST.md
+++ b/PRODUCTION_READINESS_CHECKLIST.md
@@ -53,20 +53,37 @@
 
 ### Server/API
 
-- [ ] Пройти security review env/runtime-настроек (в т.ч. OAuth redirect и token TTL).
-- [ ] Проверить rate-limit стратегии для login/invite/notify endpoints.
-- [ ] Утвердить политику логирования и маскирования PII (email/phone/telegram).
+- [x] Пройти security review **runtime**-настроек (без блока secret storage):
+  - [x] OAuth redirect: callback дополнительно валидируется по origin/path на сервере.
+  - [x] Token TTL: значения централизованы в runtime config (`ACCESS_TOKEN_TTL_SECONDS`, `REFRESH_TOKEN_TTL_DAYS`) и применяются при issue/refresh cookie+session.
+- [x] Проверить rate-limit стратегии для login/invite/notify endpoints:
+  - [x] Добавлены runtime limiter-ы: login (IP), resend-invite (user/ip), appointment notify (user/ip).
+  - [x] 429 + `Retry-After` возвращаются middleware-ограничителем.
+- [x] Утвердить политику логирования и маскирования PII (email/phone/telegram):
+  - [x] HTTP access-лог переведен на безопасный формат без query-string (`req.path`), чтобы не логировать OAuth `code`/PII из URL.
+  - [ ] Маскирование PII в application/error/webhook логах и проверка выборкой реальных записей.
 
 ### Web
 
-- [ ] Прогнать role-based smoke (owner/admin/specialist/client) на staging.
-- [ ] Добавить UX-smoke на auth, invite onboarding, settings, notification logs.
-- [ ] Подготовить мониторинг фронта (ошибки рендера, API error rate, release markers).
+- [ ] Прогнать role-based smoke (owner/admin/specialist/client) на staging:
+  - [ ] Для каждой роли проверить доступ к разрешенным страницам/действиям.
+  - [ ] Для запрещенных действий убедиться в корректных 403/guard redirect.
+- [ ] Добавить UX-smoke на auth, invite onboarding, settings, notification logs:
+  - [ ] Проверить happy-path + невалидные сценарии (валидация, пустые состояния, recover после refresh/back).
+  - [ ] Проверить ключевые потоки в мобильном viewport.
+- [ ] Подготовить мониторинг фронта:
+  - [ ] Runtime JS errors + unhandled rejections.
+  - [ ] API error rate + release markers (версия/commit) для корреляции инцидентов.
 
 ### Bot
 
-- [ ] Гарантировать idempotency по `update_id` и защиту от гонок на пользователя.
-- [ ] Проверить post-deploy smoke: `/health`, `getWebhookInfo`, отправка тестового reminder.
+- [ ] Гарантировать idempotency по `update_id` и защиту от гонок на пользователя:
+  - [ ] Dedup по `update_id` с TTL и без повторного бизнес-эффекта.
+  - [ ] Последовательная обработка/локи для одного пользователя при конкурентных callback/update.
+- [ ] Проверить post-deploy smoke:
+  - [ ] `/health` (приложение + зависимости).
+  - [ ] `getWebhookInfo` (валидный webhook URL, без `last_error_message`, контролируемый `pending_update_count`).
+  - [ ] Отправка тестового reminder и контроль отсутствия дублей.
 
 ## P2 — после стабилизации
 

--- a/bot/PRODUCTION_READINESS_CHECKLIST.md
+++ b/bot/PRODUCTION_READINESS_CHECKLIST.md
@@ -4,8 +4,12 @@
 
 ## Webhook и state machine
 
-- [ ] Идемпотентность по `update_id` (без повторного бизнес-эффекта).
-- [ ] Защита от гонок callback/query для одного пользователя.
+- [x] Идемпотентность по `update_id` (без повторного бизнес-эффекта).
+  - [x] Dedup-хранилище `processed_updates` + skip дублей в webhook-роуте.
+  - [x] Повторная доставка update возвращает `duplicate: true` без повторного side-effect.
+- [x] Защита от гонок callback/query для одного пользователя.
+  - [x] Конкурентная обработка одного `update_id` блокируется до завершения запроса.
+  - [ ] Атомарные операции в БД на критичных шагах state machine.
 - [ ] Recovery состояния после рестартов (session restore + TTL).
 
 ## Наблюдаемость
@@ -13,12 +17,14 @@
 - [ ] Structured logs: `request_id`, `update_id`, `account_id`, `user_id`.
 - [ ] Метрики latency/error/notification-failed.
 - [ ] Алерты: 5xx, нет входящих updates, рост failed уведомлений.
+- [ ] Post-deploy smoke-дашборд на первые 60 минут после релиза.
 
 ## Безопасность
 
 - [ ] Надежный `WEBHOOK_SECRET` + ротация.
 - [ ] Rate-limit и anti-spam на webhook.
 - [ ] Маскирование PII (phone/email) в логах.
+- [ ] Проверка маскирования выборкой production-подобных webhook/event логов.
 
 ## База данных
 
@@ -30,9 +36,10 @@
 
 - [ ] E2E smoke: happy path, duplicate update, race on slot, cancel/reschedule.
 - [ ] CI: `typecheck`, `test`, миграции на чистой БД.
+- [ ] Ручной staging smoke после деплоя: `/health`, `getWebhookInfo`, `/start`, тестовый reminder.
 
 ## Railway
 
-- [ ] Проверить `APP_URL`, `, `WEBHOOK_SECRET`, `DATABASE_URL`.
+- [ ] Проверить `APP_URL`, `WEBHOOK_SECRET`, `DATABASE_URL`.
 - [ ] Post-deploy smoke: `/health` + `getWebhookInfo`.
 - [ ] Разнести `app` и `worker` при росте нагрузки.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -27,7 +27,11 @@ export const createApp = () => {
 
   app.disable('x-powered-by');
   app.use(helmet());
-  app.use(morgan('dev'));
+  morgan.token('safe-url', (req) => {
+    const rawUrl = req.url ?? '/';
+    return new URL(rawUrl, 'http://localhost').pathname;
+  });
+  app.use(morgan(':method :safe-url :status :response-time ms'));
   app.use(
     cors({
       credentials: true,

--- a/server/src/i18n/dictionaries.ts
+++ b/server/src/i18n/dictionaries.ts
@@ -3,6 +3,7 @@ export const dictionaries = {
     errors: {
       unauthorized: 'Unauthorized',
       tooManyLoginAttempts: 'Too many login attempts. Try again later.',
+      tooManyRequests: 'Too many requests. Try again later.',
       invalidPayloadSystemSettings: 'Invalid system settings payload',
       invalidPayloadUserSettings: 'Invalid user settings payload',
       invalidPayloadAccountSettings: 'Invalid account settings payload',
@@ -86,6 +87,7 @@ export const dictionaries = {
     errors: {
       unauthorized: 'Не авторизован',
       tooManyLoginAttempts: 'Слишком много попыток входа. Попробуйте позже.',
+      tooManyRequests: 'Слишком много запросов. Попробуйте позже.',
       invalidPayloadSystemSettings: 'Некорректный payload системных настроек',
       invalidPayloadUserSettings: 'Некорректный payload пользовательских настроек',
       invalidPayloadAccountSettings: 'Некорректный payload настроек аккаунта',

--- a/server/src/middlewares/requestRateLimit.ts
+++ b/server/src/middlewares/requestRateLimit.ts
@@ -1,0 +1,49 @@
+import type { NextFunction, Request, Response } from 'express';
+import { t } from '../i18n/index.js';
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+type RateLimitInput = {
+  keyPrefix: string;
+  maxRequests: number;
+  windowMs: number;
+};
+
+const now = () => Date.now();
+
+function getBucket(key: string, windowMs: number): Bucket {
+  const current = buckets.get(key);
+  const ts = now();
+
+  if (!current || current.resetAt <= ts) {
+    const fresh = { count: 0, resetAt: ts + windowMs };
+    buckets.set(key, fresh);
+    return fresh;
+  }
+
+  return current;
+}
+
+function buildRateLimitKey(req: Request, keyPrefix: string) {
+  const userId = (req as Request & { user?: { id?: string } }).user?.id;
+  const ip = req.ip ?? 'unknown';
+  return `${keyPrefix}:${userId ?? ip}`;
+}
+
+export function createRequestRateLimit(input: RateLimitInput) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const key = buildRateLimitKey(req, input.keyPrefix);
+    const bucket = getBucket(key, input.windowMs);
+
+    if (bucket.count >= input.maxRequests) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((bucket.resetAt - now()) / 1000));
+      res.setHeader('Retry-After', String(retryAfterSeconds));
+      return res.status(429).json({ message: t(req, 'tooManyRequests') });
+    }
+
+    bucket.count += 1;
+    return next();
+  };
+}

--- a/server/src/routes/appointmentRoutes.ts
+++ b/server/src/routes/appointmentRoutes.ts
@@ -16,8 +16,10 @@ import {
   updateAppointmentForActor,
 } from '../services/appointmentService.js';
 import { formatZodError } from '../utils/validation.js';
+import { createRequestRateLimit } from '../middlewares/requestRateLimit.js';
 
 export const appointmentRoutes = Router();
+const notifyRateLimit = createRequestRateLimit({ keyPrefix: 'appointment-notify', maxRequests: 20, windowMs: 60_000 });
 type AppointmentAuditActionFilter = 'cancel' | 'reschedule' | 'mark-paid' | 'notify';
 const APPOINTMENT_AUDIT_ACTIONS = new Set<AppointmentAuditActionFilter>(['cancel', 'reschedule', 'mark-paid', 'notify']);
 
@@ -233,7 +235,7 @@ appointmentRoutes.post('/:id/mark-paid', async (req, res) => {
   }
 });
 
-appointmentRoutes.post('/:id/notify', async (req, res) => {
+appointmentRoutes.post('/:id/notify', notifyRateLimit, async (req, res) => {
   const actor = (req as unknown as AuthedRequest).user;
   const appointmentId = Number(req.params.id);
 

--- a/server/src/routes/userManagementRoutes.ts
+++ b/server/src/routes/userManagementRoutes.ts
@@ -10,8 +10,10 @@ import {
   updateManagedUser,
 } from '../services/userManagementService.js';
 import { formatZodError } from '../utils/validation.js';
+import { createRequestRateLimit } from '../middlewares/requestRateLimit.js';
 
 export const userManagementRoutes = Router();
+const resendInviteRateLimit = createRequestRateLimit({ keyPrefix: 'resend-invite', maxRequests: 10, windowMs: 60_000 });
 
 userManagementRoutes.use(requireAccessToken);
 
@@ -111,7 +113,7 @@ userManagementRoutes.delete('/:id', async (req, res) => {
   }
 });
 
-userManagementRoutes.post('/:id/resend-invite', async (req, res) => {
+userManagementRoutes.post('/:id/resend-invite', resendInviteRateLimit, async (req, res) => {
   const actor = (req as unknown as AuthedRequest).user;
   const userId = Number(req.params.id);
   if (!Number.isInteger(userId) || userId <= 0) {

--- a/server/src/services/googleOAuthService.ts
+++ b/server/src/services/googleOAuthService.ts
@@ -33,11 +33,31 @@ const resolveTokenExpiresAt = (expiresIn: number) => {
   return new Date(Date.now() + expiresIn * 1000);
 };
 
+
+const hasValidRedirectUri = () => {
+  try {
+    const redirectUrl = new URL(env.GOOGLE_OAUTH_REDIRECT_URI);
+    const apiBaseUrl = new URL(env.API_BASE_URL);
+
+    const isExpectedPath = redirectUrl.pathname === '/api/integrations/google/oauth/callback';
+    const isSameOriginAsApi = redirectUrl.origin === apiBaseUrl.origin;
+    const isAllowedProtocol = env.PORT === 3003
+      ? redirectUrl.protocol === 'http:' || redirectUrl.protocol === 'https:'
+      : redirectUrl.protocol === 'https:';
+
+    return isExpectedPath && isSameOriginAsApi && isAllowedProtocol;
+  } catch {
+    return false;
+  }
+};
+
+
 const isGoogleOAuthConfigured = () => {
   return Boolean(
     env.GOOGLE_OAUTH_CLIENT_ID &&
       env.GOOGLE_OAUTH_CLIENT_SECRET &&
-      env.GOOGLE_OAUTH_REDIRECT_URI
+      env.GOOGLE_OAUTH_REDIRECT_URI &&
+      hasValidRedirectUri()
   );
 };
 


### PR DESCRIPTION
### Motivation
- Reduce risk of leaking sensitive query parameters (OAuth codes/PII) in access logs and add basic rate limits to protect endpoints from abuse. 
- Ensure Google OAuth redirect URI is validated at runtime to prevent misconfiguration or redirect-based attacks. 
- Surface a localized error for rate-limited responses and update production readiness checklists to reflect runtime/security changes.

### Description
- Add a new middleware `createRequestRateLimit` in `server/src/middlewares/requestRateLimit.ts` that implements an in-memory bucketed rate limiter and sets `Retry-After` on 429 responses. 
- Apply the rate limiter to `POST /appointments/:id/notify` and `POST /user-management/:id/resend-invite` by creating `notifyRateLimit` and `resendInviteRateLimit` in route files. 
- Replace verbose `morgan('dev')` logging with a custom token `safe-url` and formatter in `server/src/app.ts` to log only the request path (no query string). 
- Add `tooManyRequests` translation key to `server/src/i18n/dictionaries.ts` for `en` and `ru`. 
- Add `hasValidRedirectUri` validation in `server/src/services/googleOAuthService.ts` and require it in `isGoogleOAuthConfigured` to check path, origin, and protocol sanity for `GOOGLE_OAUTH_REDIRECT_URI`. 
- Update `PRODUCTION_READINESS_CHECKLIST.md` and `bot/PRODUCTION_READINESS_CHECKLIST.md` to reflect completed items and add new runtime/security/observability checks.

### Testing
- Ran `typecheck` and it completed successfully. 
- Ran `test` (unit/integration suite) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e37154c88333a10af6bec2246bf2)