### PR TITLE
Add offline locationAddress support in appointment flow

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -181,3 +181,11 @@
 - добавить Mapbox UI (выбор адреса в админке + read-only карта в публичной части);
 - довести fallback-цепочку online->offline/manual при ошибках внешних API;
 - добавить уведомления для offline с адресом/картой и отдельное событие для обновления manual-ссылки после создания записи.
+
+
+## Обновление locationAddress в appointment (2026-05-01)
+
+- в `POST/PATCH /api/appointments` добавлено поле `locationAddress` (MVP-хранение для `offline`);
+- адрес сохраняется и читается через существующий `comment`-payload (`locationAddress: ...`) вместе с `meetingProvider`/`meetingLink`;
+- в форме записи (`web`) для `meetingProvider=offline` добавлено поле адреса встречи;
+- добавлены i18n-ключи `appointments.fields.locationAddress` (ru/en).

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -219,7 +219,7 @@ export const specialistUpdateSchema = z.object({
 });
 
 const appointmentStatusSchema = z.enum(['new', 'confirmed', 'cancelled']);
-const appointmentMeetingProviderSchema = z.enum(['manual', 'zoom']);
+const appointmentMeetingProviderSchema = z.enum(['manual', 'zoom', 'offline']);
 
 const appointmentClientSchema = z.object({
   clientId: z.coerce.number().int().positive().optional(),
@@ -236,6 +236,7 @@ export const appointmentCreateSchema = z.object({
   appointmentEndAt: z.string().datetime(v.appointmentEndInvalid),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url(v.appointmentLinkInvalid).max(2048).optional().or(z.literal('')),
+  locationAddress: z.string().trim().max(500).optional(),
   meetingProvider: appointmentMeetingProviderSchema.optional(),
   saveClientMeetingPreference: z.boolean().optional(),
   notes: z.string().trim().max(2000, v.appointmentNotesTooLong).optional(),
@@ -283,6 +284,7 @@ export const appointmentUpdateSchema = z.object({
   durationMin: z.coerce.number().int().min(15, v.appointmentDurationMin).max(480, v.appointmentDurationMax).optional(),
   status: appointmentStatusSchema.optional(),
   meetingLink: z.string().trim().url(v.appointmentLinkInvalid).max(2048).optional().or(z.literal('')),
+  locationAddress: z.string().trim().max(500).optional(),
   meetingProvider: appointmentMeetingProviderSchema.optional(),
   notes: z.string().trim().max(2000, v.appointmentNotesTooLong).optional(),
 }).merge(appointmentClientSchema).superRefine((value, ctx) => {

--- a/server/src/services/appointmentService.ts
+++ b/server/src/services/appointmentService.ts
@@ -56,6 +56,7 @@ type AppointmentDto = {
   paymentStatus: 'paid' | 'unpaid';
   meetingProvider: 'manual' | 'zoom' | 'offline';
   meetingLink: string;
+  locationAddress: string;
   notes: string;
   client: AppointmentClientDto;
   events: AppointmentEventDto[];
@@ -95,6 +96,7 @@ type CreateAppointmentPayload = {
   status?: AppointmentStatus;
   meetingLink?: string;
   meetingProvider?: 'manual' | 'zoom' | 'offline';
+  locationAddress?: string;
   saveClientMeetingPreference?: boolean;
   notes?: string;
 } & AppointmentClientPayload;
@@ -106,16 +108,18 @@ type UpdateAppointmentPayload = {
   status?: AppointmentStatus;
   meetingLink?: string;
   meetingProvider?: 'manual' | 'zoom' | 'offline';
+  locationAddress?: string;
   notes?: string;
 } & AppointmentClientPayload;
 
-function parseMeetingMetaFromNotes(notes: string | null): { notes: string; meetingLink: string; meetingProvider: 'manual' | 'zoom' | 'offline' } {
+function parseMeetingMetaFromNotes(notes: string | null): { notes: string; meetingLink: string; locationAddress: string; meetingProvider: 'manual' | 'zoom' | 'offline' } {
   if (!notes) {
-    return { notes: '', meetingLink: '', meetingProvider: 'manual' };
+    return { notes: '', meetingLink: '', locationAddress: '', meetingProvider: 'manual' };
   }
 
   const lines = notes.split('\n');
   let meetingLink = '';
+  let locationAddress = '';
   let meetingProvider: 'manual' | 'zoom' | 'offline' = 'manual';
   const restLines: string[] = [];
   for (const line of lines) {
@@ -128,13 +132,18 @@ function parseMeetingMetaFromNotes(notes: string | null): { notes: string; meeti
       meetingProvider = parsed === 'zoom' ? 'zoom' : parsed === 'offline' ? 'offline' : 'manual';
       continue;
     }
+    if (line.startsWith('locationAddress: ')) {
+      locationAddress = line.slice('locationAddress: '.length).trim();
+      continue;
+    }
     restLines.push(line);
   }
-  return { meetingLink, meetingProvider, notes: restLines.join('\n').trim() };
+  return { meetingLink, locationAddress, meetingProvider, notes: restLines.join('\n').trim() };
 }
 
-function composeNotes(meetingLink: string | undefined, notes: string | undefined, meetingProvider: 'manual' | 'zoom' | 'offline' | undefined): string | null {
+function composeNotes(meetingLink: string | undefined, locationAddress: string | undefined, notes: string | undefined, meetingProvider: 'manual' | 'zoom' | 'offline' | undefined): string | null {
   const normalizedMeetingLink = meetingLink?.trim() ?? '';
+  const normalizedLocationAddress = locationAddress?.trim() ?? '';
   const normalizedNotes = notes?.trim() ?? '';
   const normalizedProvider = meetingProvider ?? 'manual';
 
@@ -144,6 +153,9 @@ function composeNotes(meetingLink: string | undefined, notes: string | undefined
   const lines = [`meetingProvider: ${normalizedProvider}`];
   if (normalizedMeetingLink) {
     lines.push(`meetingLink: ${normalizedMeetingLink}`);
+  }
+  if (normalizedLocationAddress) {
+    lines.push(`locationAddress: ${normalizedLocationAddress}`);
   }
   if (normalizedNotes) {
     lines.push(normalizedNotes);
@@ -175,6 +187,7 @@ function mapAppointment(row: AppointmentRecord): AppointmentDto {
     meetingProvider: parsed.meetingProvider,
     notes: parsed.notes,
     meetingLink: parsed.meetingLink,
+    locationAddress: parsed.locationAddress,
     client: {
       id: row.user_id,
       username: row.client_username ?? '',
@@ -498,7 +511,7 @@ export async function createAppointmentForActor(
     specialistId: payload.specialistId,
     scheduledAt: new Date(payload.appointmentAt),
     status: payload.status ?? 'new',
-    notes: composeNotes(meetingLink, payload.notes, meetingProvider),
+    notes: composeNotes(meetingLink, payload.locationAddress, payload.notes, meetingProvider),
     userId,
     serviceId,
     durationMin: resolveDurationFromRange(payload.appointmentAt, payload.appointmentEndAt),
@@ -593,8 +606,8 @@ export async function updateAppointmentForActor(
     durationMin,
     status: payload.status,
     userId,
-    notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink') || Object.prototype.hasOwnProperty.call(payload, 'meetingProvider')
-      ? composeNotes(payload.meetingLink, payload.notes, payload.meetingProvider)
+    notes: Object.prototype.hasOwnProperty.call(payload, 'notes') || Object.prototype.hasOwnProperty.call(payload, 'meetingLink') || Object.prototype.hasOwnProperty.call(payload, 'meetingProvider') || Object.prototype.hasOwnProperty.call(payload, 'locationAddress')
+      ? composeNotes(payload.meetingLink, payload.locationAddress, payload.notes, payload.meetingProvider)
       : undefined,
   });
 

--- a/web/src/components/appointments/AppointmentFormDialog.tsx
+++ b/web/src/components/appointments/AppointmentFormDialog.tsx
@@ -70,6 +70,7 @@ type Props = {
     status: AppointmentStatus;
     meetingProvider: 'manual' | 'zoom' | 'offline';
     meetingLink: string;
+    locationAddress: string;
     notes: string;
     appointmentAt: string;
     appointmentEndAt: string;
@@ -91,6 +92,7 @@ const EMPTY_FORM: AppointmentFormState = {
   status: 'new',
   meetingProvider: 'manual',
   meetingLink: '',
+  locationAddress: '',
   notes: '',
   username: '',
   firstName: '',
@@ -150,6 +152,7 @@ export function AppointmentFormDialog({
         status: editingItem.status,
         meetingProvider: editingItem.meetingProvider ?? 'manual',
         meetingLink: editingItem.meetingLink,
+        locationAddress: editingItem.locationAddress ?? '',
         notes: editingItem.notes,
         username: editingItem.client?.username ?? '',
         firstName: editingItem.client?.firstName ?? '',
@@ -174,6 +177,7 @@ export function AppointmentFormDialog({
       status: 'new',
       meetingProvider: 'manual',
       meetingLink: '',
+      locationAddress: '',
       notes: '',
       username: '',
       firstName: '',
@@ -245,6 +249,7 @@ export function AppointmentFormDialog({
       status: form.status,
       meetingProvider: form.meetingProvider,
       meetingLink: form.meetingLink,
+      locationAddress: form.locationAddress,
       notes: form.notes,
       appointmentAt: startIso,
       appointmentEndAt: endIso,
@@ -453,6 +458,19 @@ export function AppointmentFormDialog({
                 />
               )}
             />
+            {meetingProviderValue === 'offline' && (
+              <Controller
+                name="locationAddress"
+                control={control}
+                render={({ field }: any) => (
+                  <AppRhfTextField
+                    field={field}
+                    label={t('appointments.fields.locationAddress')}
+                    sx={{ gridColumn: { xs: 'span 1', sm: 'span 2' } }}
+                  />
+                )}
+              />
+            )}
             <Controller name="firstName" control={control} render={({ field }: any) => <AppRhfTextField field={field} label={t('appointments.fields.clientFirstName')} />} />
             <Controller name="lastName" control={control} render={({ field }: any) => <AppRhfTextField field={field} label={t('appointments.fields.clientLastName')} />} />
             <Controller

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -352,6 +352,7 @@ export function AppointmentsContainer() {
     status: AppointmentItem['status'];
     meetingProvider: 'manual' | 'zoom' | 'offline';
     meetingLink: string;
+    locationAddress: string;
     notes: string;
     clientId?: number;
     username: string;
@@ -379,6 +380,7 @@ export function AppointmentsContainer() {
           status: payload.status,
           meetingProvider: payload.meetingProvider,
           meetingLink: payload.meetingLink,
+          locationAddress: payload.locationAddress,
           notes: payload.notes,
           clientId: payload.clientId,
           username: payload.username,
@@ -397,6 +399,7 @@ export function AppointmentsContainer() {
           status: payload.status,
           meetingProvider: payload.meetingProvider,
           meetingLink: payload.meetingLink,
+          locationAddress: payload.locationAddress,
           notes: payload.notes,
           clientId: payload.clientId,
           username: payload.username,

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -387,6 +387,7 @@ export const dictionaries = {
         status: 'Status',
         meetingProvider: 'Meeting provider',
         meetingLink: 'Meeting link',
+        locationAddress: 'Location address',
         notes: 'Notes',
         clientFirstName: 'Client first name',
         clientLastName: 'Client last name',
@@ -785,6 +786,7 @@ export const dictionaries = {
         status: 'Статус',
         meetingProvider: 'Провайдер встречи',
         meetingLink: 'Ссылка на встречу',
+        locationAddress: 'Адрес встречи',
         notes: 'Комментарий',
         clientFirstName: 'Имя клиента',
         clientLastName: 'Фамилия клиента',
@@ -1091,6 +1093,7 @@ export type TranslationKey =
   | 'appointments.fields.status'
   | 'appointments.fields.meetingProvider'
   | 'appointments.fields.meetingLink'
+  | 'appointments.fields.locationAddress'
   | 'notificationLogs.pageTitle'
   | 'notificationLogs.pageSubtitle'
   | 'notificationLogs.accessDenied'

--- a/web/src/shared/types/api.ts
+++ b/web/src/shared/types/api.ts
@@ -141,6 +141,7 @@ export type AppointmentItem = {
   paymentStatus: 'paid' | 'unpaid';
   meetingProvider: 'manual' | 'zoom' | 'offline';
   meetingLink: string;
+  locationAddress: string;
   notes: string;
   client: ClientItem;
   events: Array<{


### PR DESCRIPTION
### Motivation
- Реализация следующего шага из плана по meeting providers: добавить MVP-хранение адреса для офлайн-встреч (`locationAddress`) и протянуть его через API/UI без изменения схемы БД. 

### Description
- Расширена валидация request/response схемы: `meetingProvider` теперь включает `offline`, а в `appointmentCreate/Update` добавлено поле `locationAddress` в `server/src/config/schemas.ts`.
- В `server/src/services/appointmentService.ts` добавлен парсинг/составление `locationAddress` внутри существующего `comment`-payload (`locationAddress: ...`) вместе с `meetingProvider`/`meetingLink`, и поле включено в API DTO.
- На фронтенде обновлены контракты и UI: `locationAddress` добавлено в `web/src/shared/types/api.ts`, в форму записи (`AppointmentFormDialog`) отображается поле адреса для `meetingProvider === 'offline'`, и значение отправляется при `POST/PATCH /api/appointments` (`web/src/components/...` и `web/src/containers/AppointmentsContainer.tsx`).
- Добавлены i18n-ключи `appointments.fields.locationAddress` для `en/ru` и обновлён документ плана `docs/meeting-platforms-zoom-plan.md` с пометкой выполненного шага.

### Testing
- `npm run -w @scheduletm/web lint -- --max-warnings=0` — успешно (lint прошёл).
- `npm run -w @scheduletm/server test` — запущены тесты через `vitest`, часть интеграционных тестов не прошла (3 failed) из-за сетевой ошибки при подключении к удалённой тестовой БД (`Error: connect ENETUNREACH ...`), остальные тесты выполнились; на месте CI/локального окружения проблема выглядит как внешняя/сетевая, а не как регрессия в логике новых изменений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f485887c948333ae164e2720e5b921)