### PR TITLE
web: switch map preview to mapbox-gl npm package

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -57,6 +57,7 @@ npm run -w @scheduletm/web verify
 
 - `VITE_API_URL` — базовый URL API (build-time).
 - `VITE_MAPBOX_PUBLIC_TOKEN` — публичный токен Mapbox для предпросмотра карты в `Settings -> Account settings`.
+- Компонент карты использует npm-пакет `mapbox-gl` (без runtime-подгрузки script/style с CDN).
 
 Пример:
 

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.74.0",
     "react-router-dom": "^7.14.2",
-    "serve": "^14.2.6"
+    "serve": "^14.2.6",
+    "mapbox-gl": "^3.16.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/web/src/components/map/BaseMap.tsx
+++ b/web/src/components/map/BaseMap.tsx
@@ -1,4 +1,6 @@
 import { Box } from '@mui/material';
+import mapboxgl, { type Map as MapboxMap } from 'mapbox-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
 import { useEffect, useRef } from 'react';
 
 import type { MapCoordinates } from './mapStore';
@@ -9,24 +11,9 @@ type Props = {
   onCenterChange: (coords: MapCoordinates) => void;
 };
 
-type MapInstance = {
-  remove: () => void;
-  on: (event: string, callback: () => void) => void;
-  getCenter: () => { lat: number; lng: number };
-  setCenter: (coords: [number, number]) => void;
-};
-
-type MapboxGlobal = {
-  Map: new (options: Record<string, unknown>) => MapInstance;
-  accessToken: string;
-};
-
-const MAPBOX_SCRIPT_ID = 'mapbox-gl-script';
-const MAPBOX_STYLE_ID = 'mapbox-gl-style';
-
 export function BaseMap({ token, center, onCenterChange }: Props) {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<MapInstance | null>(null);
+  const mapRef = useRef<MapboxMap | null>(null);
   const onCenterChangeRef = useRef(onCenterChange);
   const initialCenterRef = useRef(center);
 
@@ -39,28 +26,8 @@ export function BaseMap({ token, center, onCenterChange }: Props) {
       return;
     }
 
-    const loadMap = async () => {
-      if (!document.getElementById(MAPBOX_STYLE_ID)) {
-        const link = document.createElement('link');
-        link.id = MAPBOX_STYLE_ID;
-        link.rel = 'stylesheet';
-        link.href = 'https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.css';
-        document.head.appendChild(link);
-      }
-
-      if (!document.getElementById(MAPBOX_SCRIPT_ID)) {
-        await new Promise<void>((resolve, reject) => {
-          const script = document.createElement('script');
-          script.id = MAPBOX_SCRIPT_ID;
-          script.src = 'https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.js';
-          script.onload = () => resolve();
-          script.onerror = () => reject(new Error('Mapbox script load failed'));
-          document.body.appendChild(script);
-        });
-      }
-
-      const mapboxgl = (window as any).mapboxgl as MapboxGlobal | undefined;
-      if (!mapboxgl || mapRef.current || !mapContainerRef.current) {
+    const loadMap = () => {
+      if (mapRef.current || !mapContainerRef.current) {
         return;
       }
 


### PR DESCRIPTION
### Motivation
- Replace runtime CDN loading of Mapbox assets with a packaged dependency to simplify bundling and avoid injecting `<script>/<link>` at runtime.
- Make the map preview implementation deterministic for local builds and easier to maintain across versions of `mapbox-gl`.

### Description
- Replaced dynamic CDN script/style injection in `web/src/components/map/BaseMap.tsx` with direct imports `import mapboxgl from 'mapbox-gl'` and `import 'mapbox-gl/dist/mapbox-gl.css'` and adjusted the map instance typing and initialization accordingly.
- Removed the old runtime loading helpers/ids and the temporary `window.mapboxgl` lookup from `BaseMap` while preserving map center initialization and `moveend` handling.
- Added `mapbox-gl` to `web/package.json` dependencies and updated `web/README.md` to document that the component now uses the `mapbox-gl` npm package.

### Testing
- Attempted `npm install -w @scheduletm/web mapbox-gl`, which failed with `403 Forbidden` from the npm registry so the package could not be installed in this environment.
- Ran `npm run -w @scheduletm/web typecheck` and it failed because `mapbox-gl` is not available locally due to the registry access error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71173980083339bc53911bfdbab14)