### PR TITLE
docs(compliance): align Zoom Beta evidence status and artifact index

### DIFF
--- a/docs/compliance/zoom-beta/README.md
+++ b/docs/compliance/zoom-beta/README.md
@@ -7,7 +7,7 @@ This directory stores redacted artifacts for Zoom Beta review.
 ## Status
 
 - [x] TLS 1.2+ evidence for `www.meetli.cc` and `dev.meetli.cc` is collected in `evidence/tls-check-latest.txt` and `evidence/tls-summary-latest.md`.
-- [x] DAST baseline evidence on staging is collected in `evidence/zap-report.md` and `evidence/zap-report.json` (current result: `High=0`, `Medium=2`).
+- [x] DAST baseline evidence on staging is collected in `evidence/zap-report.md` and `evidence/zap-report.json` (current result: `High=0`, `Medium=1`).
 - [x] Zoom Beta evidence package (structure) — SSDLC, Privacy Policy, security policy documents, and index were added.
 - [~] Full compliance-block closure — findings remediation is tracked in `evidence/remediation-plan-2026-05-02.md`.
 

--- a/docs/compliance/zoom-beta/evidence/tls-summary-latest.md
+++ b/docs/compliance/zoom-beta/evidence/tls-summary-latest.md
@@ -2,10 +2,13 @@
 
 Generated: 2026-05-02 15:47:50 UTC
 
-Hosts: - www.meetli.cc - dev.meetli.cc
+Hosts:
+- www.meetli.cc
+- dev.meetli.cc
 
-Raw log: - \
+Raw log:
+- docs/compliance/zoom-beta/evidence/tls-check-latest.txt
 
 ## Quick checks
 - TLS 1.2 handshake: detected in output.
-- TLS 1.1 appears blocked or failed (verify raw output).
+- TLS 1.1: handshake failed (legacy protocol blocked).

--- a/docs/compliance/zoom-beta/index.md
+++ b/docs/compliance/zoom-beta/index.md
@@ -7,13 +7,13 @@
 | Security policy #1 | `security-policy-access-control.md` | ✅ Ready | RBAC, MFA, least privilege. |
 | Security policy #2 | `security-policy-vulnerability-management.md` | ✅ Ready | SAST/DAST, patch SLA. |
 | Security policy #3 | `security-policy-incident-response.md` | ✅ Ready | Detection/triage/escalation/RCA. |
-| TLS 1.2+ evidence | `tls-evidence.md`, `evidence/tls-check-2026-05-02.txt` | ⚠️ Partial | No outbound network in current container; verify in connected runner. |
-| DAST on staging | `dast-evidence.md` | ⚠️ Partial | Real run is required against `dev.meetli.cc`. |
-| SAST in CI | `sast-evidence.md` | ⚠️ Partial | Actual CI report + commit hash required. |
+| TLS 1.2+ evidence | `tls-1.2-evidence.md`, `evidence/tls-check-latest.txt`, `evidence/tls-summary-latest.md` | ✅ Ready | Latest run: 2026-05-02. |
+| DAST on staging | `dast-latest.md`, `evidence/zap-report.md`, `evidence/zap-report.json` | ⚠️ In progress | Latest run: High=0, Medium=1; hardening still required. |
+| SAST in CI | `sast-latest.md`, `evidence/npm-audit-latest.json`, `evidence/semgrep-latest.json` | ⚠️ In progress | Findings must be closed or risk-accepted. |
 
 ## Definition of Done
 
 1. TLS evidence contains successful checks for production + staging endpoints, including Zoom OAuth callback/API path.
-2. DAST report on staging contains date, commit, tool version, and high/critical findings status.
-3. SAST report from CI contains date, commit, and high/critical findings status.
+2. DAST report on staging contains date, commit, tool version, and High/Critical findings status (`High=0`, `Critical=0`).
+3. SAST report from CI contains date, commit, and High/Critical findings status (`High=0`, `Critical=0`).
 4. All documents in this directory are redacted (no secrets, tokens, or personal data).


### PR DESCRIPTION
### Motivation

- Bring the Zoom Beta compliance docs into a consistent, reviewer-friendly state by reconciling small but important discrepancies between reports and the artifact index.  
- Make TLS/DAST/SAST evidence references explicit so evidence consumers can find raw outputs and summaries easily.  
- Reduce accidental confusion during the next remediation/resubmission cycle by reflecting the latest scan results and run date in documentation.

### Description

- Updated `docs/compliance/zoom-beta/README.md` to reflect the current DAST result (`High=0`, `Medium=1`) and keep the overall status accurate.  
- Fixed `docs/compliance/zoom-beta/evidence/tls-summary-latest.md` formatting to list `Hosts` on separate lines and link the `Raw log` to `docs/compliance/zoom-beta/evidence/tls-check-latest.txt`.  
- Rewrote `docs/compliance/zoom-beta/index.md` entries to reference the actual artifact filenames (`tls-1.2-evidence.md`, `dast-latest.md`, `sast-latest.md`, and the corresponding evidence files) and updated status/notes to show the latest run date and current readiness.  
- Tightened Definition of Done language to require explicit `High=0`/`Critical=0` statements for DAST/SAST in the index.

### Testing

- No automated tests were executed as part of these documentation edits; please run the CI workflow `/.github/workflows/zoom-beta-compliance.yml` (or trigger the DAST/SAST/npm-audit jobs) to regenerate evidence and validate results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6234b23d48333820fd7779930ee34)