### PR TITLE
Fix password field autocomplete forwarding

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -13,6 +13,7 @@ React SPA для owner/admin/specialist/client.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.
 - Phone fields with country selector auto-detect default country from browser locale and can still be changed manually.
+- Password fields support explicit `autocomplete` attributes (e.g. `current-password`, `new-password`) for correct browser autofill behavior.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
 - Appointments page includes role-based top filters:
   - owner: `Account`, `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;

--- a/web/src/shared/ui/AppRhfPasswordField.tsx
+++ b/web/src/shared/ui/AppRhfPasswordField.tsx
@@ -22,6 +22,7 @@ export function AppRhfPasswordField<TFieldValues extends FieldValues>({
   const { t } = useI18n();
   const [showPassword, setShowPassword] = useState(false);
   const inputSlotProps = (props.slotProps?.input ?? {}) as Record<string, unknown>;
+  const htmlInputSlotProps = (props.slotProps?.htmlInput ?? {}) as Record<string, unknown>;
 
   return (
     <AppRhfTextField
@@ -31,6 +32,10 @@ export function AppRhfPasswordField<TFieldValues extends FieldValues>({
       type={showPassword ? 'text' : 'password'}
       slotProps={{
         ...props.slotProps,
+        htmlInput: {
+          ...htmlInputSlotProps,
+          autoComplete: props.autoComplete ?? htmlInputSlotProps.autoComplete,
+        },
         input: {
           ...inputSlotProps,
           endAdornment: (


### PR DESCRIPTION
### Motivation
- Browser autofill hints were not reliably applied to password inputs because the `autoComplete` prop wasn't forwarded to the underlying HTML input slot, causing `autocomplete` values like `current-password`/`new-password` to be ignored.

### Description
- Forward `autoComplete` into `slotProps.htmlInput` in `AppRhfPasswordField` while preserving existing `htmlInput` slot props so browser autofill hints reach the real `<input>` element (`web/src/shared/ui/AppRhfPasswordField.tsx`).
- Leave existing input adornment and show/hide-password logic unchanged.
- Add a short note about password `autocomplete` support to `web/README.md`.

### Testing
- Ran linting with `npm run -w @scheduletm/web lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30958bf98833388f1f2202af1c03a)