### PR TITLE
feat(web): auto-detect phone country from browser locale

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -12,6 +12,7 @@ React SPA для owner/admin/specialist/client.
 - Основные разделы: `/appointments`, `/specialists`, `/users`, `/settings`, `/notification-logs`.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.
+- Phone fields with country selector auto-detect default country from browser locale and can still be changed manually.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
 - Appointments page includes role-based top filters:
   - owner: `Account`, `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;

--- a/web/src/shared/ui/AppRhfPhoneField.tsx
+++ b/web/src/shared/ui/AppRhfPhoneField.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState, type ChangeEvent } from 'react';
 import { FormControl, InputLabel, MenuItem, Select, Stack, TextField, type TextFieldProps } from '@mui/material';
 import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
 import { useI18n } from '../i18n/I18nContext';
-import { getCountryByPhone, getCountryByIso, DEFAULT_COUNTRY, PHONE_COUNTRIES, onlyDigits, parseLocalDigits } from './phoneUtils';
+import { getCountryByLocale, getCountryByPhone, getCountryByIso, DEFAULT_COUNTRY, PHONE_COUNTRIES, onlyDigits, parseLocalDigits } from './phoneUtils';
 
 type AppRhfPhoneFieldProps<TFieldValues extends FieldValues> = Omit<
   TextFieldProps,
@@ -72,6 +72,14 @@ export function AppRhfPhoneField<TFieldValues extends FieldValues>({
   const { t } = useI18n();
   const [manualCountryIso, setManualCountryIso] = useState<string | null>(null);
 
+  const localeCountryIso = useMemo(() => {
+    if (typeof navigator === 'undefined') {
+      return null;
+    }
+
+    return getCountryByLocale(navigator.language)?.isoCode ?? null;
+  }, []);
+
   const detectedCountry = useMemo(
     () => getCountryByPhone(String(field.value ?? '')),
     [field.value],
@@ -79,7 +87,7 @@ export function AppRhfPhoneField<TFieldValues extends FieldValues>({
 
   const selectedCountryIso =
     manualCountryIso ??
-    (field.value ? detectedCountry.isoCode : DEFAULT_COUNTRY.isoCode);
+    (field.value ? detectedCountry.isoCode : (localeCountryIso ?? DEFAULT_COUNTRY.isoCode));
 
   const selectedCountry = getCountryByIso(selectedCountryIso);
 

--- a/web/src/shared/ui/phoneUtils.ts
+++ b/web/src/shared/ui/phoneUtils.ts
@@ -79,6 +79,23 @@ export const parseLocalDigits = (value: string, country: PhoneCountry) => {
   return fullDigits.slice(0, country.localDigitsCount);
 };
 
+
+export const getCountryByLocale = (locale: string | undefined) => {
+  if (!locale) {
+    return null;
+  }
+
+  const normalizedLocale = locale.replace('_', '-');
+  const localeParts = normalizedLocale.split('-');
+  const maybeIsoCode = localeParts.at(-1)?.toUpperCase();
+
+  if (!maybeIsoCode || maybeIsoCode.length !== 2) {
+    return null;
+  }
+
+  return PHONE_COUNTRIES.find((country) => country.isoCode === maybeIsoCode) ?? null;
+};
+
 export const getCountryByPhone = (value: string) => {
   const digits = onlyDigits(value.startsWith('+') ? value.slice(1) : value);
 


### PR DESCRIPTION
### Motivation
- Improve phone input UX by defaulting the country code to the user’s browser locale when the phone field is initially empty. 
- Preserve existing behavior where an entered number dictates country detection and manual selection always has priority.

### Description
- Added `getCountryByLocale` to `web/src/shared/ui/phoneUtils.ts` to map `navigator.language` locale to a `PHONE_COUNTRIES` entry. 
- Updated `web/src/shared/ui/AppRhfPhoneField.tsx` to use `navigator.language` (via `getCountryByLocale`) as the default country when the field is empty and the user hasn't chosen a country manually. 
- Kept existing number-based detection (`getCountryByPhone`) and manual country selection logic unchanged. 
- Updated `web/README.md` to document the new phone field behavior and applied a small lint fix in `phoneUtils.ts` (`length !== 2`).

### Testing
- Ran `npm run -w @scheduletm/web lint` and the lint check passed successfully. 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f304c293908333b38c524048b4d9d0)