### PR TITLE
feat(settings): convert meeting provider policy inputs to dropdowns

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -307,3 +307,12 @@
 ### Decision point
 Если цель — быстрый go-live в Marketplace, можно идти в **Published/Unlisted** без Beta.
 Если нужен именно **Beta badge/workflow**, обязательно закрываем пакет evidence выше.
+
+## UI update: specialist meeting provider selectors (2026-05-02)
+
+- Вкладка Specialist policy в настройках теперь использует dropdown для:
+  - `meeting_providers_priority`
+  - `allowed_meeting_providers`
+- В UI показываются человекочитаемые названия (`Offline`, `Zoom`, `Manual link`),
+  а в payload на backend по-прежнему уходит строка с ID провайдеров (например `offline,zoom,manual`).
+- Решение сделано в формате KISS: фиксированные MVP-наборы комбинаций для приоритета и allowed-списка.

--- a/web/src/components/settings-tabs/SpecialistPolicyTab.tsx
+++ b/web/src/components/settings-tabs/SpecialistPolicyTab.tsx
@@ -1,4 +1,4 @@
-import { FormControlLabel, Switch, Typography } from '@mui/material';
+import { FormControl, FormControlLabel, InputLabel, MenuItem, Select, Switch, Typography } from '@mui/material';
 import { Controller, Control } from 'react-hook-form';
 
 import type { SpecialistBookingPolicy } from '../../shared/types/api';
@@ -14,6 +14,37 @@ type Props = {
   isSaving: boolean;
   onSubmit: () => void;
 };
+
+const providerLabelById: Record<string, string> = {
+  offline: 'Offline',
+  zoom: 'Zoom',
+  manual: 'Manual link'
+};
+
+const providerPriorityOptions = [
+  'offline,zoom,manual',
+  'offline,manual,zoom',
+  'zoom,offline,manual',
+  'zoom,manual,offline',
+  'manual,offline,zoom',
+  'manual,zoom,offline'
+].map((value) => ({
+  value,
+  label: value.split(',').map((id) => providerLabelById[id] ?? id).join(' → ')
+}));
+
+const allowedProviderOptions = [
+  'offline,zoom,manual',
+  'offline,zoom',
+  'offline,manual',
+  'zoom,manual',
+  'offline',
+  'zoom',
+  'manual'
+].map((value) => ({
+  value,
+  label: value.split(',').map((id) => providerLabelById[id] ?? id).join(', ')
+}));
 
 export function SpecialistPolicyTab({ copy, control, isSaving, onSubmit }: Props) {
   return (
@@ -69,18 +100,34 @@ export function SpecialistPolicyTab({ copy, control, isSaving, onSubmit }: Props
           />
         )}
       />
+
       <Controller
         name="meetingProvidersPriority"
         control={control}
         render={({ field }: any) => (
-          <AppRhfTextField field={field} label={copy.meetingProvidersPriority} />
+          <FormControl fullWidth>
+            <InputLabel>{copy.meetingProvidersPriority}</InputLabel>
+            <Select {...field} label={copy.meetingProvidersPriority}>
+              {providerPriorityOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         )}
       />
+
       <Controller
         name="allowedMeetingProviders"
         control={control}
         render={({ field }: any) => (
-          <AppRhfTextField field={field} label={copy.allowedMeetingProviders} />
+          <FormControl fullWidth>
+            <InputLabel>{copy.allowedMeetingProviders}</InputLabel>
+            <Select {...field} label={copy.allowedMeetingProviders}>
+              {allowedProviderOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         )}
       />
       <Controller


### PR DESCRIPTION
### Motivation
- Prevent invalid free-text input for meeting provider policies and improve UX by showing human-readable provider names.
- Keep existing API contract so backend still receives provider ID strings like `offline,zoom,manual`.
- Implement a simple, KISS MVP set of selectable combinations for priority and allowed-provider lists.

### Description
- Replaced free-text `meetingProvidersPriority` and `allowedMeetingProviders` fields with MUI `Select` dropdowns in `web/src/components/settings-tabs/SpecialistPolicyTab.tsx`.
- Added `providerLabelById` mapping and fixed option sets `providerPriorityOptions` and `allowedProviderOptions` that render readable labels while storing ID strings as values.
- Kept form value format unchanged so payloads continue to send comma-separated provider IDs (e.g. `offline,zoom,manual`).
- Updated documentation `docs/meeting-platforms-zoom-plan.md` with a dated note about the UI change and the decision rationale.

### Testing
- Ran lint: `npm --prefix web run lint -- --max-warnings=0`, which completed successfully.
- No unit tests were modified in this change and no additional automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ef89120c8333bdb5aead9644a61f)