### PR TITLE
Add deeplink support for Settings tabs

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -5,6 +5,7 @@ React SPA для owner/admin/specialist/client.
 ## Что умеет
 
 - Settings page UI decomposition: each settings tab is implemented as a separate UI component under `src/components/settings-tabs/` to keep `SettingsCard.tsx` lightweight.
+- Settings tabs support deeplinks via route segment: `/settings/:tab` (for example `/settings/integrations`, `/settings/password`).
 - Auth: `/login`, `/register`, `/invite/accept`, `/verify-email`.
   - `register`: required fields `firstName`, `lastName`, `email`, `phone`, optional `telegramUsername`.
   - `verify-email`: 4-digit OTP with auto-confirm when all digits are entered, auto-focus between inputs, full-code paste support, and resend cooldown timer.

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -69,7 +69,7 @@ export const router = createBrowserRouter([
         )
       },
       {
-        path: '/settings',
+        path: '/settings/:tab?',
         element: (
           <ProtectedRoute>
             <SettingsPage />

--- a/web/src/components/SettingsCard.tsx
+++ b/web/src/components/SettingsCard.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
 import type {
@@ -59,6 +59,8 @@ type SettingsCardProps = {
   onCancelPasswordChange: () => void;
   onRequestPasswordOtp: () => Promise<void> | void;
   onConfirmPasswordOtp: () => Promise<void> | void;
+  activeTab: string;
+  onTabChange: (tab: string) => void;
 };
 
 export function SettingsCard({
@@ -100,6 +102,8 @@ export function SettingsCard({
   ,onCancelPasswordChange
   ,onRequestPasswordOtp
   ,onConfirmPasswordOtp
+  ,activeTab
+  ,onTabChange
 }: SettingsCardProps) {
   const tabs = useMemo(() => ([
     ...(canManageSystemSettings ? [{ key: 'system', label: copy.systemTab }] : []),
@@ -115,7 +119,6 @@ export function SettingsCard({
   const timingOptions = ['disabled', ...[1, 2, ...Array.from({ length: 12 }, (_, i) => 4 + i * 2)].map(h => `${h}h`)];
   const selectableChannels: NotificationChannel[] = ['email', 'telegram', 'viber', 'sms', 'whatsapp'];
   const meetingDurationOptions = Array.from({ length: 7 }, (_, i) => 30 + i * 10);
-  const [tab, setTab] = useState<string>(initialTab);
 
   const { control: systemControl, handleSubmit: handleSystemSubmit, reset: resetSystem } = useForm<SystemSettings>({ defaultValues: systemSettings });
   const { control: accountControl, handleSubmit: handleAccountSubmit, reset: resetAccount } = useForm<AccountSettings>({ defaultValues: accountSettings });
@@ -149,16 +152,18 @@ export function SettingsCard({
     });
   }, [accountNotificationDefaults, resetNotificationDefaults]);
 
+  const resolvedTab = tabs.some((item) => item.key === activeTab) ? activeTab : initialTab;
+
   return (
     <Box>
-      <AppTabs value={tabs.findIndex((item) => item.key === tab)} onChange={(_, next) => setTab(tabs[next]?.key ?? initialTab)} sx={{ mb: 2 }}>
+      <AppTabs value={tabs.findIndex((item) => item.key === resolvedTab)} onChange={(_, next) => onTabChange(tabs[next]?.key ?? initialTab)} sx={{ mb: 2 }}>
         {tabs.map((item) => <AppTab key={item.key} label={item.label} />)}
       </AppTabs>
 
-      {tab === 'system' && <SystemSettingsTab copy={copy} control={systemControl} meetingDurationOptions={meetingDurationOptions} isSaving={isSavingSystem} onSubmit={handleSystemSubmit(onSaveSystem)} />}
-      {tab === 'account' && <AccountSettingsTab copy={copy} control={accountControl} meetingDurationOptions={meetingDurationOptions} isSaving={isSavingAccount} onSubmit={handleAccountSubmit(onSaveAccount)} />}
-      {tab === 'specialistPolicy' && <SpecialistPolicyTab copy={copy} control={specialistPolicyControl} isSaving={isSavingSpecialistBookingPolicy} onSubmit={handleSpecialistPolicySubmit(onSaveSpecialistBookingPolicy)} />}
-      {tab === 'user' && (
+      {resolvedTab === 'system' && <SystemSettingsTab copy={copy} control={systemControl} meetingDurationOptions={meetingDurationOptions} isSaving={isSavingSystem} onSubmit={handleSystemSubmit(onSaveSystem)} />}
+      {resolvedTab === 'account' && <AccountSettingsTab copy={copy} control={accountControl} meetingDurationOptions={meetingDurationOptions} isSaving={isSavingAccount} onSubmit={handleAccountSubmit(onSaveAccount)} />}
+      {resolvedTab === 'specialistPolicy' && <SpecialistPolicyTab copy={copy} control={specialistPolicyControl} isSaving={isSavingSpecialistBookingPolicy} onSubmit={handleSpecialistPolicySubmit(onSaveSpecialistBookingPolicy)} />}
+      {resolvedTab === 'user' && (
         <UserSettingsTab
           copy={copy}
           control={userControl}
@@ -166,7 +171,7 @@ export function SettingsCard({
           onSubmit={handleUserSubmit(onSaveUser)}
         />
       )}
-      {tab === 'integrations' && (
+      {resolvedTab === 'integrations' && (
         <IntegrationsSettingsTab
           copy={copy}
           control={userControl}
@@ -182,7 +187,7 @@ export function SettingsCard({
           onDisconnectGoogle={onDisconnectGoogle}
         />
       )}
-      {tab === 'password' && (
+      {resolvedTab === 'password' && (
         <PasswordSettingsTab
           copy={copy}
           currentPassword={currentPassword}
@@ -199,7 +204,7 @@ export function SettingsCard({
           onConfirmOtp={onConfirmPasswordOtp}
         />
       )}
-      {tab === 'notifications' && (
+      {resolvedTab === 'notifications' && (
         <NotificationSettingsTab
           copy={copy}
           control={notificationDefaultsControl}

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -1,6 +1,6 @@
 import { Alert, Box, Skeleton, Stack } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { SettingsCard } from '../components/SettingsCard';
 import { apiClient, authHeaders } from '../shared/api/client';
 import { resolveApiError } from '../shared/api/error';
@@ -65,6 +65,7 @@ const defaultAccountNotificationDefaults: AccountNotificationDefault[] = [];
 export function SettingsContainer() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { tab } = useParams<{ tab?: string }>();
   const { accessToken, user } = useAuth();
   const { t } = useI18n();
   const [systemSettings, setSystemSettings] = useState<SystemSettings>(defaultSystemSettings);
@@ -97,6 +98,34 @@ export function SettingsContainer() {
   const canManageAccountSettings = user?.role === 'owner' || user?.role === 'admin';
   const canManageSpecialistBookingPolicy =
     user?.role === 'owner' || user?.role === 'admin' || user?.role === 'specialist';
+
+  const allowedTabs = useMemo(() => ([
+    ...(canManageSystemSettings ? ['system'] : []),
+    ...(canManageAccountSettings ? ['account'] : []),
+    ...(canManageSpecialistBookingPolicy ? ['specialistPolicy'] : []),
+    ...(canManageAccountSettings ? ['notifications'] : []),
+    'user',
+    'integrations',
+    'password'
+  ] as const), [canManageAccountSettings, canManageSpecialistBookingPolicy, canManageSystemSettings]);
+
+  const activeTab = useMemo(() => {
+    if (!tab) {
+      return allowedTabs[0] ?? 'user';
+    }
+
+    return allowedTabs.includes(tab as (typeof allowedTabs)[number]) ? tab : (allowedTabs[0] ?? 'user');
+  }, [allowedTabs, tab]);
+
+  useEffect(() => {
+    if (!tab || !allowedTabs.includes(tab as (typeof allowedTabs)[number])) {
+      navigate(`/settings/${allowedTabs[0] ?? 'user'}`, { replace: true });
+    }
+  }, [allowedTabs, navigate, tab]);
+
+  const handleTabChange = (nextTab: string) => {
+    navigate(`/settings/${nextTab}`);
+  };
 
   useEffect(() => {
     if (!googleOauthStatus && !zoomOauthStatus) {
@@ -613,6 +642,8 @@ export function SettingsContainer() {
             onCancelPasswordChange={cancelPasswordChange}
             onRequestPasswordOtp={requestPasswordOtp}
             onConfirmPasswordOtp={confirmPasswordOtp}
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
           />
         )}
       </Box>


### PR DESCRIPTION
### Motivation
- Сделать каждый таб страницы настроек доступным по собственному URL (deeplink) и обеспечить изменение роута при переключении табов.
- Защитить переходы к табам проверкой прав по роли пользователя и автоматически перенаправлять на первый доступный таб при некорректном или отсутствующем сегменте пути.

### Description
- Изменён маршрут настроек на `/settings/:tab?` в `web/src/app/router.tsx` для поддержки опционального сегмента таба.
- В `web/src/containers/SettingsContainer.tsx` добавлено чтение `tab` из route params, вычисление `allowedTabs` по ролям, вычисление `activeTab`, редирект на первый доступный таб при неверном/отсутствующем параметре и функция навигации `handleTabChange` которая вызывает `navigate('/settings/<tab>')`.
- В `web/src/components/SettingsCard.tsx` табы сделаны контролируемыми: убран локальный state, добавлены пропсы `activeTab` и `onTabChange`, и переключение табов теперь делегируется контейнеру через `onTabChange`.
- Обновлён `web/README.md` с упоминанием формата deeplink для табов настроек и примерами URL.

### Testing
- Запущена проверка линтинга командой `npm run -w @scheduletm/web lint` и она завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36ed2bec48333b6c09f5f7553d73a)