### PR TITLE
Add TimezoneSelect and hardcoded IANA timezone list; use in settings and appointment forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ scheduletm/
 
 - Auth: register/login/refresh/logout + 4-digit OTP email verification (with resend and auto-confirm UX) + invite onboarding page `/verify-email` for creating account from invitation.
 - Роли: `owner` / `admin` / `specialist` / `client` (RBAC policy централизована в server).
-- Settings: system + account + user settings, plus user integrations. In `User settings`, users can edit required `firstName`/`lastName`, optional `phone` and optional `telegramUsername`, along with timezone/locale and integration fields. `Default meeting duration` in system/account settings is selected from dropdown options 30–90 minutes (step 10).
+- Settings: system + account + user settings, plus user integrations. In `User settings`, users can edit required `firstName`/`lastName`, optional `phone` and optional `telegramUsername`, along with timezone/locale and integration fields. Timezone fields in Web use a fixed hardcoded IANA list (same list for appointments, account and user settings). `Default meeting duration` in system/account settings is selected from dropdown options 30–90 minutes (step 10).
 - Integrations: Google OAuth start/callback, Telegram bot token в user integrations.
 - Notifications: appointment notify flow with channel fallback (Telegram -> Email) + retry/backoff pipeline in scheduler (`pending/retry/processing/sent/failed`, `next_retry_at`, `max_attempts`, idempotent key per `appointment_id + type + channel`).
 - Notification logs page (`/notification-logs`) with role-aware access (`owner/admin/specialist`), filters and human-readable fields (specialist/client names, message, Telegram, email), including manual resend for failed deliveries.

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -18,6 +18,7 @@ import { AppRhfPasswordField } from '../shared/ui/AppRhfPasswordField';
 import { AppRhfPhoneField } from '../shared/ui/AppRhfPhoneField';
 import { AppRhfTextField } from '../shared/ui/AppRhfTextField';
 import { AppTab, AppTabs } from '../shared/ui/AppTabs';
+import { TimezoneSelect } from './TimezoneSelect';
 
 type SettingsCardCopy = {
   systemTab: string;
@@ -312,9 +313,19 @@ export function SettingsCard({
         <AppForm component="form" onSubmit={handleAccountSubmit(onSaveAccount)}>
           <Typography variant="h5">{copy.accountTitle}</Typography>
 
-          <Controller name="timezone" control={accountControl} render={({ field }: any) => (
-            <AppRhfTextField field={field} label={copy.timezone} />
-          )} />
+          <Controller
+            name="timezone"
+            control={accountControl}
+            render={({ field }: any) => (
+              <TimezoneSelect
+                label={copy.timezone}
+                labelId="account-timezone-label"
+                value={field.value}
+                onChange={field.onChange}
+                margin="normal"
+              />
+            )}
+          />
 
           <Controller name="locale" control={accountControl} render={({ field }: any) => (
             <AppRhfTextField field={field} label={copy.locale} />
@@ -559,7 +570,13 @@ export function SettingsCard({
             name="timezone"
             control={userControl}
             render={({ field }: any) => (
-              <AppRhfTextField field={field} label={copy.timezone} />
+              <TimezoneSelect
+                label={copy.timezone}
+                labelId="user-timezone-label"
+                value={field.value}
+                onChange={field.onChange}
+                margin="normal"
+              />
             )}
           />
 

--- a/web/src/components/TimezoneSelect.tsx
+++ b/web/src/components/TimezoneSelect.tsx
@@ -1,0 +1,37 @@
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+
+import { AVAILABLE_TIMEZONES } from './appointments/appointmentsUtils';
+
+type TimezoneSelectProps = {
+  label: string;
+  labelId: string;
+  value: string;
+  onChange: (next: string) => void;
+  fullWidth?: boolean;
+  margin?: 'none' | 'dense' | 'normal';
+};
+
+export function TimezoneSelect({
+  label,
+  labelId,
+  value,
+  onChange,
+  fullWidth = true,
+  margin = 'none',
+}: TimezoneSelectProps) {
+  return (
+    <FormControl fullWidth={fullWidth} margin={margin}>
+      <InputLabel id={labelId}>{label}</InputLabel>
+      <Select
+        labelId={labelId}
+        label={label}
+        value={value || 'UTC'}
+        onChange={(event) => onChange(String(event.target.value))}
+      >
+        {AVAILABLE_TIMEZONES.map((timeZone) => (
+          <MenuItem key={timeZone} value={timeZone}>{timeZone}</MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -21,7 +21,6 @@ import { AppRhfPhoneField } from '../../shared/ui/AppRhfPhoneField';
 import { isValidPhoneValue } from '../../shared/ui/phoneUtils';
 import { AppRhfTextField } from '../../shared/ui/AppRhfTextField';
 import {
-  AVAILABLE_TIMEZONES,
   BROWSER_TIMEZONE,
   buildStartEndIso,
   composeFormDateTime,
@@ -34,6 +33,7 @@ import {
 } from './appointmentsUtils';
 
 import type { TranslationKey } from '../../shared/i18n/dictionaries';
+import { TimezoneSelect } from '../TimezoneSelect';
 
 type AppointmentFormState = EditFormState & {
   clientId: string;
@@ -263,19 +263,12 @@ export function AppointmentFormDialog({
             </Typography>
           </Stack>
           <Collapse in={showTimezoneSelect}>
-            <FormControl fullWidth>
-              <InputLabel id="appointment-timezone-label">{t('appointments.timezone')}</InputLabel>
-              <Select
-                labelId="appointment-timezone-label"
-                label={t('appointments.timezone')}
-                value={formTimeZone}
-                onChange={(event) => setFormTimeZone(String(event.target.value))}
-              >
-                {AVAILABLE_TIMEZONES.map((timeZone) => (
-                  <MenuItem key={timeZone} value={timeZone}>{timeZone}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <TimezoneSelect
+              label={t('appointments.timezone')}
+              labelId="appointment-timezone-label"
+              value={formTimeZone}
+              onChange={setFormTimeZone}
+            />
           </Collapse>
           <Box sx={createResponsiveFieldGridSx(2)}>
             <Controller

--- a/web/src/components/appointments/appointmentsUtils.ts
+++ b/web/src/components/appointments/appointmentsUtils.ts
@@ -17,10 +17,24 @@ export const DEFAULT_SLOT_STEP_MIN = 30;
 export const SLOT_ROWS = Array.from({ length: 48 }, (_, index) => index * 30);
 export const BROWSER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 
-const FALLBACK_TIMEZONES = ['UTC', BROWSER_TIMEZONE];
-export const AVAILABLE_TIMEZONES = typeof Intl.supportedValuesOf === 'function'
-  ? Intl.supportedValuesOf('timeZone')
-  : FALLBACK_TIMEZONES;
+export const AVAILABLE_TIMEZONES = [
+  'UTC',
+  'Europe/London',
+  'Europe/Berlin',
+  'Europe/Moscow',
+  'Asia/Dubai',
+  'Asia/Tbilisi',
+  'Asia/Almaty',
+  'Asia/Bangkok',
+  'Asia/Singapore',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Sao_Paulo',
+];
 
 export function getDateTimeParts(date: Date, timeZone: string) {
   const parts = new Intl.DateTimeFormat('en-CA', {


### PR DESCRIPTION
### Motivation

- Provide a consistent timezone selection UI across the web app and make timezone options predictable across browsers by using a fixed IANA list.

### Description

- Add a new `TimezoneSelect` component that renders a labeled timezone `Select` using a shared `AVAILABLE_TIMEZONES` list.
- Replace inline timezone `Select` controls in `SettingsCard.tsx` and `AppointmentFormDialog.tsx` with the new `TimezoneSelect` component.
- Replace runtime detection via `Intl.supportedValuesOf('timeZone')` with a curated hardcoded `AVAILABLE_TIMEZONES` array in `appointmentsUtils.ts` and update imports accordingly.
- Update `README.md` to document that timezone fields in Web use a fixed hardcoded IANA list for appointments, account and user settings.

### Testing

- Ran TypeScript type check and frontend build (`yarn build`), and the build completed successfully.
- Ran frontend unit tests (`yarn test`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2164682948333bb178181f890f3e9)