### PR TITLE
Use AppRhfPasswordField for password settings inputs

### DIFF
--- a/web/src/components/settings-tabs/PasswordSettingsTab.tsx
+++ b/web/src/components/settings-tabs/PasswordSettingsTab.tsx
@@ -3,6 +3,7 @@ import { Stack, Typography } from '@mui/material';
 import type { SettingsCardCopy } from '../SettingsCard.types';
 import { AppButton } from '../../shared/ui/AppButton';
 import { AppForm } from '../../shared/ui/AppForm';
+import { AppRhfPasswordField } from '../../shared/ui/AppRhfPasswordField';
 import { AppTextField } from '../../shared/ui/AppTextField';
 
 type Props = {
@@ -36,13 +37,30 @@ export function PasswordSettingsTab({
   onRequestOtp,
   onConfirmOtp,
 }: Props) {
+  const passwordFieldBase = {
+    onBlur: () => undefined,
+    ref: () => undefined,
+  };
+
   return (
     <AppForm component="form" onSubmit={(event) => event.preventDefault()}>
       <Typography variant="h5">{copy.passwordTitle}</Typography>
       <Stack spacing={2}>
-        <AppTextField value={currentPassword} onChange={(event) => onCurrentPasswordChange(event.target.value)} label={copy.currentPassword} type="password" />
-        <AppTextField value={newPassword} onChange={(event) => onNewPasswordChange(event.target.value)} label={copy.newPassword} type="password" />
-        <AppTextField value={confirmPassword} onChange={(event) => onConfirmPasswordChange(event.target.value)} label={copy.confirmPassword} type="password" />
+        <AppRhfPasswordField
+          field={{ ...passwordFieldBase, name: 'currentPassword', value: currentPassword, onChange: onCurrentPasswordChange }}
+          label={copy.currentPassword}
+          autoComplete="current-password"
+        />
+        <AppRhfPasswordField
+          field={{ ...passwordFieldBase, name: 'newPassword', value: newPassword, onChange: onNewPasswordChange }}
+          label={copy.newPassword}
+          autoComplete="new-password"
+        />
+        <AppRhfPasswordField
+          field={{ ...passwordFieldBase, name: 'confirmPassword', value: confirmPassword, onChange: onConfirmPasswordChange }}
+          label={copy.confirmPassword}
+          autoComplete="new-password-confirm"
+        />
         {passwordStep === 'otp' && (
           <AppTextField
             value={otpCode}


### PR DESCRIPTION
### Motivation
- Replace plain password inputs with the RHF-aware password component to provide consistent behavior (visibility toggle, RHF integration) and enable proper browser autocomplete for each password field.

### Description
- Imported `AppRhfPasswordField` into `web/src/components/settings-tabs/PasswordSettingsTab.tsx` and replaced three `AppTextField` password inputs with it.
- Each password field now receives a `field` adapter object with `name`, `value`, and `onChange` to work with the existing state-based handlers.
- Set distinct `autoComplete` attributes for the fields: `current-password`, `new-password`, and `new-password-confirm`.
- Added a minimal `passwordFieldBase` shim to satisfy the `field` shape required by `AppRhfPasswordField` and left the OTP input unchanged.

### Testing
- Ran the linter with `npm run lint -- src/components/settings-tabs/PasswordSettingsTab.tsx` and it completed successfully.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3072aae088333b44e75e0d1d897a1)