### PR TITLE
Add Playwright auth UI tests, UI coverage audit, and update README

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -108,8 +108,10 @@ VITE_API_URL=http://localhost:3003
 - покрывают owner-flow для `Users` (create/edit/deactivate), переход owner в `/error-logs`, logout из profile menu;
 - проверяют role-aware доступность пунктов меню и видимость табов `System settings`/`Account settings` на странице настроек;
 - проверяют доступ к страницам по прямому URL и access denied состояния (owner/admin/client) для `/specialists`, `/notification-logs`, `/error-logs`.
+- покрывают публичные auth-экраны: переключение `/login` ↔ `/register`, а также invalid-состояния `/invite/accept` и `/verify-email` без token/email.
+- отдельно нужно расширить покрытие **негативных UI-сценариев**: невалидные формы, серверные ошибки, access denied действия, просроченные/некорректные токены, пустые и error состояния страниц.
 
-Структура UI e2e разнесена по файлам: `users.ui.e2e.spec.mjs`, `navigation.ui.e2e.spec.mjs`, `settings.ui.e2e.spec.mjs`, `session.ui.e2e.spec.mjs`, `access-control.ui.e2e.spec.mjs`; общие auth-хелперы вынесены в `ui/helpers/auth.mjs`.
+Структура UI e2e разнесена по файлам: `auth.ui.e2e.spec.mjs`, `users.ui.e2e.spec.mjs`, `navigation.ui.e2e.spec.mjs`, `settings.ui.e2e.spec.mjs`, `session.ui.e2e.spec.mjs`, `access-control.ui.e2e.spec.mjs`; общие auth-хелперы вынесены в `ui/helpers/auth.mjs`.
 
 
 > Для запуска используется `@playwright/test` (единый раннер/DSL), чтобы избежать конфликтов вида `test.describe() called here` при смешивании разных Playwright пакетов.

--- a/web/tests/e2e/UI_COVERAGE_AUDIT.md
+++ b/web/tests/e2e/UI_COVERAGE_AUDIT.md
@@ -1,0 +1,88 @@
+# UI Integration Coverage Audit (as of 2026-04-29)
+
+## Current coverage (Playwright UI e2e)
+
+Covered by real browser integration tests in `web/tests/e2e/ui/*.spec.mjs`:
+
+- Navigation and role-aware menu visibility for `owner/admin/specialist/client`.
+- Access control for direct URL opens (`/specialists`, `/notification-logs`, `/error-logs`).
+- Session logout from profile menu.
+- Public auth routes: `/login` ↔ `/register` screen switch; invalid invite states on `/invite/accept` and `/verify-email` without token/email.
+- Settings tabs visibility by role (`System settings`, `Account settings`).
+- Users flow for owner: create → edit → deactivate.
+
+## Current gaps (high priority)
+
+1. **Auth UI flow is only partially covered via browser interactions**
+   - Covered: screen switching `/login` ↔ `/register`, invalid invite states for `/invite/accept` and `/verify-email` without token/email.
+   - Missing: form submission/validation errors for `/login`, full `/register` happy/negative flows, OTP UX (autofocus/paste/resend cooldown).
+
+2. **Appointments UI workflows are not covered end-to-end**
+   - No UI e2e that clicks through create/edit/cancel/reschedule/mark-paid/notify in calendar.
+   - No UI e2e for late-cancel policy UX (refund vs no-refund confirmation text in actual UI).
+   - No UI e2e for role-based filter set visibility on Appointments page.
+
+3. **Specialists management UI behavior is not covered**
+   - Missing owner/admin positive CRUD flows for specialists.
+   - Missing specialist/client negative-path checks in specialist management interactions (not only page-level denial).
+
+4. **Settings form behavior is mostly uncovered**
+   - Only tab visibility is checked.
+   - No save/update tests for user/system/account/notification/specialist policy tabs.
+   - No validation and optimistic/pessimistic UI feedback checks for settings forms.
+
+5. **Notification logs page functionality is not covered**
+   - No UI e2e for filters (`account/specialist/user`) and table rendering.
+   - No UI e2e for retry action availability by status and retry execution result.
+
+6. **Users RBAC positive/negative matrix is incomplete**
+   - Positive CRUD is only verified for owner.
+   - No explicit admin/specialist/client create/edit/deactivate permission matrix at action level.
+
+7. **Localization/theme UI checks are not covered**
+   - No UI e2e for ru/en switching and key user-visible strings.
+   - No UI e2e for theme mode/palette changes persistence.
+
+## Medium-priority gaps
+
+- Error logs page: only owner navigation/admin deny covered; missing rendering/filters/details checks.
+- Router deep-link behavior for protected pages under expired session.
+- Cross-page smoke for empty/loading/error UI states.
+
+## Recommended next test additions (order)
+
+1. `auth.ui.e2e.spec.mjs`
+   - login success/failure + validation
+   - invite accept + verify-email OTP flow
+
+2. `appointments.ui.e2e.spec.mjs`
+   - create/edit/cancel/reschedule/mark-paid/notify
+   - late-cancel refund/no-refund messaging
+   - role-based filters visibility matrix
+
+3. `settings-forms.ui.e2e.spec.mjs`
+   - save flows for key settings tabs
+   - validation and toast/error checks
+
+4. `notification-logs.ui.e2e.spec.mjs`
+   - filters + retry action by status
+
+5. Extend existing suites
+   - `users.ui.e2e.spec.mjs`: admin/specialist/client action-level permissions
+   - `access-control.ui.e2e.spec.mjs`: deeper assertions for denied actions, not only page text
+
+## Notes on existing contract/smoke tests
+
+The fast `node:test` suites (`web.integration.e2e.test.mjs`, `smoke.e2e.test.mjs`) validate source-level contracts and route/API usage patterns, but they do not replace browser UI interaction coverage for form/input/click/state behavior.
+
+## Negative scenarios coverage to add
+
+Add explicit browser-level negative-path checks across key modules:
+
+- Auth: invalid credentials, weak password, password mismatch, expired/invalid OTP, resend failures.
+- Appointments: invalid reschedule slot, cancel/mark-paid/notify API failures, forbidden actions by role.
+- Settings: validation errors, failed save requests, disabled actions for non-permitted roles.
+- Specialists/Users: forbidden CRUD actions, backend validation errors, conflict errors.
+- Notification logs: retry failures and unavailable retry action for non-retriable statuses.
+
+These scenarios should be added as separate test cases (or dedicated `*.negative.ui.e2e.spec.mjs` suites) to keep intent and failure diagnostics clear.

--- a/web/tests/e2e/ui/auth.ui.e2e.spec.mjs
+++ b/web/tests/e2e/ui/auth.ui.e2e.spec.mjs
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('web ui e2e: auth public flows', () => {
+  test('user can switch between login and register screens', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+
+    await page.getByRole('button', { name: /Register/ }).click();
+    await expect(page).toHaveURL(/\/register$/);
+    await expect(page.getByRole('heading', { name: 'Register' })).toBeVisible();
+
+    await page.getByRole('button', { name: /Sign in/ }).click();
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+  });
+
+  test('invite accept without token/email shows invalid invite state', async ({ page }) => {
+    await page.goto('/invite/accept');
+    await expect(page).toHaveURL(/\/invite\/accept$/);
+    await expect(page.getByText('Invitation is invalid')).toBeVisible();
+    await expect(page.getByText('This link has expired or has already been used.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Request a new invitation' })).toBeDisabled();
+  });
+
+  test('verify-email route without token/email shows invalid invite state', async ({ page }) => {
+    await page.goto('/verify-email');
+    await expect(page).toHaveURL(/\/verify-email$/);
+    await expect(page.getByText('Invitation is invalid')).toBeVisible();
+    await expect(page.getByText('This link has expired or has already been used.')).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve end-to-end browser coverage for public authentication flows and capture current UI test gaps in a single audit document.
- Surface missing negative-path UI scenarios and register the new auth test suite in project documentation.

### Description
- Add a new Playwright UI e2e test file `web/tests/e2e/ui/auth.ui.e2e.spec.mjs` that covers `/login` ↔ `/register` switching and invalid states for `/invite/accept` and `/verify-email` without token/email.
- Introduce `web/tests/e2e/UI_COVERAGE_AUDIT.md` documenting current Playwright UI coverage, priority gaps, and recommended next test additions.
- Update `web/README.md` to mention public auth screens coverage and include `auth.ui.e2e.spec.mjs` in the UI e2e structure list.

### Testing
- No automated test runs were recorded in this rollout; the change adds Playwright tests which can be executed with `npx playwright test web/tests/e2e/ui/auth.ui.e2e.spec.mjs` and will be picked up by the CI test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f226bdf9dc83338ca6be9472ae322e)