### PR TITLE
Start Zoom user OAuth flow from Settings (Connect Zoom)

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -120,12 +120,12 @@
 Сделан первый шаг UI-интеграции на странице `Settings` в табе `Integrations`:
 
 - добавлена брендированная кнопка `Connect Zoom` с логотипом Zoom;
-- по клику запускается backend-интеграция через `POST /api/integrations/zoom/meetings`;
+- по клику запускается user-level OAuth flow через `POST /api/integrations/zoom/oauth/start` (c последующим redirect в Zoom);
 - при успешном ответе показывается success-уведомление;
 - при ошибке показывается локализованная ошибка `connectZoom` (ru/en);
 - все строки добавлены в i18n-словари (без hardcoded текста).
 
-Текущая реализация запускает тестовое создание Zoom meeting (MVP handshake), чтобы пользователь мог быстро проверить, что интеграция доступна с его аккаунтом.
+Текущая реализация инициирует OAuth-подключение пользователя; создание встреч выполняется отдельно через `POST /api/integrations/zoom/meetings` после успешного callback.
 
 Следующие шаги:
 - привязать создание Zoom meeting к flow создания `appointment`;
@@ -139,4 +139,4 @@
 - в `GET /api/settings/user` добавлен флаг `zoomConnected`;
 - значение `zoomConnected=true` возвращается, если в `web_user_integrations` есть `zoom_access_token` и `zoom_token_expires_at` еще не истек;
 - на frontend в `Settings -> Integrations` кнопка Zoom теперь показывает состояние `Zoom connected` и блокируется после успешного подключения;
-- состояние также обновляется локально сразу после успешного `POST /api/integrations/zoom/meetings`.
+- состояние обновляется локально после возврата из Zoom callback (`zoom_oauth=success`) и при последующей загрузке `GET /api/settings/user`.

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -12,6 +12,7 @@ import type {
   AccountSettings,
   GoogleOAuthDisconnectResponse,
   GoogleOAuthStartResponse,
+  ZoomOAuthStartResponse,
   SpecialistBookingPolicy,
   SystemSettings,
   UserSettings,
@@ -91,13 +92,14 @@ export function SettingsContainer() {
   const [passwordStep, setPasswordStep] = useState<'password' | 'otp'>('password');
 
   const googleOauthStatus = useMemo(() => searchParams.get('google_oauth'), [searchParams]);
+  const zoomOauthStatus = useMemo(() => searchParams.get('zoom_oauth'), [searchParams]);
   const canManageSystemSettings = user?.role === 'owner';
   const canManageAccountSettings = user?.role === 'owner' || user?.role === 'admin';
   const canManageSpecialistBookingPolicy =
     user?.role === 'owner' || user?.role === 'admin' || user?.role === 'specialist';
 
   useEffect(() => {
-    if (!googleOauthStatus) {
+    if (!googleOauthStatus && !zoomOauthStatus) {
       return;
     }
 
@@ -113,14 +115,26 @@ export function SettingsContainer() {
         setSuccess('');
       }
 
+      if (zoomOauthStatus === 'success') {
+        setSuccess(t('settings.zoomConnectedSuccessfully'));
+        setUserSettings((prev) => ({ ...prev, zoomConnected: true }));
+        setError('');
+      }
+
+      if (zoomOauthStatus === 'error') {
+        setError(t('settings.errors.connectZoom'));
+        setSuccess('');
+      }
+
       const nextParams = new URLSearchParams(searchParams);
       nextParams.delete('google_oauth');
+      nextParams.delete('zoom_oauth');
       nextParams.delete('reason');
       setSearchParams(nextParams, { replace: true });
     }, 0);
 
     return () => window.clearTimeout(timeoutId);
-  }, [googleOauthStatus, searchParams, setSearchParams, t]);
+  }, [googleOauthStatus, searchParams, setSearchParams, t, zoomOauthStatus]);
 
   useEffect(() => {
     if (!accessToken) {
@@ -385,26 +399,19 @@ export function SettingsContainer() {
     setIsZoomConnecting(true);
 
     try {
-      await apiClient.post(
-        '/api/integrations/zoom/meetings',
-        {
-          topic: 'Meetli Zoom integration test',
-          startTime: new Date(Date.now() + 5 * 60_000).toISOString(),
-          duration: 30,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
-        },
+      const response = await apiClient.post<ZoomOAuthStartResponse>(
+        '/api/integrations/zoom/oauth/start',
+        {},
         { headers: authHeaders(accessToken) }
       );
-      setError('');
-      setSuccess(t('settings.zoomConnectedSuccessfully'));
-      setUserSettings((prev) => ({ ...prev, zoomConnected: true }));
+
+      window.location.assign(response.data.authorizeUrl);
     } catch (err) {
       setError(resolveApiError(err, {
         fallbackMessage: t('settings.errors.connectZoom'),
         networkMessage: t('common.errors.network')
       }).message);
       setSuccess('');
-    } finally {
       setIsZoomConnecting(false);
     }
   };

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -105,6 +105,13 @@ export type GoogleOAuthStartResponse = {
   state: string;
 };
 
+
+export type ZoomOAuthStartResponse = {
+  provider: 'zoom';
+  authorizeUrl: string;
+  state: string;
+};
+
 export type GoogleOAuthDisconnectResponse = {
   provider: 'google';
   connected: boolean;


### PR DESCRIPTION
### Motivation
- `Connect Zoom` should initiate a user-level OAuth flow so the app can persist user-specific Zoom access/refresh tokens on the backend, instead of creating a test meeting directly. 
- The settings UI must reflect the OAuth callback status (`zoom_oauth`) and set the `zoomConnected` flag consistently with Google OAuth handling.

### Description
- Replaced the previous test-meeting call in the `connectZoom` flow with a call to `POST /api/integrations/zoom/oauth/start` and redirect to the returned `authorizeUrl` to start user OAuth. 
- Added `ZoomOAuthStartResponse` type to `web/src/shared/types/api.ts` for typed handling of the OAuth start response. 
- Added `zoom_oauth` query handling in `web/src/containers/SettingsContainer.tsx` to set success/error messages and update `userSettings.zoomConnected` on callback, and to remove the OAuth params from the URL. 
- Updated `docs/meeting-platforms-zoom-plan.md` to reflect the OAuth-first connect behavior and clarify that meeting creation remains a separate backend call (`POST /api/integrations/zoom/meetings`) after OAuth completion.

### Testing
- Ran frontend typecheck with `cd web && npm run typecheck`, which succeeded. 
- Ran linter with `cd web && npm run lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34b4cffc8833392714106a799397a)