### PR TITLE
Add meetingProvider to appointments and auto-create Zoom meetings

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -140,3 +140,10 @@
 - значение `zoomConnected=true` возвращается, если в `web_user_integrations` есть `zoom_access_token` и `zoom_token_expires_at` еще не истек;
 - на frontend в `Settings -> Integrations` кнопка Zoom теперь показывает состояние `Zoom connected` и блокируется после успешного подключения;
 - состояние обновляется локально после возврата из Zoom callback (`zoom_oauth=success`) и при последующей загрузке `GET /api/settings/user`.
+
+## Обновление appointment flow (2026-04-30)
+
+- создание Zoom meeting привязано к `POST /api/appointments`: если выбран `meetingProvider=zoom` и ссылка не указана, backend пытается автоматически создать Zoom-встречу от имени текущего пользователя (specialist/admin/owner с подключенным Zoom OAuth) и сохраняет `joinUrl` в appointment;
+- в appointment API добавлен `meetingProvider` (`manual | zoom`) и он сохраняется/читается вместе с `meetingLink`;
+- в UI формы записи добавлен выбор провайдера встречи (`Manual link`/`Zoom`);
+- в календарных карточках записи отображается выбранный `meetingProvider`.

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -213,6 +213,7 @@ export const specialistUpdateSchema = z.object({
 });
 
 const appointmentStatusSchema = z.enum(['new', 'confirmed', 'cancelled']);
+const appointmentMeetingProviderSchema = z.enum(['manual', 'zoom']);
 
 const appointmentClientSchema = z.object({
   clientId: z.coerce.number().int().positive().optional(),
@@ -229,6 +230,7 @@ export const appointmentCreateSchema = z.object({
   appointmentEndAt: z.string().datetime(v.appointmentEndInvalid),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url(v.appointmentLinkInvalid).max(2048).optional().or(z.literal('')),
+  meetingProvider: appointmentMeetingProviderSchema.optional(),
   notes: z.string().trim().max(2000, v.appointmentNotesTooLong).optional(),
 }).merge(appointmentClientSchema).superRefine((value, ctx) => {
   if (!value.firstName) {
@@ -274,6 +276,7 @@ export const appointmentUpdateSchema = z.object({
   durationMin: z.coerce.number().int().min(15, v.appointmentDurationMin).max(480, v.appointmentDurationMax).optional(),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url(v.appointmentLinkInvalid).max(2048).optional().or(z.literal('')),
+  meetingProvider: appointmentMeetingProviderSchema.optional(),
   notes: z.string().trim().max(2000, v.appointmentNotesTooLong).optional(),
 }).merge(appointmentClientSchema).superRefine((value, ctx) => {
   if (Object.keys(value).length === 0) {

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -34,6 +34,7 @@ import type { User } from '../types/domain.js';
 import { WebUserRole } from '../types/webUserRole.js';
 import { canCreateAppointments, canManageAllAppointments, canMarkPaidAndNotify, isClientRole } from '../policies/rolePermissions.js';
 import { sendAppointmentNotificationByType } from './appointmentNotificationService.js';
+import { createZoomMeeting } from './zoomService.js';
 
 type AppointmentClientDto = {
   id: number;
@@ -51,6 +52,7 @@ type AppointmentDto = {
   durationMin: number;
   status: AppointmentStatus;
   paymentStatus: 'paid' | 'unpaid';
+  meetingProvider: 'manual' | 'zoom';
   meetingLink: string;
   notes: string;
   client: AppointmentClientDto;
@@ -90,6 +92,7 @@ type CreateAppointmentPayload = {
   appointmentEndAt: string;
   status?: AppointmentStatus;
   meetingLink?: string;
+  meetingProvider?: 'manual' | 'zoom';
   notes?: string;
 } & AppointmentClientPayload;
 
@@ -99,40 +102,50 @@ type UpdateAppointmentPayload = {
   durationMin?: number;
   status?: AppointmentStatus;
   meetingLink?: string;
+  meetingProvider?: 'manual' | 'zoom';
   notes?: string;
 } & AppointmentClientPayload;
 
-function parseMeetingLinkFromNotes(notes: string | null): { notes: string; meetingLink: string } {
+function parseMeetingMetaFromNotes(notes: string | null): { notes: string; meetingLink: string; meetingProvider: 'manual' | 'zoom' } {
   if (!notes) {
-    return { notes: '', meetingLink: '' };
+    return { notes: '', meetingLink: '', meetingProvider: 'manual' };
   }
 
-  const [firstLine, ...restLines] = notes.split('\n');
-  const prefix = 'meetingLink: ';
-
-  if (!firstLine.startsWith(prefix)) {
-    return { notes, meetingLink: '' };
+  const lines = notes.split('\n');
+  let meetingLink = '';
+  let meetingProvider: 'manual' | 'zoom' = 'manual';
+  const restLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('meetingLink: ')) {
+      meetingLink = line.slice('meetingLink: '.length).trim();
+      continue;
+    }
+    if (line.startsWith('meetingProvider: ')) {
+      const parsed = line.slice('meetingProvider: '.length).trim();
+      meetingProvider = parsed === 'zoom' ? 'zoom' : 'manual';
+      continue;
+    }
+    restLines.push(line);
   }
-
-  return {
-    meetingLink: firstLine.slice(prefix.length).trim(),
-    notes: restLines.join('\n').trim(),
-  };
+  return { meetingLink, meetingProvider, notes: restLines.join('\n').trim() };
 }
 
-function composeNotes(meetingLink: string | undefined, notes: string | undefined): string | null {
+function composeNotes(meetingLink: string | undefined, notes: string | undefined, meetingProvider: 'manual' | 'zoom' | undefined): string | null {
   const normalizedMeetingLink = meetingLink?.trim() ?? '';
   const normalizedNotes = notes?.trim() ?? '';
+  const normalizedProvider = meetingProvider ?? 'manual';
 
-  if (!normalizedMeetingLink && !normalizedNotes) {
+  if (!normalizedMeetingLink && !normalizedNotes && !normalizedProvider) {
     return null;
   }
-
-  if (!normalizedMeetingLink) {
-    return normalizedNotes;
+  const lines = [`meetingProvider: ${normalizedProvider}`];
+  if (normalizedMeetingLink) {
+    lines.push(`meetingLink: ${normalizedMeetingLink}`);
   }
-
-  return [`meetingLink: ${normalizedMeetingLink}`, normalizedNotes].filter(Boolean).join('\n');
+  if (normalizedNotes) {
+    lines.push(normalizedNotes);
+  }
+  return lines.filter(Boolean).join('\n');
 }
 
 function mapClient(row: ClientRecord): AppointmentClientDto {
@@ -147,7 +160,7 @@ function mapClient(row: ClientRecord): AppointmentClientDto {
 }
 
 function mapAppointment(row: AppointmentRecord): AppointmentDto {
-  const parsed = parseMeetingLinkFromNotes(row.comment);
+  const parsed = parseMeetingMetaFromNotes(row.comment);
 
   return {
     id: row.id,
@@ -156,6 +169,7 @@ function mapAppointment(row: AppointmentRecord): AppointmentDto {
     durationMin: row.duration_min,
     status: row.status,
     paymentStatus: row.is_paid ? 'paid' : 'unpaid',
+    meetingProvider: parsed.meetingProvider,
     notes: parsed.notes,
     meetingLink: parsed.meetingLink,
     client: {
@@ -456,12 +470,27 @@ export async function createAppointmentForActor(
     throw new Error('CLIENT_PROFILE_NOT_FOUND');
   }
 
+  let meetingLink = payload.meetingLink?.trim() ?? '';
+  const meetingProvider = payload.meetingProvider ?? (meetingLink ? 'manual' : 'zoom');
+  if (meetingProvider === 'zoom' && !meetingLink) {
+    const zoom = await createZoomMeeting({
+      userId: actor.id,
+      topic: 'Appointment',
+      startTime: payload.appointmentAt,
+      duration: resolveDurationFromRange(payload.appointmentAt, payload.appointmentEndAt),
+      timezone: specialist.timezone || 'UTC',
+    });
+    if (zoom.ok) {
+      meetingLink = zoom.meeting.joinUrl;
+    }
+  }
+
   const created = await createAppointment({
     accountId,
     specialistId: payload.specialistId,
     scheduledAt: new Date(payload.appointmentAt),
     status: payload.status ?? 'new',
-    notes: composeNotes(payload.meetingLink, payload.notes),
+    notes: composeNotes(meetingLink, payload.notes, meetingProvider),
     userId,
     serviceId,
     durationMin: resolveDurationFromRange(payload.appointmentAt, payload.appointmentEndAt),
@@ -552,8 +581,8 @@ export async function updateAppointmentForActor(
     durationMin,
     status: payload.status,
     userId,
-    notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink')
-      ? composeNotes(payload.meetingLink, payload.notes)
+    notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink') || Object.prototype.hasOwnProperty.call(payload, 'meetingProvider')
+      ? composeNotes(payload.meetingLink, payload.notes, payload.meetingProvider)
       : undefined,
   });
 

--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -65,6 +65,7 @@ type Props = {
   onSubmit: (payload: {
     specialistId: number;
     status: AppointmentStatus;
+    meetingProvider: 'manual' | 'zoom';
     meetingLink: string;
     notes: string;
     appointmentAt: string;
@@ -85,6 +86,7 @@ const EMPTY_FORM: AppointmentFormState = {
   startTime: '',
   endTime: '',
   status: 'new',
+  meetingProvider: 'manual',
   meetingLink: '',
   notes: '',
   username: '',
@@ -140,6 +142,7 @@ export function AppointmentFormDialog({
         startTime: times.startTime,
         endTime: times.endTime,
         status: editingItem.status,
+        meetingProvider: editingItem.meetingProvider ?? 'manual',
         meetingLink: editingItem.meetingLink,
         notes: editingItem.notes,
         username: editingItem.client?.username ?? '',
@@ -163,6 +166,7 @@ export function AppointmentFormDialog({
       startTime: times.startTime,
       endTime: times.endTime,
       status: 'new',
+      meetingProvider: 'manual',
       meetingLink: '',
       notes: '',
       username: '',
@@ -231,6 +235,7 @@ export function AppointmentFormDialog({
     await onSubmit({
       specialistId,
       status: form.status,
+      meetingProvider: form.meetingProvider,
       meetingLink: form.meetingLink,
       notes: form.notes,
       appointmentAt: startIso,
@@ -343,6 +348,24 @@ export function AppointmentFormDialog({
                     {STATUS_OPTIONS.map((status) => (
                       <MenuItem key={status} value={status}>{statusLabel(status)}</MenuItem>
                     ))}
+                  </Select>
+                </FormControl>
+              )}
+            />
+            <Controller
+              name="meetingProvider"
+              control={control}
+              render={({ field }: any) => (
+                <FormControl fullWidth sx={{ gridColumn: { xs: 'span 1', sm: 'span 2' } }}>
+                  <InputLabel id="meeting-provider-label">{t('appointments.fields.meetingProvider')}</InputLabel>
+                  <Select
+                    labelId="meeting-provider-label"
+                    label={t('appointments.fields.meetingProvider')}
+                    value={field.value}
+                    onChange={(event) => field.onChange(event.target.value as 'manual' | 'zoom')}
+                  >
+                    <MenuItem value="manual">{t('appointments.meetingProviderManual')}</MenuItem>
+                    <MenuItem value="zoom">{t('appointments.meetingProviderZoom')}</MenuItem>
                   </Select>
                 </FormControl>
               )}

--- a/web/src/components/appointments/AppointmentsCalendar.tsx
+++ b/web/src/components/appointments/AppointmentsCalendar.tsx
@@ -84,6 +84,9 @@ export function AppointmentsCalendar({
     ]
       .filter(Boolean)
       .join(' · ');
+  const getMeetingProviderLabel = (provider: AppointmentItem['meetingProvider']) => (
+    provider === 'zoom' ? t('appointments.meetingProviderZoom') : t('appointments.meetingProviderManual')
+  );
 
   return (
     <>
@@ -193,7 +196,7 @@ export function AppointmentsCalendar({
                                   {formatLocalTime(item.scheduledAt)}
                                 </Typography>
                                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                  {`${statusLabel(item.status)} · ${t('appointments.durationMinutesShort').replace('{minutes}', String(item.durationMin))}`}
+                                  {`${statusLabel(item.status)} · ${getMeetingProviderLabel(item.meetingProvider)} · ${t('appointments.durationMinutesShort').replace('{minutes}', String(item.durationMin))}`}
                                 </Typography>
                               </Box>
                             ))
@@ -400,7 +403,7 @@ export function AppointmentsCalendar({
                                     {formatLocalTime(item.scheduledAt)}
                                   </Typography>
                                   <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                    {`${statusLabel(item.status)} · ${t('appointments.durationMinutesShort').replace('{minutes}', String(item.durationMin))}`}
+                                    {`${statusLabel(item.status)} · ${getMeetingProviderLabel(item.meetingProvider)} · ${t('appointments.durationMinutesShort').replace('{minutes}', String(item.durationMin))}`}
                                   </Typography>
                                 </Box>
                               ))}

--- a/web/src/components/appointments/appointmentsUtils.ts
+++ b/web/src/components/appointments/appointmentsUtils.ts
@@ -6,6 +6,7 @@ export type EditFormState = {
   startTime: string;
   endTime: string;
   status: AppointmentStatus;
+  meetingProvider: 'manual' | 'zoom';
   meetingLink: string;
   notes: string;
 };

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -350,6 +350,7 @@ export function AppointmentsContainer() {
     appointmentAt: string;
     appointmentEndAt: string;
     status: AppointmentItem['status'];
+    meetingProvider: 'manual' | 'zoom';
     meetingLink: string;
     notes: string;
     clientId?: number;
@@ -376,6 +377,7 @@ export function AppointmentsContainer() {
           appointmentAt: payload.appointmentAt,
           appointmentEndAt: payload.appointmentEndAt,
           status: payload.status,
+          meetingProvider: payload.meetingProvider,
           meetingLink: payload.meetingLink,
           notes: payload.notes,
           clientId: payload.clientId,
@@ -393,6 +395,7 @@ export function AppointmentsContainer() {
           appointmentAt: payload.appointmentAt,
           appointmentEndAt: payload.appointmentEndAt,
           status: payload.status,
+          meetingProvider: payload.meetingProvider,
           meetingLink: payload.meetingLink,
           notes: payload.notes,
           clientId: payload.clientId,
@@ -778,6 +781,7 @@ export function AppointmentsContainer() {
           appointmentAt: payload.appointmentAt,
           appointmentEndAt: payload.appointmentEndAt,
           status: payload.status,
+          meetingProvider: payload.meetingProvider,
           meetingLink: payload.meetingLink,
           notes: payload.notes,
           clientId: payload.clientId,

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -360,6 +360,8 @@ export const dictionaries = {
       eventReschedule: 'Appointment rescheduled',
       eventMarkPaid: 'Payment confirmed',
       eventNotify: 'Manual notification sent',
+      meetingProviderManual: 'Manual link',
+      meetingProviderZoom: 'Zoom',
       errors: {
         load: 'Unable to load appointments.',
         save: 'Unable to save appointment.',
@@ -372,6 +374,7 @@ export const dictionaries = {
       fields: {
         scheduledAt: 'Date and time',
         status: 'Status',
+        meetingProvider: 'Meeting provider',
         meetingLink: 'Meeting link',
         notes: 'Notes'
       }
@@ -738,6 +741,8 @@ export const dictionaries = {
       eventReschedule: 'Запись перенесена',
       eventMarkPaid: 'Оплата подтверждена',
       eventNotify: 'Ручное уведомление отправлено',
+      meetingProviderManual: 'Ручная ссылка',
+      meetingProviderZoom: 'Zoom',
       errors: {
         load: 'Не удалось загрузить записи.',
         save: 'Не удалось сохранить запись.',
@@ -750,6 +755,7 @@ export const dictionaries = {
       fields: {
         scheduledAt: 'Дата и время',
         status: 'Статус',
+        meetingProvider: 'Провайдер встречи',
         meetingLink: 'Ссылка на встречу',
         notes: 'Комментарий'
       }
@@ -1027,6 +1033,8 @@ export type TranslationKey =
   | 'appointments.eventReschedule'
   | 'appointments.eventMarkPaid'
   | 'appointments.eventNotify'
+  | 'appointments.meetingProviderManual'
+  | 'appointments.meetingProviderZoom'
   | 'appointments.errors.load'
   | 'appointments.errors.save'
   | 'appointments.errors.cancel'
@@ -1036,6 +1044,7 @@ export type TranslationKey =
   | 'appointments.errors.createSpecialistFirst'
   | 'appointments.fields.scheduledAt'
   | 'appointments.fields.status'
+  | 'appointments.fields.meetingProvider'
   | 'appointments.fields.meetingLink'
   | 'notificationLogs.pageTitle'
   | 'notificationLogs.pageSubtitle'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -133,6 +133,7 @@ export type AppointmentItem = {
   durationMin: number;
   status: AppointmentStatus;
   paymentStatus: 'paid' | 'unpaid';
+  meetingProvider: 'manual' | 'zoom';
   meetingLink: string;
   notes: string;
   client: ClientItem;


### PR DESCRIPTION
### Motivation

- Support Zoom as a selectable meeting provider for appointments and optionally auto-create Zoom meetings when scheduling; persist provider alongside meeting link. 
- Surface provider state in the UI so users can choose between a manual link and Zoom-created meetings, and show provider in calendar cards. 

### Description

- Add `meetingProvider` enum (`'manual' | 'zoom'`) to server validation schemas for appointment create/update in `server/src/config/schemas.ts`. 
- Extend appointment storage/serialization logic in `server/src/services/appointmentService.ts` to parse and compose `meetingProvider` alongside `meetingLink` in appointment `comment`/`notes`, include `meetingProvider` in mapped DTOs, and attempt to create a Zoom meeting via `createZoomMeeting` when `meetingProvider='zoom'` and no link is provided. 
- Update frontend types and API payloads to include `meetingProvider` (`web/src/shared/types/api.ts` and API calls in `web/src/containers/AppointmentsContainer.tsx`). 
- Add meeting provider selection to the appointment form (`web/src/components/appointments/AppointmentFormDialog.tsx`) and default values handling, and surface provider labels in the calendar UI (`web/src/components/appointments/AppointmentsCalendar.tsx`). 
- Add i18n strings for provider labels and field name in `web/src/shared/i18n/dictionaries.ts` and wire the translation keys into the UI (`appointments.fields.meetingProvider`, `appointments.meetingProviderManual`, `appointments.meetingProviderZoom`). 
- Rename and extend helpers for notes parsing/composition to `parseMeetingMetaFromNotes` and `composeNotes` that include `meetingProvider` metadata. 

### Testing

- Ran TypeScript type check and the repository build to ensure both server and web compile cleanly, and the build succeeded. 
- Ran backend and frontend unit test suites and linters where present, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34c828b4c83339b8d46516c7bd811)