### PR TITLE
Show Mapbox fallback UI in Account settings (hint when token missing)

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -215,6 +215,12 @@
   - при наличии `businessAddress` показывается кнопка перехода в Mapbox Search;
 - для включения используется `VITE_MAPBOX_PUBLIC_TOKEN` на frontend.
 
+## Обновление Mapbox UX fallback в Account Settings (2026-05-01)
+
+- блок карты в `Settings -> Account settings` теперь всегда отображается (даже без токена);
+- если `VITE_MAPBOX_PUBLIC_TOKEN` не задан или координаты пустые, показывается явная подсказка о необходимости токена вместо «пропавшей» карты;
+- кнопка перехода в `Mapbox Search` по `businessAddress` остается доступной отдельно.
+
 ## Что осталось доделать (актуально на 2026-05-01)
 
 Ниже — короткий actionable backlog именно по Zoom/multi-provider направлению, синхронизированный с `README.md`, `TODO.md` и текущим состоянием этого плана.

--- a/web/README.md
+++ b/web/README.md
@@ -55,11 +55,13 @@ npm run -w @scheduletm/web verify
 ## Переменные окружения
 
 - `VITE_API_URL` — базовый URL API (build-time).
+- `VITE_MAPBOX_PUBLIC_TOKEN` — публичный токен Mapbox для предпросмотра карты в `Settings -> Account settings`.
 
 Пример:
 
 ```bash
 VITE_API_URL=https://api.example.com
+VITE_MAPBOX_PUBLIC_TOKEN=pk.xxxxx
 ```
 
 Для отдельного dev-домена:
@@ -73,7 +75,10 @@ VITE_API_URL=https://apidev.meetli.cc
 
 ```bash
 VITE_API_URL=http://localhost:3003
+VITE_MAPBOX_PUBLIC_TOKEN=pk.xxxxx
 ```
+
+Если `VITE_MAPBOX_PUBLIC_TOKEN` не задан, в `Account settings` вместо карты показывается явная подсказка, а кнопка `Open in Mapbox search` продолжает работать по `Business address`.
 
 Если оставить удалённый `VITE_API_URL` (например `https://apidev.meetli.cc`) при локальном запуске, на странице `/login` может появляться `Network connection issue`, и login-шаг UI e2e не пройдет.
 

--- a/web/src/components/SettingsCard.types.ts
+++ b/web/src/components/SettingsCard.types.ts
@@ -26,6 +26,7 @@ export type SettingsCardCopy = {
   businessLat: string;
   businessLng: string;
   businessMapPreview: string;
+  mapboxTokenMissingHint: string;
   openMapboxSearch: string;
   refreshTokenTtlDays: string;
   accessTokenTtlSeconds: string;

--- a/web/src/components/settings-tabs/AccountSettingsTab.tsx
+++ b/web/src/components/settings-tabs/AccountSettingsTab.tsx
@@ -79,22 +79,26 @@ export function AccountSettingsTab({ copy, control, meetingDurationOptions, isSa
         )}
       />
 
-      {mapboxToken ? (
-        <Stack spacing={1} sx={{ mt: 1, mb: 2 }}>
-          <Typography variant="body2" color="text.secondary">
-            {copy.businessMapPreview}
+      <Stack spacing={1} sx={{ mt: 1, mb: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          {copy.businessMapPreview}
+        </Typography>
+        {mapboxToken && staticMapUrl ? (
+          <Box component="img" src={staticMapUrl} alt={copy.businessAddress} sx={{ width: '100%', borderRadius: 1, border: '1px solid', borderColor: 'divider' }} />
+        ) : (
+          <Typography variant="caption" color="text.secondary">
+            {copy.mapboxTokenMissingHint}
           </Typography>
-          {staticMapUrl ? <Box component="img" src={staticMapUrl} alt={copy.businessAddress} sx={{ width: '100%', borderRadius: 1, border: '1px solid', borderColor: 'divider' }} /> : null}
-          {businessAddress.trim() ? (
-            <AppButton
-              variant="outlined"
-              onClick={() => window.open(`https://www.mapbox.com/search/?query=${encodeURIComponent(businessAddress.trim())}`, '_blank', 'noopener,noreferrer')}
-            >
-              {copy.openMapboxSearch}
-            </AppButton>
-          ) : null}
-        </Stack>
-      ) : null}
+        )}
+        {businessAddress.trim() ? (
+          <AppButton
+            variant="outlined"
+            onClick={() => window.open(`https://www.mapbox.com/search/?query=${encodeURIComponent(businessAddress.trim())}`, '_blank', 'noopener,noreferrer')}
+          >
+            {copy.openMapboxSearch}
+          </AppButton>
+        ) : null}
+      </Stack>
 
       <Controller
         name="defaultMeetingDuration"

--- a/web/src/containers/SettingsContainer.tsx
+++ b/web/src/containers/SettingsContainer.tsx
@@ -580,6 +580,7 @@ export function SettingsContainer() {
               businessLat: t('settings.businessLat'),
               businessLng: t('settings.businessLng'),
               businessMapPreview: t('settings.businessMapPreview'),
+              mapboxTokenMissingHint: t('settings.mapboxTokenMissingHint'),
               openMapboxSearch: t('settings.openMapboxSearch'),
               refreshTokenTtlDays: t('settings.refreshTokenTtlDays'),
               accessTokenTtlSeconds: t('settings.accessTokenTtlSeconds'),

--- a/web/src/shared/i18n/dictionaries.ts
+++ b/web/src/shared/i18n/dictionaries.ts
@@ -117,6 +117,7 @@ export const dictionaries = {
       businessLat: 'Business latitude',
       businessLng: 'Business longitude',
       businessMapPreview: 'Map preview',
+      mapboxTokenMissingHint: 'Set VITE_MAPBOX_PUBLIC_TOKEN to show map preview.',
       openMapboxSearch: 'Open in Mapbox search',
       refreshTokenTtlDays: 'Refresh token TTL (days)',
       accessTokenTtlSeconds: 'Access token TTL (seconds)',
@@ -521,6 +522,7 @@ export const dictionaries = {
       businessLat: 'Широта',
       businessLng: 'Долгота',
       businessMapPreview: 'Предпросмотр на карте',
+      mapboxTokenMissingHint: 'Укажите VITE_MAPBOX_PUBLIC_TOKEN, чтобы включить предпросмотр карты.',
       openMapboxSearch: 'Открыть поиск в Mapbox',
       refreshTokenTtlDays: 'TTL refresh token (дни)',
       accessTokenTtlSeconds: 'TTL access token (сек)',
@@ -919,6 +921,7 @@ export type TranslationKey =
   | 'settings.businessLat'
   | 'settings.businessLng'
   | 'settings.businessMapPreview'
+  | 'settings.mapboxTokenMissingHint'
   | 'settings.openMapboxSearch'
   | 'settings.refreshTokenTtlDays'
   | 'settings.accessTokenTtlSeconds'


### PR DESCRIPTION
### Motivation
- The Mapbox preview block in `Settings -> Account settings` could disappear when `VITE_MAPBOX_PUBLIC_TOKEN` or coordinates were not present, causing confusing UI gaps. 
- Provide a simple KISS UX so the map area is always visible and users see an actionable hint when the token is missing. 
- Keep existing behavior for the `Open in Mapbox search` button regardless of preview availability. 

### Description
- Updated `AccountSettingsTab` to always render the Mapbox section and to show the static map only when both `VITE_MAPBOX_PUBLIC_TOKEN` and coordinates are available, otherwise rendering a hint text. 
- Added new copy key `mapboxTokenMissingHint` to `SettingsCard.types` and wired it through `SettingsContainer` to the settings copy passed into the tab. 
- Added i18n strings (EN/RU) and extended the translation union for the new `settings.mapboxTokenMissingHint` key. 
- Updated documentation in `docs/meeting-platforms-zoom-plan.md` and `web/README.md` to document the `VITE_MAPBOX_PUBLIC_TOKEN` env var and the new fallback UX. 

### Testing
- Ran lint for the web package with `npm run -w @scheduletm/web lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4955173d48333811ed587cbd3b920)