### PR TITLE
Introduce AppRhfSecretKeyField for token inputs and simplify password field

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -13,6 +13,7 @@ React SPA для owner/admin/specialist/client.
 - Role-aware UI (owner/admin/specialist/client).
 - i18n (`ru/en`), theme mode, palette variants.
 - Phone fields with country selector auto-detect default country from browser locale and can still be changed manually.
+- `AppRhfPasswordField` is used for real password inputs with native browser autofill hints (`current-password`, `new-password`), while secrets/tokens use dedicated `AppRhfSecretKeyField` with manual show/hide toggle and custom masking in `type="text"` mode.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
 - Appointments page includes role-based top filters:
   - owner: `Account`, `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;

--- a/web/src/components/settings-tabs/UserSettingsTab.tsx
+++ b/web/src/components/settings-tabs/UserSettingsTab.tsx
@@ -6,7 +6,7 @@ import type { SettingsCardCopy } from '../SettingsCard.types';
 import { AppButton } from '../../shared/ui/AppButton';
 import { AppForm } from '../../shared/ui/AppForm';
 import { AppIcons } from '../../shared/ui/AppIcons';
-import { AppRhfPasswordField } from '../../shared/ui/AppRhfPasswordField';
+import { AppRhfSecretKeyField } from '../../shared/ui/AppRhfSecretKeyField';
 import { AppRhfPhoneField } from '../../shared/ui/AppRhfPhoneField';
 import { AppRhfTextField } from '../../shared/ui/AppRhfTextField';
 import { TimezoneSelect } from '../TimezoneSelect';
@@ -100,7 +100,7 @@ export function UserSettingsTab({
         name="telegramBotToken"
         control={control}
         render={({ field }: any) => (
-          <AppRhfPasswordField field={field} label={copy.telegramBotToken} autoComplete="telegram-bot-token" />
+          <AppRhfSecretKeyField field={field} label={copy.telegramBotToken} autoComplete="off" />
         )}
       />
 

--- a/web/src/shared/ui/AppRhfPasswordField.tsx
+++ b/web/src/shared/ui/AppRhfPasswordField.tsx
@@ -1,9 +1,5 @@
-import VisibilityOffRoundedIcon from '@mui/icons-material/VisibilityOffRounded';
-import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
-import { IconButton, InputAdornment, type TextFieldProps } from '@mui/material';
-import { useState } from 'react';
+import type { TextFieldProps } from '@mui/material';
 import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
-import { useI18n } from '../i18n/I18nContext';
 import { AppRhfTextField } from './AppRhfTextField';
 
 type AppRhfPasswordFieldProps<TFieldValues extends FieldValues> = Omit<
@@ -19,36 +15,12 @@ export function AppRhfPasswordField<TFieldValues extends FieldValues>({
   onValueChange,
   ...props
 }: AppRhfPasswordFieldProps<TFieldValues>) {
-  const { t } = useI18n();
-  const [showPassword, setShowPassword] = useState(false);
-  const inputSlotProps = (props.slotProps?.input ?? {}) as Record<string, unknown>;
-
   return (
     <AppRhfTextField
       {...props}
       field={field}
       onValueChange={onValueChange}
-      type={showPassword ? 'text' : 'password'}
-      slotProps={{
-        ...props.slotProps,
-        input: {
-          ...inputSlotProps,
-          endAdornment: (
-            <>
-              {inputSlotProps.endAdornment}
-              <InputAdornment position="end">
-                <IconButton
-                  edge="end"
-                  onClick={() => setShowPassword((prev) => !prev)}
-                  aria-label={t('auth.togglePasswordVisibility')}
-                >
-                  {showPassword ? <VisibilityOffRoundedIcon /> : <VisibilityRoundedIcon />}
-                </IconButton>
-              </InputAdornment>
-            </>
-          ),
-        },
-      }}
+      type="password"
     />
   );
 }

--- a/web/src/shared/ui/AppRhfSecretKeyField.tsx
+++ b/web/src/shared/ui/AppRhfSecretKeyField.tsx
@@ -1,0 +1,63 @@
+import VisibilityOffRoundedIcon from '@mui/icons-material/VisibilityOffRounded';
+import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
+import { IconButton, InputAdornment, type TextFieldProps } from '@mui/material';
+import { useState } from 'react';
+import type { ControllerRenderProps, FieldValues, Path } from 'react-hook-form';
+import { useI18n } from '../i18n/I18nContext';
+import { AppRhfTextField } from './AppRhfTextField';
+
+type AppRhfSecretKeyFieldProps<TFieldValues extends FieldValues> = Omit<
+  TextFieldProps,
+  'name' | 'value' | 'onBlur' | 'onChange' | 'inputRef' | 'type'
+> & {
+  field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>;
+  onValueChange?: (value: string) => void;
+};
+
+export function AppRhfSecretKeyField<TFieldValues extends FieldValues>({
+  field,
+  onValueChange,
+  ...props
+}: AppRhfSecretKeyFieldProps<TFieldValues>) {
+  const { t } = useI18n();
+  const [isVisible, setIsVisible] = useState(false);
+  const inputSlotProps = (props.slotProps?.input ?? {}) as Record<string, unknown>;
+  const htmlInputSlotProps = (props.slotProps?.htmlInput ?? {}) as Record<string, unknown>;
+  const htmlInputStyle = (htmlInputSlotProps.style ?? {}) as Record<string, unknown>;
+
+  return (
+    <AppRhfTextField
+      {...props}
+      field={field}
+      onValueChange={onValueChange}
+      type="text"
+      slotProps={{
+        ...props.slotProps,
+        htmlInput: {
+          ...htmlInputSlotProps,
+          style: {
+            ...htmlInputStyle,
+            WebkitTextSecurity: isVisible ? 'none' : 'disc',
+          },
+        },
+        input: {
+          ...inputSlotProps,
+          endAdornment: (
+            <>
+              {inputSlotProps.endAdornment}
+              <InputAdornment position="end">
+                <IconButton
+                  edge="end"
+                  onClick={() => setIsVisible((prev) => !prev)}
+                  aria-label={t('auth.togglePasswordVisibility')}
+                >
+                  {isVisible ? <VisibilityOffRoundedIcon /> : <VisibilityRoundedIcon />}
+                </IconButton>
+              </InputAdornment>
+            </>
+          ),
+        },
+      }}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation

- Tokens/secrets (like telegram bot tokens) should not trigger browser password autofill yet still be masked and toggled by the user. 
- Password inputs should keep native browser autofill hints and remain simple to avoid UX conflicts with secret/token masking behaviour. 

### Description

- Added `AppRhfSecretKeyField` component which renders as `type="text"` with custom masking via `WebkitTextSecurity` and a manual show/hide toggle using MUI adornment icons. 
- Replaced the telegram bot token field in `UserSettingsTab` to use `AppRhfSecretKeyField` and set `autoComplete="off"` for that input. 
- Simplified `AppRhfPasswordField` by removing the visibility toggle and i18n dependency and enforcing `type="password"`. 
- Updated `web/README.md` to document the distinction between `AppRhfPasswordField` (real passwords with native autofill hints) and `AppRhfSecretKeyField` (secrets/tokens with manual masking). 

### Testing

- Ran `npm run -w @scheduletm/web lint` (ESLint) and it completed successfully. 
- Ran `npm run -w @scheduletm/web build` (tsc + vite build) and the build succeeded. 
- Ran `npm run -w @scheduletm/web test` (fast e2e contract checks) and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30958bf98833388f1f2202af1c03a)