### PR TITLE
Add frontend "Connect Zoom" button and hook to server-side Zoom MVP

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -94,7 +94,7 @@
 
 ## Старт backend-интеграции (2026-04-30)
 
-Реализован базовый server-side Zoom MVP без frontend-части:
+Реализован базовый server-side Zoom MVP:
 
 - добавлен endpoint `POST /api/integrations/zoom/meetings` (только backend вызов, без раскрытия секретов в браузере);
 - endpoint валидирует payload (`topic`, `startTime`, `duration`, `timezone`) и создает встречу через Zoom API `POST /v2/users/me/meetings`;
@@ -113,5 +113,19 @@
 - `joinUrl` (для клиента)
 - `startUrl` (только для организатора/служебного использования)
 
-Следующий шаг:
-- привязать создание Zoom meeting к flow создания `appointment` и хранению meeting provider в appointment-модели.
+## Обновление frontend (2026-04-30)
+
+Сделан первый шаг UI-интеграции на странице `Settings` в табе `Integrations`:
+
+- добавлена брендированная кнопка `Connect Zoom` с логотипом Zoom;
+- по клику запускается backend-интеграция через `POST /api/integrations/zoom/meetings`;
+- при успешном ответе показывается success-уведомление;
+- при ошибке показывается локализованная ошибка `connectZoom` (ru/en);
+- все строки добавлены в i18n-словари (без hardcoded текста).
+
+Текущая реализация запускает тестовое создание Zoom meeting (MVP handshake), чтобы пользователь мог быстро проверить, что интеграция доступна с его аккаунтом.
+
+Следующие шаги:
+- привязать создание Zoom meeting к flow создания `appointment`;
+- сохранять/показывать `meetingProvider` в UI записи;
+- добавить явный connected-state для Zoom в user integrations API (по аналогии с `googleConnected`).

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -32,6 +32,7 @@ type SettingsCardProps = {
   canManageSpecialistBookingPolicy: boolean;
   isGoogleConnecting: boolean;
   isGoogleDisconnecting: boolean;
+  isZoomConnecting: boolean;
   isSavingSystem?: boolean;
   isSavingAccount?: boolean;
   isSavingUser?: boolean;
@@ -49,6 +50,7 @@ type SettingsCardProps = {
   onSaveNotificationDefaults: (items: AccountNotificationDefault[]) => Promise<void> | void;
   onClearTelegramBotToken: () => Promise<void> | void;
   onConnectGoogle: () => void;
+  onConnectZoom: () => void;
   onDisconnectGoogle: () => void;
   onCurrentPasswordChange: (value: string) => void;
   onNewPasswordChange: (value: string) => void;
@@ -71,6 +73,7 @@ export function SettingsCard({
   canManageSpecialistBookingPolicy,
   isGoogleConnecting,
   isGoogleDisconnecting,
+  isZoomConnecting,
   isSavingSystem = false,
   isSavingAccount = false,
   isSavingUser = false,
@@ -88,6 +91,7 @@ export function SettingsCard({
   onSaveNotificationDefaults,
   onClearTelegramBotToken,
   onConnectGoogle,
+  onConnectZoom,
   onDisconnectGoogle
   ,onCurrentPasswordChange
   ,onNewPasswordChange
@@ -170,9 +174,11 @@ export function SettingsCard({
           isSaving={isSavingUser}
           isGoogleConnecting={isGoogleConnecting}
           isGoogleDisconnecting={isGoogleDisconnecting}
+          isZoomConnecting={isZoomConnecting}
           onSubmit={handleUserSubmit(onSaveUser)}
           onClearTelegramBotToken={onClearTelegramBotToken}
           onConnectGoogle={onConnectGoogle}
+          onConnectZoom={onConnectZoom}
           onDisconnectGoogle={onDisconnectGoogle}
         />
       )}

--- a/web/src/components/SettingsCard.types.ts
+++ b/web/src/components/SettingsCard.types.ts
@@ -31,6 +31,8 @@ export type SettingsCardCopy = {
   connectingGoogle: string;
   disconnectGoogle: string;
   disconnectingGoogle: string;
+  connectZoom: string;
+  connectingZoom: string;
   telegramBotToken: string;
   telegramBotConnected: string;
   telegramBotNotConnected: string;

--- a/web/src/components/settings-tabs/IntegrationsSettingsTab.tsx
+++ b/web/src/components/settings-tabs/IntegrationsSettingsTab.tsx
@@ -14,9 +14,11 @@ type Props = {
   isSaving: boolean;
   isGoogleConnecting: boolean;
   isGoogleDisconnecting: boolean;
+  isZoomConnecting: boolean;
   onSubmit: () => void;
   onClearTelegramBotToken: () => Promise<void> | void;
   onConnectGoogle: () => void;
+  onConnectZoom: () => void;
   onDisconnectGoogle: () => void;
 };
 
@@ -43,6 +45,17 @@ function GoogleGIcon() {
   );
 }
 
+function ZoomIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="#2D8CFF"
+        d="M7.5 6.75h5.4c2.1 0 3.15 0 3.9.41.66.36 1.19.89 1.55 1.55.41.75.41 1.8.41 3.9v.78c0 2.1 0 3.15-.41 3.9a3.75 3.75 0 0 1-1.55 1.55c-.75.41-1.8.41-3.9.41H7.5c-2.1 0-3.15 0-3.9-.41a3.75 3.75 0 0 1-1.55-1.55c-.41-.75-.41-1.8-.41-3.9v-.78c0-2.1 0-3.15.41-3.9A3.75 3.75 0 0 1 3.6 7.16c.75-.41 1.8-.41 3.9-.41Zm12.08 2.85 2.92-1.83c.57-.36 1.3.05 1.3.72v7.02c0 .67-.73 1.08-1.3.72l-2.92-1.83V9.6Z"
+      />
+    </svg>
+  );
+}
+
 export function IntegrationsSettingsTab({
   copy,
   control,
@@ -50,9 +63,11 @@ export function IntegrationsSettingsTab({
   isSaving,
   isGoogleConnecting,
   isGoogleDisconnecting,
+  isZoomConnecting,
   onSubmit,
   onClearTelegramBotToken,
   onConnectGoogle,
+  onConnectZoom,
   onDisconnectGoogle,
 }: Props) {
   return (
@@ -77,6 +92,26 @@ export function IntegrationsSettingsTab({
       </Typography>
 
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+        <AppButton
+          variant="outlined"
+          onClick={onConnectZoom}
+          isLoading={isZoomConnecting}
+          disabled={isGoogleConnecting || isGoogleDisconnecting}
+          startIcon={!isZoomConnecting ? <ZoomIcon /> : undefined}
+          sx={{
+            textTransform: 'none',
+            borderColor: '#2D8CFF',
+            color: '#2D8CFF',
+            backgroundColor: '#FFFFFF',
+            '&:hover': {
+              borderColor: '#2274D9',
+              backgroundColor: '#F4F9FF',
+            },
+          }}
+        >
+          {isZoomConnecting ? copy.connectingZoom : copy.connectZoom}
+        </AppButton>
+
         <AppButton
           variant="outlined"
           onClick={onConnectGoogle}

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -72,6 +72,7 @@ export function SettingsContainer() {
   const [success, setSuccess] = useState('');
   const [isGoogleConnecting, setIsGoogleConnecting] = useState(false);
   const [isGoogleDisconnecting, setIsGoogleDisconnecting] = useState(false);
+  const [isZoomConnecting, setIsZoomConnecting] = useState(false);
   const [isSavingSystem, setIsSavingSystem] = useState(false);
   const [isSavingAccount, setIsSavingAccount] = useState(false);
   const [isSavingUser, setIsSavingUser] = useState(false);
@@ -375,6 +376,37 @@ export function SettingsContainer() {
     }
   };
 
+  const connectZoom = async () => {
+    if (!accessToken || isZoomConnecting) {
+      return;
+    }
+
+    setIsZoomConnecting(true);
+
+    try {
+      await apiClient.post(
+        '/api/integrations/zoom/meetings',
+        {
+          topic: 'Meetli Zoom integration test',
+          startTime: new Date(Date.now() + 5 * 60_000).toISOString(),
+          duration: 30,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+        },
+        { headers: authHeaders(accessToken) }
+      );
+      setError('');
+      setSuccess(t('settings.zoomConnectedSuccessfully'));
+    } catch (err) {
+      setError(resolveApiError(err, {
+        fallbackMessage: t('settings.errors.connectZoom'),
+        networkMessage: t('common.errors.network')
+      }).message);
+      setSuccess('');
+    } finally {
+      setIsZoomConnecting(false);
+    }
+  };
+
 
   const requestPasswordOtp = async () => {
     if (!accessToken || !currentPassword.trim() || newPassword.length < 10 || newPassword !== confirmPassword) {
@@ -510,6 +542,8 @@ export function SettingsContainer() {
               connectingGoogle: t('settings.connectingGoogle'),
               disconnectGoogle: t('settings.disconnectGoogle'),
               disconnectingGoogle: t('settings.disconnectingGoogle'),
+              connectZoom: t('settings.connectZoom'),
+              connectingZoom: t('settings.connectingZoom'),
               telegramBotToken: t('settings.telegramBotToken'),
               telegramBotConnected: t('settings.telegramBotConnected'),
               telegramBotNotConnected: t('settings.telegramBotNotConnected'),
@@ -542,6 +576,7 @@ export function SettingsContainer() {
             }}
             isGoogleConnecting={isGoogleConnecting}
             isGoogleDisconnecting={isGoogleDisconnecting}
+            isZoomConnecting={isZoomConnecting}
             isSavingSystem={isSavingSystem}
             isSavingAccount={isSavingAccount}
             isSavingUser={isSavingUser}
@@ -559,6 +594,7 @@ export function SettingsContainer() {
             onSaveNotificationDefaults={saveAccountNotificationDefaults}
             onClearTelegramBotToken={clearTelegramBotToken}
             onConnectGoogle={connectGoogle}
+            onConnectZoom={connectZoom}
             onDisconnectGoogle={disconnectGoogle}
             onCurrentPasswordChange={setCurrentPassword}
             onNewPasswordChange={setNewPassword}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -122,6 +122,8 @@ export const dictionaries = {
       connectingGoogle: 'Redirecting to Google...',
       disconnectGoogle: 'Disconnect Google',
       disconnectingGoogle: 'Disconnecting...',
+      connectZoom: 'Connect Zoom',
+      connectingZoom: 'Connecting Zoom...',
       googleConnected: 'Google connected',
       telegramBotToken: 'Telegram Bot Token',
       telegramBotConnected: 'Telegram bot connected',
@@ -145,6 +147,7 @@ export const dictionaries = {
         whatsapp: 'WhatsApp',
       },
       googleConnectedSuccessfully: 'Google Calendar connected successfully.',
+      zoomConnectedSuccessfully: 'Zoom connected successfully.',
       specialists: {
         title: 'Specialists',
         add: 'Add specialist',
@@ -186,6 +189,7 @@ export const dictionaries = {
         save: 'Unable to save settings.',
         connectGoogle: 'Unable to connect Google.',
         disconnectGoogle: 'Unable to disconnect Google.',
+        connectZoom: 'Unable to connect Zoom.',
         saveSpecialist: 'Unable to save specialist.',
         deleteSpecialist: 'Unable to delete specialist.'
       }
@@ -495,6 +499,8 @@ export const dictionaries = {
       connectingGoogle: 'Переходим в Google...',
       disconnectGoogle: 'Отключить Google',
       disconnectingGoogle: 'Отключаем...',
+      connectZoom: 'Подключить Zoom',
+      connectingZoom: 'Подключаем Zoom...',
       googleConnected: 'Google подключен',
       telegramBotToken: 'Telegram Bot Token',
       telegramBotConnected: 'Telegram-бот подключен',
@@ -518,6 +524,7 @@ export const dictionaries = {
         whatsapp: 'WhatsApp',
       },
       googleConnectedSuccessfully: 'Google Calendar успешно подключен.',
+      zoomConnectedSuccessfully: 'Zoom успешно подключен.',
       specialists: {
         title: 'Специалисты',
         add: 'Добавить специалиста',
@@ -559,6 +566,7 @@ export const dictionaries = {
         save: 'Не удалось сохранить настройки.',
         connectGoogle: 'Не удалось подключить Google.',
         disconnectGoogle: 'Не удалось отключить Google.',
+        connectZoom: 'Не удалось подключить Zoom.',
         saveSpecialist: 'Не удалось сохранить специалиста.',
         deleteSpecialist: 'Не удалось удалить специалиста.'
       }
@@ -862,6 +870,8 @@ export type TranslationKey =
   | 'settings.connectingGoogle'
   | 'settings.disconnectGoogle'
   | 'settings.disconnectingGoogle'
+  | 'settings.connectZoom'
+  | 'settings.connectingZoom'
   | 'settings.googleConnected'
   | 'settings.telegramBotToken'
   | 'settings.telegramBotConnected'
@@ -883,6 +893,7 @@ export type TranslationKey =
   | 'settings.channels.sms'
   | 'settings.channels.whatsapp'
   | 'settings.googleConnectedSuccessfully'
+  | 'settings.zoomConnectedSuccessfully'
   | 'settings.passwordChange.openButton'
   | 'settings.passwordChange.title'
   | 'settings.passwordChange.currentPassword'
@@ -917,6 +928,7 @@ export type TranslationKey =
   | 'settings.errors.save'
   | 'settings.errors.connectGoogle'
   | 'settings.errors.disconnectGoogle'
+  | 'settings.errors.connectZoom'
   | 'specialists.pageTitle'
   | 'specialists.pageSubtitle'
   | 'specialists.accessDenied'


### PR DESCRIPTION
### Motivation
- Provide a first-step UI for the server-side Zoom integration so users can validate Zoom connectivity from the Settings page. 
- Allow the frontend to initiate a test Zoom meeting creation without exposing secrets in the browser and display localized feedback to the user.

### Description
- Updated docs `docs/meeting-platforms-zoom-plan.md` to reflect the server-side Zoom MVP and the new frontend UI handshake step. 
- Added UI support: new `Connect Zoom` branded button and `ZoomIcon` in `IntegrationsSettingsTab.tsx` and wired the button into the integrations tab. 
- Extended settings component types and props in `SettingsCard.types.ts`, `SettingsCard.tsx`, and `SettingsContainer.tsx` to track `isZoomConnecting`, expose `onConnectZoom`, and implement `connectZoom` which posts a test payload to `POST /api/integrations/zoom/meetings`. 
- Added i18n keys and copy for `connectZoom`, `connectingZoom`, `zoomConnectedSuccessfully`, and related error text in `web/src/shared/i18n/dictionaries.ts` and updated the `TranslationKey` union.

### Testing
- No new automated unit tests were added for this change. 
- Performed local type-check and frontend build (`yarn build` / TypeScript compile) which completed successfully. 
- Verified the Connect Zoom button triggers the `POST /api/integrations/zoom/meetings` request and shows localized success and error messages in development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32fec90388333b2b60b30c50cb0d3)