### PR TITLE
SpecialistPolicyTab: add meeting provider priority dropdown and allowed providers multiselect

### DIFF
--- a/docs/meeting-platforms-zoom-plan.md
+++ b/docs/meeting-platforms-zoom-plan.md
@@ -307,3 +307,18 @@
 ### Decision point
 Если цель — быстрый go-live в Marketplace, можно идти в **Published/Unlisted** без Beta.
 Если нужен именно **Beta badge/workflow**, обязательно закрываем пакет evidence выше.
+
+## UI update: specialist meeting provider selectors (2026-05-02)
+
+- Вкладка Specialist policy в настройках теперь использует dropdown для:
+  - `meeting_providers_priority`
+  - `allowed_meeting_providers`
+- В UI показываются человекочитаемые названия (`Offline`, `Zoom`, `Manual link`),
+  а в payload на backend по-прежнему уходит строка с ID провайдеров (например `offline,zoom,manual`).
+- Решение сделано в формате KISS: фиксированные MVP-наборы комбинаций для приоритета и allowed-списка.
+
+## UI update: allowed meeting providers multiselect (2026-05-02)
+
+- Поле `allowed_meeting_providers` на вкладке Specialist policy переведено в **multi-select** по отдельным провайдерам (`offline`, `zoom`, `manual`).
+- UI показывает читаемые названия провайдеров, а на backend сохраняется прежний формат строки с ID через запятую (например `offline,manual`).
+- Это упрощает поведение: пользователь отмечает нужные провайдеры напрямую, без выбора заранее подготовленных комбинаций.

--- a/web/src/components/settings-tabs/SpecialistPolicyTab.tsx
+++ b/web/src/components/settings-tabs/SpecialistPolicyTab.tsx
@@ -1,4 +1,4 @@
-import { FormControlLabel, Switch, Typography } from '@mui/material';
+import { FormControl, FormControlLabel, InputLabel, MenuItem, Select, Switch, Typography } from '@mui/material';
 import { Controller, Control } from 'react-hook-form';
 
 import type { SpecialistBookingPolicy } from '../../shared/types/api';
@@ -14,6 +14,26 @@ type Props = {
   isSaving: boolean;
   onSubmit: () => void;
 };
+
+const providerLabelById: Record<string, string> = {
+  offline: 'Offline',
+  zoom: 'Zoom',
+  manual: 'Manual link'
+};
+
+const providerIds = ['offline', 'zoom', 'manual'];
+
+const providerPriorityOptions = [
+  'offline,zoom,manual',
+  'offline,manual,zoom',
+  'zoom,offline,manual',
+  'zoom,manual,offline',
+  'manual,offline,zoom',
+  'manual,zoom,offline'
+].map((value) => ({
+  value,
+  label: value.split(',').map((id) => providerLabelById[id] ?? id).join(' → ')
+}));
 
 export function SpecialistPolicyTab({ copy, control, isSaving, onSubmit }: Props) {
   return (
@@ -69,19 +89,50 @@ export function SpecialistPolicyTab({ copy, control, isSaving, onSubmit }: Props
           />
         )}
       />
+
       <Controller
         name="meetingProvidersPriority"
         control={control}
         render={({ field }: any) => (
-          <AppRhfTextField field={field} label={copy.meetingProvidersPriority} />
+          <FormControl fullWidth>
+            <InputLabel>{copy.meetingProvidersPriority}</InputLabel>
+            <Select {...field} label={copy.meetingProvidersPriority}>
+              {providerPriorityOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         )}
       />
+
       <Controller
         name="allowedMeetingProviders"
         control={control}
-        render={({ field }: any) => (
-          <AppRhfTextField field={field} label={copy.allowedMeetingProviders} />
-        )}
+        render={({ field }: any) => {
+          const selectedProviders = (field.value || '').split(',').filter(Boolean);
+
+          return (
+            <FormControl fullWidth>
+              <InputLabel>{copy.allowedMeetingProviders}</InputLabel>
+              <Select
+                multiple
+                value={selectedProviders}
+                label={copy.allowedMeetingProviders}
+                onChange={(event) => {
+                  const next = [...(event.target.value as string[])].join(',');
+                  field.onChange(next);
+                }}
+                renderValue={(selected) => (selected as string[])
+                  .map((id) => providerLabelById[id] ?? id)
+                  .join(', ')}
+              >
+                {providerIds.map((providerId) => (
+                  <MenuItem key={providerId} value={providerId}>{providerLabelById[providerId]}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          );
+        }}
       />
       <Controller
         name="meetingProviderOverrideEnabled"


### PR DESCRIPTION
### Motivation
- Replace free-form text fields for meeting provider settings with clearer controls so users pick readable provider names while preserving backend comma-separated IDs.
- Surface explicit provider choices in the UI to reduce errors and simplify configuration.

### Description
- Replaced `AppRhfTextField` for `meetingProvidersPriority` with an MUI `Select` dropdown that shows human-readable priority options mapped from comma-separated provider IDs.
- Converted `allowedMeetingProviders` to an MUI `Select` multi-select that maps between the comma-separated ID string and an array of provider IDs while rendering readable labels via `providerLabelById`.
- Added `providerLabelById`, `providerIds`, and `providerPriorityOptions`, and updated imports to include `FormControl`, `InputLabel`, `MenuItem`, and `Select` in `SpecialistPolicyTab.tsx`.
- Updated `docs/meeting-platforms-zoom-plan.md` with notes documenting the UI changes and expected payload behavior.

### Testing
- Ran TypeScript typecheck (`tsc --noEmit`) and frontend linting, and they completed without errors.
- Executed existing frontend unit tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ef89120c8333bdb5aead9644a61f)