### PR TITLE
Add meeting link generation (manual/Zoom) to Appointment form

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -16,6 +16,7 @@ React SPA для owner/admin/specialist/client.
 - Phone fields with country selector auto-detect default country from browser locale and can still be changed manually.
 - `AppRhfPasswordField` is used for real password inputs with native browser autofill hints (`current-password`, `new-password`), while secrets/tokens use dedicated `AppRhfSecretKeyField` with manual show/hide toggle and custom masking in `type="text"` mode.
 - Calendar flow: create/edit/reschedule/cancel/mark-paid/notify.
+- In appointment dialog, `Meeting provider` and `Meeting link` are placed together; link can be generated directly from the form (`Zoom` via API integration, `Manual` via generated unique URL).
 - Appointments page includes role-based top filters:
   - owner: `Account`, `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;
   - admin: `Specialist`, `Client`, `Service`, `Status`, `From/To` dates;

--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -34,6 +34,8 @@ import {
 
 import type { TranslationKey } from '../../shared/i18n/dictionaries';
 import { TimezoneSelect } from '../TimezoneSelect';
+import { apiClient, authHeaders } from '../../shared/api/client';
+import { resolveApiError } from '../../shared/api/error';
 
 type AppointmentFormState = EditFormState & {
   clientId: string;
@@ -54,6 +56,7 @@ type Props = {
   selectedSlotStepMin: number;
   initialScheduledAtIso: string | null;
   isSubmittingForm: boolean;
+  accessToken: string;
   isCancellingAppointment: boolean;
   isMarkingPaid: boolean;
   isNotifyingClient: boolean;
@@ -112,6 +115,7 @@ export function AppointmentFormDialog({
   selectedSlotStepMin,
   initialScheduledAtIso,
   isSubmittingForm,
+  accessToken,
   isCancellingAppointment,
   isMarkingPaid,
   isNotifyingClient,
@@ -124,6 +128,8 @@ export function AppointmentFormDialog({
 }: Props) {
   const [showTimezoneSelect, setShowTimezoneSelect] = useState(false);
   const [formTimeZone, setFormTimeZone] = useState(BROWSER_TIMEZONE);
+  const [isGeneratingMeetingLink, setIsGeneratingMeetingLink] = useState(false);
+  const [generateMeetingLinkError, setGenerateMeetingLinkError] = useState('');
 
   const initialValues = useMemo(() => {
     const defaultSpecialistId = selectedSpecialistId === 'all' ? specialists[0]?.id : selectedSpecialistId;
@@ -212,6 +218,8 @@ export function AppointmentFormDialog({
 
   const startDateValue = useWatch({ control, name: 'startDate' });
   const startTimeValue = useWatch({ control, name: 'startTime' });
+  const endTimeValue = useWatch({ control, name: 'endTime' });
+  const meetingProviderValue = useWatch({ control, name: 'meetingProvider' });
 
   useEffect(() => {
     if (!open || editingItem || !startDateValue || !startTimeValue) {
@@ -248,6 +256,43 @@ export function AppointmentFormDialog({
       email: form.email,
     });
   });
+
+  const handleGenerateMeetingLink = async () => {
+    setGenerateMeetingLinkError('');
+    const provider = meetingProviderValue;
+
+    if (provider === 'manual') {
+      setValue('meetingLink', `https://meetli.link/manual/${crypto.randomUUID()}`, { shouldDirty: true });
+      return;
+    }
+
+    if (provider !== 'zoom') {
+      return;
+    }
+
+    const startAt = composeFormDateTime(startDateValue, startTimeValue);
+    const startAtIso = new Date(startAt).toISOString();
+    const endAtIso = new Date(composeFormDateTime(startDateValue, endTimeValue)).toISOString();
+    const durationMin = Math.max(1, Math.round((new Date(endAtIso).getTime() - new Date(startAtIso).getTime()) / 60000));
+
+    setIsGeneratingMeetingLink(true);
+    try {
+      const response = await apiClient.post('/api/integrations/zoom/meetings', {
+        topic: editingItem ? t('appointments.editTitle') : t('appointments.createTitle'),
+        startTime: startAtIso,
+        duration: durationMin,
+        timezone: formTimeZone,
+      }, {
+        headers: authHeaders(accessToken),
+      });
+
+      setValue('meetingLink', String(response.data?.joinUrl ?? ''), { shouldDirty: true });
+    } catch (error) {
+      setGenerateMeetingLinkError(resolveApiError(error, t('appointments.errors.generateMeetingLink')));
+    } finally {
+      setIsGeneratingMeetingLink(false);
+    }
+  };
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
@@ -370,6 +415,31 @@ export function AppointmentFormDialog({
                 </FormControl>
               )}
             />
+            <Box sx={{ gridColumn: { xs: 'span 1', sm: 'span 2' } }}>
+              <AppButton
+                onClick={handleGenerateMeetingLink}
+                isLoading={isGeneratingMeetingLink}
+                disabled={isSubmittingForm || isCancellingAppointment}
+              >
+                {t('appointments.generateMeetingLink')}
+              </AppButton>
+              {generateMeetingLinkError ? (
+                <Typography variant="caption" color="error" sx={{ display: 'block', mt: 1 }}>
+                  {generateMeetingLinkError}
+                </Typography>
+              ) : null}
+            </Box>
+            <Controller
+              name="meetingLink"
+              control={control}
+              render={({ field }: any) => (
+                <AppRhfTextField
+                  field={field}
+                  label={t('appointments.fields.meetingLink')}
+                  sx={{ gridColumn: { xs: 'span 1', sm: 'span 2' } }}
+                />
+              )}
+            />
             <Controller name="firstName" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="First name" />} />
             <Controller name="lastName" control={control} render={({ field }: any) => <AppRhfTextField field={field} label="Last name" />} />
             <Controller
@@ -392,17 +462,6 @@ export function AppointmentFormDialog({
               name="username"
               control={control}
               render={({ field }: any) => <AppRhfTextField field={field} label="Telegram username" />}
-            />
-            <Controller
-              name="meetingLink"
-              control={control}
-              render={({ field }: any) => (
-                <AppRhfTextField
-                  field={field}
-                  label={t('appointments.fields.meetingLink')}
-                  sx={{ gridColumn: { xs: 'span 1', sm: 'span 2' } }}
-                />
-              )}
             />
             <Controller
               name="notes"

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -753,6 +753,7 @@ export function AppointmentsContainer() {
 
       <AppointmentFormDialog
         t={t}
+        accessToken={accessToken}
         open={isCreateOpen}
         editingItem={editingItem}
         specialists={specialists}

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -365,6 +365,7 @@ export const dictionaries = {
       eventNotify: 'Manual notification sent',
       meetingProviderManual: 'Manual link',
       meetingProviderZoom: 'Zoom',
+      generateMeetingLink: 'Generate meeting link',
       errors: {
         load: 'Unable to load appointments.',
         save: 'Unable to save appointment.',
@@ -372,6 +373,7 @@ export const dictionaries = {
         reschedule: 'Unable to reschedule appointment.',
         markPaid: 'Unable to confirm payment.',
         notify: 'Unable to send notification.',
+        generateMeetingLink: 'Unable to generate meeting link.',
         createSpecialistFirst: 'Create at least one specialist first.',
       },
       fields: {
@@ -749,6 +751,7 @@ export const dictionaries = {
       eventNotify: 'Ручное уведомление отправлено',
       meetingProviderManual: 'Ручная ссылка',
       meetingProviderZoom: 'Zoom',
+      generateMeetingLink: 'Сгенерировать ссылку на встречу',
       errors: {
         load: 'Не удалось загрузить записи.',
         save: 'Не удалось сохранить запись.',
@@ -756,6 +759,7 @@ export const dictionaries = {
         reschedule: 'Не удалось перенести запись.',
         markPaid: 'Не удалось подтвердить оплату.',
         notify: 'Не удалось отправить уведомление.',
+        generateMeetingLink: 'Не удалось сгенерировать ссылку на встречу.',
         createSpecialistFirst: 'Сначала создайте хотя бы одного специалиста.',
       },
       fields: {
@@ -1044,12 +1048,14 @@ export type TranslationKey =
   | 'appointments.eventNotify'
   | 'appointments.meetingProviderManual'
   | 'appointments.meetingProviderZoom'
+  | 'appointments.generateMeetingLink'
   | 'appointments.errors.load'
   | 'appointments.errors.save'
   | 'appointments.errors.cancel'
   | 'appointments.errors.reschedule'
   | 'appointments.errors.markPaid'
   | 'appointments.errors.notify'
+  | 'appointments.errors.generateMeetingLink'
   | 'appointments.errors.createSpecialistFirst'
   | 'appointments.fields.scheduledAt'
   | 'appointments.fields.status'


### PR DESCRIPTION
### Motivation

- Allow creating or generating meeting links directly from the appointment dialog to streamline scheduling and integrate Zoom meetings. 

### Description

- Added a `Generate meeting link` workflow to `AppointmentFormDialog.tsx` with `handleGenerateMeetingLink` that posts to `/api/integrations/zoom/meetings` using `apiClient` and `authHeaders`, and supports a manual provider that generates a unique URL with `crypto.randomUUID()`.
- Introduced UI pieces in `AppointmentFormDialog.tsx`: `Generate` button, loading/error states (`isGeneratingMeetingLink`, `generateMeetingLinkError`), and moved the `meetingLink` field next to the provider control; added watches for `endTime` and `meetingProvider` used by the generator.
- Propagated `accessToken` from `AppointmentsContainer.tsx` to the dialog so API calls can be authorized, and added imports for `resolveApiError` to surface localized errors.
- Added i18n keys in `web/src/shared/i18n/dictionaries.ts` for `appointments.generateMeetingLink` and `appointments.errors.generateMeetingLink`, and updated the README (`web/README.md`) to mention the meeting provider/link placement and generation option.

### Testing

- Ran lint/typecheck via `npm run -w @scheduletm/web lint` and `npm run -w @scheduletm/web build`, which completed successfully.
- Executed contract-level checks via `npm run -w @scheduletm/web test:e2e:contracts`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d2f3784833381625e5b892a3c4b)