### PR TITLE
fix: add locationAddress to appointments form state and fix web typecheck

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -214,3 +214,8 @@
   - при наличии `businessLat/businessLng` показывается статическая карта с маркером;
   - при наличии `businessAddress` показывается кнопка перехода в Mapbox Search;
 - для включения используется `VITE_MAPBOX_PUBLIC_TOKEN` на frontend.
+
+## Исправление typecheck в web для offline-адреса (2026-05-01)
+
+- `locationAddress` добавлен в общий `EditFormState` (web appointments utils), чтобы состояние формы записи и submit payload для `meetingProvider=offline` были согласованы типами;
+- устранены ошибки `tsc --noEmit` в `AppointmentFormDialog` и `AppointmentsContainer`, связанные с отсутствием `locationAddress` в базовом типе формы.

--- a/web/src/components/appointments/appointmentsUtils.ts
+++ b/web/src/components/appointments/appointmentsUtils.ts
@@ -8,6 +8,7 @@ export type EditFormState = {
   status: AppointmentStatus;
   meetingProvider: 'manual' | 'zoom' | 'offline';
   meetingLink: string;
+  locationAddress: string;
   notes: string;
 };
 

--- a/web/src/containers/AppointmentsContainer.tsx
+++ b/web/src/containers/AppointmentsContainer.tsx
@@ -787,6 +787,7 @@ export function AppointmentsContainer() {
           status: payload.status,
           meetingProvider: payload.meetingProvider,
           meetingLink: payload.meetingLink,
+          locationAddress: payload.locationAddress,
           notes: payload.notes,
           clientId: payload.clientId,
           username: payload.username,


### PR DESCRIPTION
### Motivation

- Внедряется поддержка офлайн-встреч с полем `locationAddress`, и типы формы должны быть согласованы с новым payload и документацией.

### Description

- Добавлено `locationAddress` в `EditFormState` в `web/src/components/appointments/appointmentsUtils.ts` для согласования состояния формы с офлайн-потоком.
- Проброшено поле `locationAddress` в маппинге submit-пэйлоуда в `web/src/containers/AppointmentsContainer.tsx` чтобы убрать несовпадение типов при отправке формы.
- Обновлена документация `docs/meeting-platforms-zoom-plan.md` с заметкой об исправлении typecheck для offline-адреса.

### Testing

- Запущена команда `npm run -w @scheduletm/web typecheck` до правок, которая возвращала ошибки компиляции по отсутствующему `locationAddress` в форме, и ошибки были видимы в `AppointmentFormDialog` и `AppointmentsContainer`.
- После правок `npm run -w @scheduletm/web typecheck` выполнена повторно и завершилась успешно (`tsc --noEmit` прошёл без ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4923e6444833395eed20feba16792)