### PR TITLE
Expose Zoom connected state and reflect it in Settings UI

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -129,3 +129,12 @@
 - привязать создание Zoom meeting к flow создания `appointment`;
 - сохранять/показывать `meetingProvider` в UI записи;
 - добавить явный connected-state для Zoom в user integrations API (по аналогии с `googleConnected`).
+
+## Обновление connected-state Zoom (2026-04-30)
+
+Сделан следующий шаг по интеграции:
+
+- в `GET /api/settings/user` добавлен флаг `zoomConnected`;
+- значение `zoomConnected=true` возвращается, если в `web_user_integrations` есть `zoom_access_token` и `zoom_token_expires_at` еще не истек;
+- на frontend в `Settings -> Integrations` кнопка Zoom теперь показывает состояние `Zoom connected` и блокируется после успешного подключения;
+- состояние также обновляется локально сразу после успешного `POST /api/integrations/zoom/meetings`.

--- a/server/README.md
+++ b/server/README.md
@@ -21,6 +21,7 @@ Node.js/Express API для web-клиента и интеграций.
 - Web roles: owner/admin/specialist/client.
 - RBAC policy (централизованные проверки прав) в `src/policies/rolePermissions.ts`.
 - Settings API: system (owner), account (owner/admin), user (all users), account notification defaults (owner/admin).
+  - `GET /api/settings/user` возвращает статусы интеграций `googleConnected` и `zoomConnected` для текущего пользователя.
 - CRUD: users, specialists.
   - При создании пользователей owner/admin отправляется invite-link вместо временного пароля.
   - Приглашённый пользователь создаётся неактивным и активируется только после verify-email / accept-invite.

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -65,6 +65,7 @@ export type UserSettings = {
   uiThemeMode: 'light' | 'dark';
   uiPaletteVariantId: string;
   googleConnected: boolean;
+  zoomConnected: boolean;
   telegramBotConnected: boolean;
   telegramBotName: string | null;
   telegramBotUsername: string | null;
@@ -231,6 +232,7 @@ export const getUserSettings = async (actor: User): Promise<UserSettings> => {
       uiThemeMode: 'light',
       uiPaletteVariantId: 'default',
       googleConnected: false,
+      zoomConnected: false,
       telegramBotConnected: false,
       telegramBotName: null,
       telegramBotUsername: null,
@@ -254,6 +256,11 @@ export const getUserSettings = async (actor: User): Promise<UserSettings> => {
     uiThemeMode: userSettings?.ui_theme_mode ?? user?.ui_theme_mode ?? 'light',
     uiPaletteVariantId: userSettings?.ui_palette_variant_id ?? user?.ui_palette_variant_id ?? 'default',
     googleConnected: Boolean(integration?.google_api_key ?? legacyIntegration?.google_api_key),
+    zoomConnected: Boolean(
+      legacyIntegration?.zoom_access_token
+      && legacyIntegration?.zoom_token_expires_at
+      && new Date(legacyIntegration.zoom_token_expires_at).getTime() > Date.now(),
+    ),
     telegramBotConnected: Boolean(integration?.telegram_bot_token ?? legacyIntegration?.telegram_bot_token),
     telegramBotName: integration?.telegram_bot_name ?? legacyIntegration?.telegram_bot_name ?? null,
     telegramBotUsername: integration?.telegram_bot_username ?? legacyIntegration?.telegram_bot_username ?? null,

--- a/web/src/components/SettingsCard.types.ts
+++ b/web/src/components/SettingsCard.types.ts
@@ -33,6 +33,7 @@ export type SettingsCardCopy = {
   disconnectingGoogle: string;
   connectZoom: string;
   connectingZoom: string;
+  zoomConnected: string;
   telegramBotToken: string;
   telegramBotConnected: string;
   telegramBotNotConnected: string;

--- a/web/src/components/settings-tabs/IntegrationsSettingsTab.tsx
+++ b/web/src/components/settings-tabs/IntegrationsSettingsTab.tsx
@@ -96,7 +96,7 @@ export function IntegrationsSettingsTab({
           variant="outlined"
           onClick={onConnectZoom}
           isLoading={isZoomConnecting}
-          disabled={isGoogleConnecting || isGoogleDisconnecting}
+          disabled={userSettings.zoomConnected || isGoogleConnecting || isGoogleDisconnecting}
           startIcon={!isZoomConnecting ? <ZoomIcon /> : undefined}
           sx={{
             textTransform: 'none',
@@ -109,7 +109,9 @@ export function IntegrationsSettingsTab({
             },
           }}
         >
-          {isZoomConnecting ? copy.connectingZoom : copy.connectZoom}
+          {isZoomConnecting
+            ? copy.connectingZoom
+            : (userSettings.zoomConnected ? copy.zoomConnected : copy.connectZoom)}
         </AppButton>
 
         <AppButton

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -44,6 +44,7 @@ const defaultUserSettings: UserSettings = {
   uiThemeMode: 'light',
   uiPaletteVariantId: 'default',
   googleConnected: false,
+  zoomConnected: false,
   telegramBotConnected: false,
   telegramBotName: null,
   telegramBotUsername: null,
@@ -396,6 +397,7 @@ export function SettingsContainer() {
       );
       setError('');
       setSuccess(t('settings.zoomConnectedSuccessfully'));
+      setUserSettings((prev) => ({ ...prev, zoomConnected: true }));
     } catch (err) {
       setError(resolveApiError(err, {
         fallbackMessage: t('settings.errors.connectZoom'),
@@ -544,6 +546,7 @@ export function SettingsContainer() {
               disconnectingGoogle: t('settings.disconnectingGoogle'),
               connectZoom: t('settings.connectZoom'),
               connectingZoom: t('settings.connectingZoom'),
+              zoomConnected: t('settings.zoomConnected'),
               telegramBotToken: t('settings.telegramBotToken'),
               telegramBotConnected: t('settings.telegramBotConnected'),
               telegramBotNotConnected: t('settings.telegramBotNotConnected'),

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -125,6 +125,7 @@ export const dictionaries = {
       connectZoom: 'Connect Zoom',
       connectingZoom: 'Connecting Zoom...',
       googleConnected: 'Google connected',
+      zoomConnected: 'Zoom connected',
       telegramBotToken: 'Telegram Bot Token',
       telegramBotConnected: 'Telegram bot connected',
       telegramBotNotConnected: 'Telegram bot is not connected',
@@ -502,6 +503,7 @@ export const dictionaries = {
       connectZoom: 'Подключить Zoom',
       connectingZoom: 'Подключаем Zoom...',
       googleConnected: 'Google подключен',
+      zoomConnected: 'Zoom подключен',
       telegramBotToken: 'Telegram Bot Token',
       telegramBotConnected: 'Telegram-бот подключен',
       telegramBotNotConnected: 'Telegram-бот не подключен',
@@ -873,6 +875,7 @@ export type TranslationKey =
   | 'settings.connectZoom'
   | 'settings.connectingZoom'
   | 'settings.googleConnected'
+  | 'settings.zoomConnected'
   | 'settings.telegramBotToken'
   | 'settings.telegramBotConnected'
   | 'settings.telegramBotNotConnected'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -72,6 +72,7 @@ export type UserSettings = {
   uiThemeMode: 'light' | 'dark';
   uiPaletteVariantId: string;
   googleConnected: boolean;
+  zoomConnected: boolean;
   telegramBotConnected: boolean;
   telegramBotName: string | null;
   telegramBotUsername: string | null;


### PR DESCRIPTION
### Motivation

- Surface Zoom integration status for users so the Settings UI can show a connected state similarly to Google and prevent duplicate connect attempts.
- Ensure the backend `GET /api/settings/user` provides a reliable `zoomConnected` flag based on stored tokens and expiry.

### Description

- Added `zoomConnected: boolean` to server `UserSettings` and implemented logic in `getUserSettings` to return `true` when `zoom_access_token` exists and `zoom_token_expires_at` is in the future. 
- Documented the new flag in `server/README.md` and extended the meeting/zoom doc notes in `docs/meeting-platforms-zoom-plan.md` about connected-state behavior. 
- Updated frontend types (`web/src/shared/types/api.ts`) and defaults (`SettingsContainer`) to include `zoomConnected`, added i18n keys (`settings.zoomConnected`) and dictionaries for RU/EN, and added the string to `SettingsCard.types.ts`. 
- Changed `IntegrationsSettingsTab` and `SettingsContainer` to disable the Connect Zoom button when connected, show `Zoom connected` text, and set `zoomConnected` locally after successful `POST /api/integrations/zoom/meetings`.

### Testing

- Ran TypeScript type checking and frontend build, which succeeded. 
- Ran automated unit/type tests for server and web code, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f336d785688333947e48df8dc94668)