### PR TITLE
Implement silent access-token refresh in client and add session FAQ to server README

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -121,6 +121,39 @@ npm run -w @scheduletm/server test -- business.integration.test.ts
 - `errorAlertsTelegramChatId` — chat id (личный/групповой);
 - в `GET /api/settings/system` возвращается только флаг `errorAlertsTelegramEnabled`, сами секреты не отдаются.
 
+
+## FAQ: почему разлогинивает после рестарта локального фронта/бэка
+
+Коротко: web-сессии **не хранятся в памяти процесса** и не должны теряться из-за restart самого Node.js.
+
+Сроки жизни по умолчанию:
+- `ACCESS_TOKEN_TTL_SECONDS=900` (15 минут).
+- `REFRESH_TOKEN_TTL_DAYS=30` (30 дней).
+
+- Refresh/access токены сохраняются в таблице `web_user_sessions` (PostgreSQL).
+- В браузере хранится только refresh cookie (`SESSION_COOKIE_NAME`) и csrf cookie (`<SESSION_COOKIE_NAME>_csrf`).
+
+Если после локального рестарта вылетает логин, обычно причина в окружении/cookie:
+
+1. Меняется `SESSION_COOKIE_NAME` между запусками (или между `.env` файлами).
+2. Неверный `SESSION_COOKIE_DOMAIN` для локалки (должен быть пустой).
+3. Фронт и API ходят на другой origin, который не входит в `CORS_ALLOWED_ORIGINS`.
+4. В dev фронт не отправляет credentials (cookie не прикладываются к `/api/auth/refresh`).
+5. Вы пересоздали БД/применили миграции в другую БД, и `web_user_sessions` пустая.
+
+
+Важно по безопасности (OAuth 2.0 / BCP):
+- Текущий web-auth flow — это cookie + session-tokens backend-а (не сторонний OAuth authorization server).
+- Silent refresh на 401 допустим, если сохраняются CSRF-проверка и rotation refresh-токена (у нас refresh одноразовый: старый сразу revoke).
+- Для production рекомендуется минимизировать хранение access token в `localStorage` (предпочтительнее in-memory), чтобы снизить риск при XSS.
+
+Практичный чек для локалки:
+
+- `SESSION_COOKIE_DOMAIN=` (пусто)
+- одинаковый `SESSION_COOKIE_NAME` во всех локальных env
+- `CORS_ALLOWED_ORIGINS` содержит origin фронта (например, `http://localhost:5173`)
+- в браузере у запроса `POST /api/auth/refresh` реально уходит cookie + `x-csrf-token`
+
 ## Документация
 
 - Глобальный обзор: [`../README.md`](../README.md)

--- a/web/src/shared/api/client.ts
+++ b/web/src/shared/api/client.ts
@@ -18,9 +18,83 @@ export const apiClient = axios.create({
 });
 
 let unauthorizedHandler: (() => void) | null = null;
+let accessTokenRefreshedHandler: ((token: string) => void) | null = null;
 
 export function setUnauthorizedHandler(handler: (() => void) | null) {
   unauthorizedHandler = handler;
+}
+
+export function setAccessTokenRefreshedHandler(handler: ((token: string) => void) | null) {
+  accessTokenRefreshedHandler = handler;
+}
+
+function readCookie(name: string): string {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+
+  const parts = document.cookie.split(';').map((part) => part.trim());
+  const match = parts.find((part) => part.startsWith(`${name}=`));
+  if (!match) {
+    return '';
+  }
+
+  return decodeURIComponent(match.slice(name.length + 1));
+}
+
+function readAuthCsrfCookie(): string {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+
+  const entries = document.cookie.split(';')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const eqIndex = part.indexOf('=');
+      if (eqIndex <= 0) {
+        return null;
+      }
+
+      return {
+        name: part.slice(0, eqIndex),
+        value: decodeURIComponent(part.slice(eqIndex + 1)),
+      };
+    })
+    .filter((entry): entry is { name: string; value: string } => Boolean(entry));
+
+  const byName = new Map(entries.map((entry) => [entry.name, entry.value]));
+  const csrfEntry = entries.find((entry) => entry.name.endsWith('_csrf') && byName.has(entry.name.slice(0, -5)));
+  return csrfEntry?.value ?? '';
+}
+
+let refreshPromise: Promise<string | null> | null = null;
+
+async function refreshAccessToken(): Promise<string | null> {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const csrfToken = readAuthCsrfCookie() || readCookie('scheduletm_refresh_csrf') || readCookie('meetli_refresh_token_csrf');
+      const response = await apiClient.post<{ accessToken: string }>(
+        '/api/auth/refresh',
+        {},
+        {
+          headers: csrfToken ? { 'x-csrf-token': csrfToken } : undefined,
+          ...( { skipAuthRefresh: true } as Record<string, unknown>),
+        }
+      );
+      return response.data.accessToken;
+    })()
+      .catch(() => null)
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
+
+export async function tryRefreshAccessToken(): Promise<string | null> {
+  return refreshAccessToken();
 }
 
 apiClient.interceptors.request.use((config) => {
@@ -47,8 +121,25 @@ apiClient.interceptors.response.use((response) => {
   }
 
   return response;
-}, (error) => {
-  if (error?.response?.status === 401) {
+}, async (error) => {
+  const originalRequest = error?.config as (Record<string, unknown> & { headers?: Record<string, string> }) | undefined;
+  const status = error?.response?.status;
+  const url = String(originalRequest?.url ?? '');
+
+  if (status === 401 && !originalRequest?.skipAuthRefresh && !originalRequest?._retry && !url.includes('/api/auth/refresh')) {
+    originalRequest._retry = true;
+    const nextAccessToken = await refreshAccessToken();
+    if (nextAccessToken) {
+      accessTokenRefreshedHandler?.(nextAccessToken);
+      originalRequest.headers = {
+        ...(originalRequest.headers ?? {}),
+        Authorization: `Bearer ${nextAccessToken}`,
+      };
+      return apiClient.request(originalRequest);
+    }
+  }
+
+  if (status === 401) {
     unauthorizedHandler?.();
   }
 

--- a/web/src/shared/auth/AuthContext.tsx
+++ b/web/src/shared/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
-import { setUnauthorizedHandler } from '../api/client';
+import { setAccessTokenRefreshedHandler, setUnauthorizedHandler, tryRefreshAccessToken } from '../api/client';
 import type { WebUserRole } from '../types/roles';
 
 type AuthUser = {
@@ -53,6 +53,11 @@ export function AuthProvider({ children }: PropsWithChildren) {
   };
 
   useEffect(() => {
+    setAccessTokenRefreshedHandler((token) => {
+      setAccessTokenState(token);
+      localStorage.setItem(TOKEN_KEY, token);
+    });
+
     setUnauthorizedHandler(() => {
       clearAuth();
       if (window.location.pathname !== '/login') {
@@ -60,10 +65,27 @@ export function AuthProvider({ children }: PropsWithChildren) {
       }
     });
 
+    if (!accessToken && user) {
+      tryRefreshAccessToken()
+        .then((nextToken) => {
+          if (!nextToken) {
+            clearAuth();
+            return;
+          }
+
+          setAccessTokenState(nextToken);
+          localStorage.setItem(TOKEN_KEY, nextToken);
+        })
+        .catch(() => {
+          clearAuth();
+        });
+    }
+
     return () => {
+      setAccessTokenRefreshedHandler(null);
       setUnauthorizedHandler(null);
     };
-  }, []);
+  }, [accessToken, user]);
 
   const value = useMemo(() => ({
     accessToken,


### PR DESCRIPTION
### Motivation

- Ensure single-page app recovers web session after backend restarts by performing a silent refresh and persisting refreshed access tokens to localStorage.
- Prevent unnecessary logouts on 401 responses by retrying requests after rotating refresh tokens are used by the backend.
- Provide local development guidance about why sessions may appear to be lost after restarting frontend/backend.

### Description

- Added FAQ and troubleshooting section to `server/README.md` explaining session storage, cookie names, CSRF cookies, TTLs, common local-dev pitfalls, and security notes.
- Enhanced `web/src/shared/api/client.ts` to support refresh flow by adding cookie readers, `refreshAccessToken()` and `tryRefreshAccessToken()`, a single-flight `refreshPromise`, an `accessTokenRefreshedHandler`, and an axios response interceptor that attempts a refresh and retries the original request on 401s while avoiding refresh loops.
- Updated `web/src/shared/auth/AuthContext.tsx` to register the `accessTokenRefreshedHandler`, attempt an initial silent refresh when there is a stored user but no access token, and persist renewed access tokens to `localStorage` using the existing `TOKEN_KEY` (`scheduletm_access_token`).

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cd2657a083338255214928f9d866)