### PR TITLE
web: add geolocation fallback for Account Settings map preview

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -78,6 +78,8 @@ VITE_API_URL=http://localhost:3003
 VITE_MAPBOX_PUBLIC_TOKEN=pk.xxxxx
 ```
 
+Если `VITE_MAPBOX_PUBLIC_TOKEN` задан, предпросмотр карты в `Account settings` сначала берет `Business lat/lng`, а если они пустые — пытается использовать текущие координаты браузера (через `navigator.geolocation`, с разрешением пользователя).
+
 Если `VITE_MAPBOX_PUBLIC_TOKEN` не задан, в `Account settings` вместо карты показывается явная подсказка, а кнопка `Open in Mapbox search` продолжает работать по `Business address`.
 
 Если оставить удалённый `VITE_API_URL` (например `https://apidev.meetli.cc`) при локальном запуске, на странице `/login` может появляться `Network connection issue`, и login-шаг UI e2e не пройдет.

--- a/web/src/components/settings-tabs/AccountSettingsTab.tsx
+++ b/web/src/components/settings-tabs/AccountSettingsTab.tsx
@@ -1,5 +1,6 @@
 import { Box, FormControl, FormControlLabel, InputLabel, MenuItem, Select, Stack, Switch, Typography } from '@mui/material';
 import { Controller, Control, useWatch } from 'react-hook-form';
+import { useEffect, useState } from 'react';
 
 import type { AccountSettings } from '../../shared/types/api';
 import type { SettingsCardCopy } from '../SettingsCard.types';
@@ -22,9 +23,30 @@ export function AccountSettingsTab({ copy, control, meetingDurationOptions, isSa
   const businessLat = useWatch({ control, name: 'businessLat' });
   const businessLng = useWatch({ control, name: 'businessLng' });
   const mapboxToken = import.meta.env.VITE_MAPBOX_PUBLIC_TOKEN as string | undefined;
-  const hasCoordinates = typeof businessLat === 'number' && typeof businessLng === 'number';
+  const [defaultCoordinates, setDefaultCoordinates] = useState<{ lat: number; lng: number } | null>(null);
+
+  useEffect(() => {
+    if (typeof businessLat === 'number' && typeof businessLng === 'number') {
+      return;
+    }
+
+    if (!navigator.geolocation) {
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition((position) => {
+      setDefaultCoordinates({
+        lat: position.coords.latitude,
+        lng: position.coords.longitude,
+      });
+    });
+  }, [businessLat, businessLng]);
+
+  const mapLat = typeof businessLat === 'number' ? businessLat : defaultCoordinates?.lat;
+  const mapLng = typeof businessLng === 'number' ? businessLng : defaultCoordinates?.lng;
+  const hasCoordinates = typeof mapLat === 'number' && typeof mapLng === 'number';
   const staticMapUrl = hasCoordinates && mapboxToken
-    ? `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/pin-s+285A98(${businessLng},${businessLat})/${businessLng},${businessLat},14/720x320?access_token=${mapboxToken}`
+    ? `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/pin-s+285A98(${mapLng},${mapLat})/${mapLng},${mapLat},14/720x320?access_token=${mapboxToken}`
     : '';
 
   return (


### PR DESCRIPTION
### Motivation
- Сделать предпросмотр карты в `AccountSettingsTab` более полезным, даже если поля `businessLat`/`businessLng` пустые. 
- Улучшить UX, подставляя текущие координаты пользователя вместо пустого превью, когда пользователь даст разрешение на геолокацию.

### Description
- В `web/src/components/settings-tabs/AccountSettingsTab.tsx` добавлен `useState`/`useEffect` и логика запроса через `navigator.geolocation` для получения текущих координат при отсутствии `businessLat`/`businessLng`.
- Вычисляются `mapLat`/`mapLng` с приоритетом явных бизнес-координат и fallback на данные из браузера, и `staticMapUrl` теперь строится из `mapLat`/`mapLng`.
- Сохранено текущее поведение при наличии явных координат бизнеса; поведение не интрузивное и запрашивает геолокацию только при необходимости.
- Обновлён `web/README.md` с описанием нового fallback-поведения для Mapbox preview.

### Testing
- Запущен линтер с `npm run -w @scheduletm/web lint`, результат — успешно (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49a408180833388d46af1b70096b6)